### PR TITLE
Change pipeline behaviour to autoexecute upon exit of the `with` block

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -3874,7 +3874,7 @@ class Pipeline(Redis):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.reset()
+        self.execute()  # also resets
 
     def __del__(self):
         try:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -51,6 +51,15 @@ class TestPipeline:
             pipe.execute()
             assert len(pipe) == 0
 
+    def test_pipeline_autoexecute(self, r):
+        with r.pipeline() as pipe:
+            # Fill 'er up!
+            pipe.set('d', 'd1').set('e', 'e1').set('f', 'f1')
+            assert len(pipe) == 3
+
+        # exiting with block calls execute() and reset(), so empty once again
+        assert len(pipe) == 0
+
     def test_pipeline_no_transaction(self, r):
         with r.pipeline(transaction=False) as pipe:
             pipe.set('a', 'a1').set('b', 'b1').set('c', 'c1')


### PR DESCRIPTION
A behaviour I very much expected!

I've a similar open pull request for aredis at https://github.com/NoneGG/aredis/pull/168
The author there suggested that redis-py is the template being followed, so I thought it might be good to open it up for discussion here also to see if there are any objections?

The idea is that if you are just setting a few values in a transaction, you'd expect them all to be completed upon exiting the `with` block (you don't care about the results in this case):

```
        with r.pipeline() as pipe:
            pipe.set('d', 'val')
            pipe.set('d1', 'val2')
            pipe.set('d1.1', 'val3')
```

I didn't find any documentation relating to pipelines, but didn't look all that hard.