### PR TITLE
slowlog get - include fields added in Redis version 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ vagrant/.vagrant
 env
 venv
 coverage.xml
+.venv
+.vscode

--- a/redis/client.py
+++ b/redis/client.py
@@ -400,12 +400,20 @@ def parse_zscan(response, **options):
 
 def parse_slowlog_get(response, **options):
     space = ' ' if options.get('decode_responses', False) else b' '
-    return [{
-        'id': item[0],
-        'start_time': int(item[1]),
-        'duration': int(item[2]),
-        'command': space.join(item[3])
-    } for item in response]
+    parsed_items = []
+    for item in response:
+        parsed_item = {
+            'id': item[0],
+            'start_time': int(item[1]),
+            'duration': int(item[2]),
+            'command': space.join(item[3])
+        }
+        if len(item) >= 5:
+            parsed_item['client_address'] = str_if_bytes(item[4])
+        if len(item) >= 6:
+            parsed_item['client_name'] = str_if_bytes(item[5])
+        parsed_items.append(parsed_item)
+    return parsed_items
 
 
 def parse_cluster_info(response, **options):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -447,6 +447,9 @@ class TestRedisCommands:
     def test_ping(self, r):
         assert r.ping()
 
+    # slowlog get was available since 2.2.12
+    # but socket address and name were added in version 4.0
+    @skip_if_server_version_lt('4.0.0')
     def test_slowlog_get(self, r, slowlog):
         assert r.slowlog_reset()
         unicode_string = chr(3456) + 'abcd' + chr(3421)
@@ -467,6 +470,9 @@ class TestRedisCommands:
         # make sure other attributes are typed correctly
         assert isinstance(slowlog[0]['start_time'], int)
         assert isinstance(slowlog[0]['duration'], int)
+
+        assert isinstance(slowlog[0]['client_address'], str)
+        assert isinstance(slowlog[0]['client_name'], str)
 
     def test_slowlog_get_limit(self, r, slowlog):
         assert r.slowlog_reset()


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Since v4, Redis returns two additional fields in slowlog get:

- Client IP address and port - I've named this `socket_address`.
- Client name if set via the CLIENT SETNAME command - I've named this `name`.
