### PR TITLE
Add note re deprecated charset parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,9 @@ automatically encode any strings passed to commands, such as key names and
 values. When `decode_responses=True`, string data returned from commands
 will be decoded with the same `encoding`.
 
+The `charset` parameter in older versions has been deprecated and is replaced 
+by the `encoding` parameter.
+
 
 Upgrading from redis-py 2.X to 3.0
 ----------------------------------


### PR DESCRIPTION
### Description of change

This is just a small docs tweak that I wanted to add since I had to dig into the code to understand why the `charset` parameter was recommended on StackOverflow. Answer: It's an old parameter and the answer was old. I updated SO, but it'd be nice for others if this was easier to find in the future.