### PR TITLE
specify ssl_cert_reqs=None for TSL 

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -975,6 +975,7 @@ def parse_url(url):
 
         if url.scheme == 'rediss':
             kwargs['connection_class'] = SSLConnection
+            kwargs['ssl_cert_reqs'] = None
     else:
         valid_schemes = 'redis://, rediss://, unix://'
         raise ValueError('Redis URL must specify one of the following '


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This change updates `connection.parse_url` to set `ssl_cert_reqs=None` for `rediss://` connections.


```console
$ rq info -u rediss://:**********@ec2-34-206-168-30.compute-1.amazonaws.com:29259
Error 1 connecting to ec2-34-206-168-30.compute-1.amazonaws.com:29259. [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1091).
```
I came across this error after migrating to a redis environment with SSL/TSL. I found that it was caused by the connection. Heroku's documentation recommends instantiating the redis connection with `ssl_cert_reqs=None`. 
https://devcenter.heroku.com/articles/heroku-redis#connecting-in-python

