### PR TITLE
Updated to return multiple elements

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2022,9 +2022,10 @@ class Redis:
         "Return the length of the list ``name``"
         return self.execute_command('LLEN', name)
 
-    def lpop(self, name):
-        "Remove and return the first item of the list ``name``"
-        return self.execute_command('LPOP', name)
+    def lpop(self, name, count = None):
+        "Removes and returns the first elements of the list ``name``"
+        args = (count is not None) and [count] or []
+        return self.execute_command('LPOP', name, *args)
 
     def lpush(self, name, *values):
         "Push ``values`` onto the head of the list ``name``"


### PR DESCRIPTION
Updated to return multiple elements 

 https://redis.io/commands/lpop: "By default, the command pops a single element from the beginning of the list. When provided with the optional count argument, the reply will consist of up to count elements, depending on the list's length."
