### PR TITLE
Add a client info from func for parse_slowlog_get

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -404,7 +404,8 @@ def parse_slowlog_get(response, **options):
         'id': item[0],
         'start_time': int(item[1]),
         'duration': int(item[2]),
-        'command': space.join(item[3])
+        'command': space.join(item[3]),
+        'client': item[4]
     } for item in response]
 
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
Then I collection slow-log of redis, 
I find that the logs lack source client info, like this：
```python
r = redis.StrictRedis()
r.config_set(
    "slowlog-max-len", self.slowlog_max_log
)
r.config_set(
    "slowlog-log-slower-than", slowlog_ms * 10
)
s = r.slowlog_get()
print(s) 
```

response
```python
[{'id': 17, 'start_time': 1619514582, 'duration': 23, 'command': b'CONFIG SET slowlog-max-len 1000'}, {'id': 16, 'start_time': 1619513328, 'duration': 35, 'command': b'SLOWLOG GET'}
```

We need get client info from slow-log，for redisc-cli：
![image](https://user-images.githubusercontent.com/75037649/116215691-7ecaca00-a77a-11eb-9ec8-488268951b72.png)



_Please provide a description of the change here._
