### PR TITLE
Add support for SMISMEMBER command added in redis 6.2.0

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,1 +1,1 @@
-FROM redis:6.0.9-buster
+FROM redis:6.2.3-buster

--- a/redis/client.py
+++ b/redis/client.py
@@ -594,6 +594,8 @@ class Redis:
             'SDIFF SINTER SMEMBERS SUNION',
             lambda r: r and set(r) or set()
         ),
+        **string_keys_to_dict('SMISMEMBER',
+                              lambda r: [bool(int(v)) for v in r]),
         **string_keys_to_dict(
             'ZPOPMAX ZPOPMIN ZRANGE ZRANGEBYSCORE ZREVRANGE ZREVRANGEBYSCORE',
             zset_score_pairs
@@ -2386,6 +2388,14 @@ class Redis:
     def smembers(self, name):
         "Return all members of the set ``name``"
         return self.execute_command('SMEMBERS', name)
+
+    def smismember(self, name, values, *args):
+        """
+        Return whether each value in ``values`` is a member of the set ``name``
+        as a list of ``bool`` in the order of ``values``
+        """
+        args = list_or_args(values, args)
+        return self.execute_command('SMISMEMBER', name, *args)
 
     def smove(self, src, dst, value):
         "Move ``value`` from set ``src`` to set ``dst`` atomically"

--- a/redis/client.py
+++ b/redis/client.py
@@ -503,6 +503,10 @@ def parse_acl_getuser(response, **options):
     data['commands'] = commands
     data['categories'] = categories
     data['enabled'] = 'on' in data['flags']
+
+    # "channels" was added in Redis 6.2.0
+    if "channels" in data:
+        data['channels'] = list(map(str_if_bytes, data['channels']))
     return data
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,20 +40,26 @@ def pytest_sessionstart(session):
     REDIS_INFO["arch_bits"] = arch_bits
 
 
-def skip_if_server_version_lt(min_version):
+def server_version_lt(min_version):
     redis_version = REDIS_INFO["version"]
-    check = StrictVersion(redis_version) < StrictVersion(min_version)
+    return StrictVersion(redis_version) < StrictVersion(min_version)
+
+
+def server_version_gte(max_version):
+    redis_version = REDIS_INFO["version"]
+    return StrictVersion(redis_version) >= StrictVersion(max_version)
+
+
+def skip_if_server_version_lt(min_version):
     return pytest.mark.skipif(
-        check,
+        server_version_lt(min_version),
         reason="Redis version required >= {}".format(min_version))
 
 
-def skip_if_server_version_gte(min_version):
-    redis_version = REDIS_INFO["version"]
-    check = StrictVersion(redis_version) >= StrictVersion(min_version)
+def skip_if_server_version_gte(max_version):
     return pytest.mark.skipif(
-        check,
-        reason="Redis version required < {}".format(min_version))
+        server_version_gte(max_version),
+        reason="Redis version required < {}".format(max_version))
 
 
 def skip_unless_arch_bits(arch_bits):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1272,6 +1272,13 @@ class TestRedisCommands:
         r.sadd('a', '1', '2', '3')
         assert r.smembers('a') == {b'1', b'2', b'3'}
 
+    @skip_if_server_version_lt('6.2.0')
+    def test_smismember(self, r):
+        r.sadd('a', '1', '2', '3')
+        result_list = [True, False, True, True]
+        assert r.smismember('a', '1', '4', '2', '3') == result_list
+        assert r.smismember('a', ['1', '4', '2', '3']) == result_list
+
     def test_smove(self, r):
         r.sadd('a', 'a1', 'a2')
         r.sadd('b', 'b1', 'b2')


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
- Add support for the `SMISMEMBER` command added in Redis 6.2.0 as mentioned in #1434.
- Bump the server version used in the Docker test environment to 6.2.0 to test the new command
- Add support for the `channels` (new in 6.2.0) setting in `acl_getuser` and fix ACL tests using a version check to make them pass on 6.2.0. This does NOT add support for the channel ACLs in `acl_setuser` or support for it in general.