### PR TITLE
Replace uses of time.time with time.monotonic

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -3649,7 +3649,8 @@ class PubSub:
                 'pubsub connection not set: '
                 'did you forget to call subscribe() or psubscribe()?')
 
-        if conn.health_check_interval and time.time() > conn.next_health_check:
+        if (conn.health_check_interval
+                and time.monotonic() > conn.next_health_check):
             conn.send_command('PING', self.HEALTH_CHECK_MESSAGE,
                               check_health=False)
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,6 +1,6 @@
 from distutils.version import StrictVersion
 from itertools import chain
-from time import time
+from time import monotonic
 from queue import LifoQueue, Empty, Full
 from urllib.parse import parse_qs, unquote, urlparse
 import errno
@@ -514,7 +514,7 @@ class Connection:
         self.socket_type = socket_type
         self.retry_on_timeout = retry_on_timeout
         self.health_check_interval = health_check_interval
-        self.next_health_check = 0
+        self.next_health_check = -1
         self.encoder = Encoder(encoding, encoding_errors, decode_responses)
         self._sock = None
         self._parser = parser_class(socket_read_size=socket_read_size)
@@ -675,7 +675,7 @@ class Connection:
 
     def check_health(self):
         "Check the health of the connection with a PING/PONG"
-        if self.health_check_interval and time() > self.next_health_check:
+        if self.health_check_interval and monotonic() > self.next_health_check:
             try:
                 self.send_command('PING', check_health=False)
                 if str_if_bytes(self.read_response()) != 'PONG':
@@ -746,7 +746,7 @@ class Connection:
             raise
 
         if self.health_check_interval:
-            self.next_health_check = time() + self.health_check_interval
+            self.next_health_check = monotonic() + self.health_check_interval
 
         if isinstance(response, ResponseError):
             raise response
@@ -873,7 +873,7 @@ class UnixDomainSocketConnection(Connection):
         self.socket_timeout = socket_timeout
         self.retry_on_timeout = retry_on_timeout
         self.health_check_interval = health_check_interval
-        self.next_health_check = 0
+        self.next_health_check = -1
         self.encoder = Encoder(encoding, encoding_errors, decode_responses)
         self._sock = None
         self._parser = parser_class(socket_read_size=socket_read_size)

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -123,11 +123,11 @@ class TestBlockingConnectionPool:
                              connection_kwargs=connection_kwargs)
         pool.get_connection('_')
 
-        start = time.time()
+        start = time.monotonic()
         with pytest.raises(redis.ConnectionError):
             pool.get_connection('_')
         # we should have waited at least 0.1 seconds
-        assert time.time() - start >= 0.1
+        assert time.monotonic() - start >= 0.1
 
     def test_connection_pool_blocks_until_conn_available(self, master_host):
         """
@@ -143,10 +143,10 @@ class TestBlockingConnectionPool:
             time.sleep(0.1)
             pool.release(c1)
 
-        start = time.time()
+        start = time.monotonic()
         Thread(target=target).start()
         pool.get_connection('_')
-        assert time.time() - start >= 0.1
+        assert time.monotonic() - start >= 0.1
 
     def test_reuse_previously_released_connection(self, master_host):
         connection_kwargs = {'host': master_host}
@@ -582,18 +582,18 @@ class TestHealthCheck:
                            health_check_interval=self.interval)
 
     def assert_interval_advanced(self, connection):
-        diff = connection.next_health_check - time.time()
+        diff = connection.next_health_check - time.monotonic()
         assert self.interval > diff > (self.interval - 1)
 
     def test_health_check_runs(self, r):
-        r.connection.next_health_check = time.time() - 1
+        r.connection.next_health_check = time.monotonic() - 1
         r.connection.check_health()
         self.assert_interval_advanced(r.connection)
 
     def test_arbitrary_command_invokes_health_check(self, r):
         # invoke a command to make sure the connection is entirely setup
         r.get('foo')
-        r.connection.next_health_check = time.time()
+        r.connection.next_health_check = time.monotonic()
         with mock.patch.object(r.connection, 'send_command',
                                wraps=r.connection.send_command) as m:
             r.get('foo')

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -12,7 +12,7 @@ from .conftest import skip_if_server_version_lt
 
 
 def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False):
-    now = time.time()
+    now = time.monotonic()
     timeout = now + timeout
     while now < timeout:
         message = pubsub.get_message(
@@ -20,7 +20,7 @@ def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False):
         if message is not None:
             return message
         time.sleep(0.01)
-        now = time.time()
+        now = time.monotonic()
     return None
 
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

The latter is unaffected by changes to the system clock and hence is
more appropriate for measuring time elapsed between two events, such as
health checks.

Since the initial value is not specified, I set the initial
next_health_check to -1 instead of 0 in case the first call returns 0.
It's unlikely in any real environment, but might be possible if time is
being mocked out.

This change was already done for redis.lock in e635130.