### PR TITLE
Fix garbage collection deadlock

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,6 @@
 flake8>=3.9.2
 pytest==6.2.5
+pytest-timeout==2.0.1
 tox==3.24.4
 tox-docker==3.1.0
 invoke==1.6.0

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -570,3 +570,15 @@ class TestPubSubWorkerThread:
         assert event.wait(timeout=1.0)
         pubsub_thread.join(timeout=1.0)
         assert not pubsub_thread.is_alive()
+
+
+class TestPubSubDeadlock:
+    @pytest.mark.timeout(30, method='thread')
+    def test_pubsub_deadlock(self, master_host):
+        pool = redis.ConnectionPool(host=master_host)
+        r = redis.Redis(connection_pool=pool)
+
+        for i in range(60):
+            p = r.pubsub()
+            p.subscribe("my-channel-1", "my-channel-2")
+            pool.reset()


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

For a long time we experienced weird lockups of the Celery package when using Redis backend (even when using redis backend only for results).

After weeks of debugging, I've found a culprit: `PubSub` objects create a circular reference to self via `connection.register_connect_callback`. This means that `PubSub` objects are not garbage collected immediately, when their refcount decreases to zero, they're collected asynchronously using generational GC.

Also, `PubSub` defines a destructor that releases a connection from pool. Pool uses threading.Lock when managing connections. If some pool method grabs the lock and at the same time `PubSub` object is garbage collected (which is pretty likely as our celery instances lock up at least once a week), `PubSub` destructor deadlocks forever waiting for a lock that will be never released.

I've decided that the only solution to this problem is to avoid creating circular references to `PubSub` objects.

Test look weird and I'm worried that it is a bit fragile, but I failed to devise a scheme that would cause Python garbage collector to run at exact moment in time when the pool is inside critical section. So the test run enough cycles to cause a problem. But different interpreters/different gc settings may cause a test to finish without locking up. I don't know how to solve that.

It runs on CPython 3.9 though: without weakref changes, the test will hang forever until pytest-timeout will cancel it.
