### PR TITLE
Added the ThrottleConnectionPool

### DIFF
--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -4,6 +4,7 @@ from redis.connection import (
     ConnectionPool,
     Connection,
     SSLConnection,
+    ThrottleConnectionPool,
     UnixDomainSocketConnection
 )
 from redis.utils import from_url
@@ -53,6 +54,7 @@ __all__ = [
     'ResponseError',
     'SSLConnection',
     'StrictRedis',
+    'ThrottleConnectionPool',
     'TimeoutError',
     'UnixDomainSocketConnection',
     'WatchError',


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

Thanks to the ThrottleConnectionPool of a rate-limit, it can amortize the high cost of TLS connecting by performing throttle before it lets the connection open.

This will prevent to the Redis-Server(Stunnel4) has high load-average.

Would you mind interesting this code and I apologize that Pull-Request creation anyway, even though I knew that [how-to-suggest-a-feature-or-enhancement](https://github.com/andymccurdy/redis-py/blob/master/CONTRIBUTING.rst#how-to-suggest-a-feature-or-enhancement).

Below is running code and outputs.

```python
import threading

import redis


class Printer(redis.ThrottleConnectionPool):
    def make_connection(self):
        connection = super().make_connection()
        print("make a new connection")
        return connection


pool = Printer(host='localhost', port=6379, db=0, throttle_interval=1.0)


def client():
    return redis.Redis(connection_pool=pool)


def thread_function():
    for i in range(0, 10000000):
        s = str(i)
        client().ping()
        client().set(s, s)
        client().get(s)


def run_thread():
    threads = []
    for index in range(15):
        x = threading.Thread(target=thread_function, args=())
        threads.append(x)
        x.start()

    for index, thread in enumerate(threads):
        thread.join()


if __name__ == '__main__':
    run_thread()
```

**Outputs**
![redis](https://user-images.githubusercontent.com/217484/136127807-203c8a4f-3641-47e2-b6ff-85c5a5774cf6.gif)