### PR TITLE
Add support to consumername in `xpending_range` 

### DIFF
--- a/redis/commands.py
+++ b/redis/commands.py
@@ -2072,6 +2072,9 @@ class Commands:
             pieces.extend([min, max, count])
         except TypeError:
             pass
+        # consumername
+        if consumername:
+            pieces.append(consumername)
 
         return self.execute_command('XPENDING', *pieces, parse_detail=True)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3126,6 +3126,14 @@ class TestRedisCommands:
         assert response[1]['message_id'] == m2
         assert response[1]['consumer'] == consumer2.encode()
 
+        # test with consumer name
+        response = r.xpending_range(stream, group,
+                                    min='-', max='+', count=5,
+                                    consumername=consumer1)
+        assert len(response) == 1
+        assert response[0]['message_id'] == m1
+        assert response[0]['consumer'] == consumer1.encode()
+
     @skip_if_server_version_lt('6.2.0')
     def test_xpending_range_idle(self, r):
         stream = 'stream'


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Add support to consumername parameter in `xpending_range` 