### PR TITLE
Added boolean parsing to PEXPIRE and PEXPIREAT

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -618,7 +618,8 @@ class Redis(RedisModuleCommands, CoreCommands, object):
     """
     RESPONSE_CALLBACKS = {
         **string_keys_to_dict(
-            'AUTH COPY EXPIRE EXPIREAT PEXPIRE PEXPIREAT HEXISTS HMSET LMOVE BLMOVE MOVE '
+            'AUTH COPY EXPIRE EXPIREAT PEXPIRE PEXPIREAT '
+            'HEXISTS HMSET LMOVE BLMOVE MOVE '
             'MSETNX PERSIST PSETEX RENAMENX SISMEMBER SMOVE SETEX SETNX',
             bool
         ),

--- a/redis/client.py
+++ b/redis/client.py
@@ -618,7 +618,7 @@ class Redis(RedisModuleCommands, CoreCommands, object):
     """
     RESPONSE_CALLBACKS = {
         **string_keys_to_dict(
-            'AUTH COPY EXPIRE EXPIREAT HEXISTS HMSET LMOVE BLMOVE MOVE '
+            'AUTH COPY EXPIRE EXPIREAT PEXPIRE PEXPIREAT HEXISTS HMSET LMOVE BLMOVE MOVE '
             'MSETNX PERSIST PSETEX RENAMENX SISMEMBER SMOVE SETEX SETNX',
             bool
         ),

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -849,7 +849,7 @@ class TestRedisCommands:
 
     def test_expireat_no_key(self, r):
         expire_at = redis_server_time(r) + datetime.timedelta(minutes=1)
-        assert r.expireat('a', expire_at) is True
+        assert r.expireat('a', expire_at) is False
 
     def test_expireat_unixtime(self, r):
         expire_at = redis_server_time(r) + datetime.timedelta(minutes=1)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -834,9 +834,9 @@ class TestRedisCommands:
         assert 'a' in r
 
     def test_expire(self, r):
-        assert not r.expire('a', 10)
+        assert r.expire('a', 10) is False
         r['a'] = 'foo'
-        assert r.expire('a', 10)
+        assert r.expire('a', 10) is True
         assert 0 < r.ttl('a') <= 10
         assert r.persist('a')
         assert r.ttl('a') == -1
@@ -844,18 +844,18 @@ class TestRedisCommands:
     def test_expireat_datetime(self, r):
         expire_at = redis_server_time(r) + datetime.timedelta(minutes=1)
         r['a'] = 'foo'
-        assert r.expireat('a', expire_at)
+        assert r.expireat('a', expire_at) is True
         assert 0 < r.ttl('a') <= 61
 
     def test_expireat_no_key(self, r):
         expire_at = redis_server_time(r) + datetime.timedelta(minutes=1)
-        assert not r.expireat('a', expire_at)
+        assert r.expireat('a', expire_at) is True
 
     def test_expireat_unixtime(self, r):
         expire_at = redis_server_time(r) + datetime.timedelta(minutes=1)
         r['a'] = 'foo'
         expire_at_seconds = int(time.mktime(expire_at.timetuple()))
-        assert r.expireat('a', expire_at_seconds)
+        assert r.expireat('a', expire_at_seconds) is True
         assert 0 < r.ttl('a') <= 61
 
     def test_get_and_set(self, r):
@@ -998,9 +998,9 @@ class TestRedisCommands:
 
     @skip_if_server_version_lt('2.6.0')
     def test_pexpire(self, r):
-        assert not r.pexpire('a', 60000)
+        assert r.pexpire('a', 60000) is False
         r['a'] = 'foo'
-        assert r.pexpire('a', 60000)
+        assert r.pexpire('a', 60000) is True
         assert 0 < r.pttl('a') <= 60000
         assert r.persist('a')
         assert r.pttl('a') == -1
@@ -1009,20 +1009,20 @@ class TestRedisCommands:
     def test_pexpireat_datetime(self, r):
         expire_at = redis_server_time(r) + datetime.timedelta(minutes=1)
         r['a'] = 'foo'
-        assert r.pexpireat('a', expire_at)
+        assert r.pexpireat('a', expire_at) is True
         assert 0 < r.pttl('a') <= 61000
 
     @skip_if_server_version_lt('2.6.0')
     def test_pexpireat_no_key(self, r):
         expire_at = redis_server_time(r) + datetime.timedelta(minutes=1)
-        assert not r.pexpireat('a', expire_at)
+        assert r.pexpireat('a', expire_at) is False
 
     @skip_if_server_version_lt('2.6.0')
     def test_pexpireat_unixtime(self, r):
         expire_at = redis_server_time(r) + datetime.timedelta(minutes=1)
         r['a'] = 'foo'
         expire_at_seconds = int(time.mktime(expire_at.timetuple())) * 1000
-        assert r.pexpireat('a', expire_at_seconds)
+        assert r.pexpireat('a', expire_at_seconds) is True
         assert 0 < r.pttl('a') <= 61000
 
     @skip_if_server_version_lt('2.6.0')
@@ -1040,9 +1040,9 @@ class TestRedisCommands:
 
     @skip_if_server_version_lt('2.6.0')
     def test_pttl(self, r):
-        assert not r.pexpire('a', 10000)
+        assert r.pexpire('a', 10000) is False
         r['a'] = '1'
-        assert r.pexpire('a', 10000)
+        assert r.pexpire('a', 10000) is True
         assert 0 < r.pttl('a') <= 10000
         assert r.persist('a')
         assert r.pttl('a') == -1


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
Fixes: #1664 

`pexpire` and `pexpire_at` will behave like their non p* counterpart parsing the return value into a boolean
