### PR TITLE
Restore zrange functionality for older versions of Redis

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -2621,7 +2621,7 @@ class CoreCommands:
         if (start is not None and num is None) or \
                 (num is not None and start is None):
             raise DataError("``start`` and ``num`` must both be specified")
-        pieces = ['ZRANGEBYSCORE', name, max, min]
+        pieces = ['ZRANGEBYSCORE', name, min, max]
         if start is not None and num is not None:
             pieces.extend(['LIMIT', start, num])
         if withscores:

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -2536,9 +2536,14 @@ class CoreCommands:
 
         ``score_cast_func`` a callable used to cast the score return value
         """
-        return self.zrange(name, start, end, desc=True,
-                           withscores=withscores,
-                           score_cast_func=score_cast_func)
+        pieces = ['ZREVRANGE', name, start, end]
+        if withscores:
+            pieces.append(b'WITHSCORES')
+        options = {
+            'withscores': withscores,
+            'score_cast_func': score_cast_func
+        }
+        return self.execute_command(*pieces, **options)
 
     def zrangestore(self, dest, name, start, end,
                     byscore=False, bylex=False, desc=False,
@@ -2575,7 +2580,13 @@ class CoreCommands:
         If ``start`` and ``num`` are specified, then return a slice of the
         range.
         """
-        return self.zrange(name, min, max, bylex=True, offset=start, num=num)
+        if (start is not None and num is None) or \
+                (num is not None and start is None):
+            raise DataError("``start`` and ``num`` must both be specified")
+        pieces = ['ZRANGEBYLEX', name, min, max]
+        if start is not None and num is not None:
+            pieces.extend([b'LIMIT', start, num])
+        return self.execute_command(*pieces)
 
     def zrevrangebylex(self, name, max, min, start=None, num=None):
         """
@@ -2585,8 +2596,13 @@ class CoreCommands:
         If ``start`` and ``num`` are specified, then return a slice of the
         range.
         """
-        return self.zrange(name, max, min, desc=True,
-                           bylex=True, offset=start, num=num)
+        if (start is not None and num is None) or \
+                (num is not None and start is None):
+            raise DataError("``start`` and ``num`` must both be specified")
+        pieces = ['ZREVRANGEBYLEX', name, max, min]
+        if start is not None and num is not None:
+            pieces.extend(['LIMIT', start, num])
+        return self.execute_command(*pieces)
 
     def zrangebyscore(self, name, min, max, start=None, num=None,
                       withscores=False, score_cast_func=float):
@@ -2602,10 +2618,19 @@ class CoreCommands:
 
         `score_cast_func`` a callable used to cast the score return value
         """
-        return self.zrange(name, min, max, byscore=True,
-                           offset=start, num=num,
-                           withscores=withscores,
-                           score_cast_func=score_cast_func)
+        if (start is not None and num is None) or \
+                (num is not None and start is None):
+            raise DataError("``start`` and ``num`` must both be specified")
+        pieces = ['ZRANGEBYSCORE', name, max, min]
+        if start is not None and num is not None:
+            pieces.extend(['LIMIT', start, num])
+        if withscores:
+            pieces.append('WITHSCORES')
+        options = {
+            'withscores': withscores,
+            'score_cast_func': score_cast_func
+        }
+        return self.execute_command(*pieces, **options)
 
     def zrevrangebyscore(self, name, max, min, start=None, num=None,
                          withscores=False, score_cast_func=float):
@@ -2621,10 +2646,19 @@ class CoreCommands:
 
         ``score_cast_func`` a callable used to cast the score return value
         """
-        return self.zrange(name, max, min, desc=True,
-                           byscore=True, offset=start,
-                           num=num, withscores=withscores,
-                           score_cast_func=score_cast_func)
+        if (start is not None and num is None) or \
+                (num is not None and start is None):
+            raise DataError("``start`` and ``num`` must both be specified")
+        pieces = ['ZREVRANGEBYSCORE', name, max, min]
+        if start is not None and num is not None:
+            pieces.extend(['LIMIT', start, num])
+        if withscores:
+            pieces.append('WITHSCORES')
+        options = {
+            'withscores': withscores,
+            'score_cast_func': score_cast_func
+        }
+        return self.execute_command(*pieces, **options)
 
     def zrank(self, name, value):
         """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1866,7 +1866,7 @@ class TestRedisCommands:
         r.zadd('a', {'a1': 1, 'a2': 2, 'a3': 3})
         assert r.zrange('a', 0, 1) == [b'a1', b'a2']
         assert r.zrange('a', 1, 2) == [b'a2', b'a3']
-        assert r.zrange('a', 0, 2, desc=True) == [b'a3', b'a2', b'a1']
+        assert r.zrange('a', 0, 2) == [b'a1', b'a2', b'a3']
 
         # withscores
         assert r.zrange('a', 0, 1, withscores=True) == \


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

closes #1669
revert zrange commands implementation to work with older redis versions (after the change in #1603)

