### PR TITLE
Export Sentinel, and SSL like other classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,12 +365,24 @@ Connecting redis-py to the Sentinel instance(s) is easy. You can use a
 Sentinel connection to discover the master and slaves network addresses:
 
 ``` pycon
->>> from redis.sentinel import Sentinel
+>>> from redis import Sentinel
 >>> sentinel = Sentinel([('localhost', 26379)], socket_timeout=0.1)
 >>> sentinel.discover_master('mymaster')
 ('127.0.0.1', 6379)
 >>> sentinel.discover_slaves('mymaster')
 [('127.0.0.1', 6380)]
+```
+
+To connect to a sentinel which uses SSL ([see SSL
+connections](#ssl-connections) for more examples of SSL configurations):
+
+``` pycon
+>>> from redis import Sentinel
+>>> sentinel = Sentinel([('localhost', 26379)],
+                        ssl=True,
+                        ssl_ca_certs='/etc/ssl/certs/ca-certificates.crt')
+>>> sentinel.discover_master('mymaster')
+('127.0.0.1', 6379)
 ```
 
 You can also create Redis client connections from a Sentinel instance.

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -6,6 +6,12 @@ from redis.connection import (
     SSLConnection,
     UnixDomainSocketConnection
 )
+from redis.sentinel import (
+    Sentinel,
+    SentinelConnectionPool,
+    SentinelManagedConnection,
+    SentinelManagedSSLConnection,
+)
 from redis.utils import from_url
 from redis.exceptions import (
     AuthenticationError,
@@ -51,6 +57,10 @@ __all__ = [
     'Redis',
     'RedisError',
     'ResponseError',
+    'Sentinel',
+    'SentinelConnectionPool',
+    'SentinelManagedConnection',
+    'SentinelManagedSSLConnection',
     'SSLConnection',
     'StrictRedis',
     'TimeoutError',

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -80,7 +80,9 @@ class SentinelConnectionPool(ConnectionPool):
 
     def __init__(self, service_name, sentinel_manager, **kwargs):
         kwargs['connection_class'] = kwargs.get(
-            'connection_class', SentinelManagedConnection)
+            'connection_class',
+            SentinelManagedSSLConnection if kwargs.pop('ssl', False)
+            else SentinelManagedConnection)
         self.is_master = kwargs.pop('is_master', True)
         self.check_connection = kwargs.pop('check_connection', False)
         super().__init__(**kwargs)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Now that `Sentinel` needs to be used specifically instead of via `Redis`, this change exports the class at the top level like the `Redis` client is, and also allows the shorthand of `ssl=True` to set the connection class to the `SentinelManagedSSLConnection`.