### PR TITLE
Fix georadius tests

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2744,7 +2744,7 @@ class TestRedisCommands:
         assert r.georadius('barcelona', 2, 1, 1, unit='km',
                            withdist=True, withcoord=True, withhash=True) == []
 
-    @skip_if_server_version_lt('3.2.0')
+    @skip_if_server_version_lt('6.2.0')
     def test_georadius_count(self, r):
         values = (2.1909389952632, 41.433791470673, 'place1') + \
                  (2.1873744593677, 41.406342043777, 'place2')
@@ -2806,6 +2806,12 @@ class TestRedisCommands:
                  (2.187376320362091, 41.40634178640635)],
                 [b'place1', 0.0, 3471609698139488,
                  (2.1909382939338684, 41.433790281840835)]]
+
+    @skip_if_server_version_lt('6.2.0')
+    def test_georadiusmember_count(self, r):
+        values = (2.1909389952632, 41.433791470673, 'place1') + \
+                 (2.1873744593677, 41.406342043777, b'\x80place2')
+
         assert r.georadiusbymember('barcelona', 'place1', 4000,
                                    count=1, any=True) == \
                [b'\x80place2']

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2811,7 +2811,7 @@ class TestRedisCommands:
     def test_georadiusmember_count(self, r):
         values = (2.1909389952632, 41.433791470673, 'place1') + \
                  (2.1873744593677, 41.406342043777, b'\x80place2')
-
+        r.geoadd('barcelona', values)
         assert r.georadiusbymember('barcelona', 'place1', 4000,
                                    count=1, any=True) == \
                [b'\x80place2']


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

These tests were falling when running redis v6.0.9 as `COUNT` is available only from v6.2.0
