### PR TITLE
Removing dependency on six

### DIFF
--- a/redis/commands/search/_util.py
+++ b/redis/commands/search/_util.py
@@ -1,10 +1,7 @@
-import six
-
-
 def to_string(s):
-    if isinstance(s, six.string_types):
+    if isinstance(s, str):
         return s
-    elif isinstance(s, six.binary_type):
+    elif isinstance(s, bytes):
         return s.decode("utf-8", "ignore")
     else:
         return s  # Not a string we care about

--- a/redis/commands/search/aggregation.py
+++ b/redis/commands/search/aggregation.py
@@ -1,5 +1,3 @@
-from six import string_types
-
 FIELDNAME = object()
 
 
@@ -93,7 +91,7 @@ class Group(object):
         if not reducers:
             raise ValueError("Need at least one reducer")
 
-        fields = [fields] if isinstance(fields, string_types) else fields
+        fields = [fields] if isinstance(fields, str) else fields
         reducers = [reducers] if isinstance(reducers, Reducer) else reducers
 
         self.fields = fields
@@ -299,7 +297,7 @@ class AggregateRequest(object):
             .sort_by(Desc("@paid"), max=10)
         ```
         """
-        if isinstance(fields, (string_types, SortDirection)):
+        if isinstance(fields, (str, SortDirection)):
             fields = [fields]
 
         max = kwargs.get("max", 0)
@@ -318,7 +316,7 @@ class AggregateRequest(object):
         - **fields**: Fields to group by. This can either be a single string,
             or a list of strings.
         """
-        if isinstance(expressions, string_types):
+        if isinstance(expressions, str):
             expressions = [expressions]
 
         for expression in expressions:

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -1,6 +1,5 @@
 import itertools
 import time
-import six
 
 from .document import Document
 from .result import Result
@@ -308,9 +307,8 @@ class SearchCommands:
         Load a single document by id
         """
         fields = self.client.hgetall(id)
-        if six.PY3:
-            f2 = {to_string(k): to_string(v) for k, v in fields.items()}
-            fields = f2
+        f2 = {to_string(k): to_string(v) for k, v in fields.items()}
+        fields = f2
 
         try:
             del fields["id"]
@@ -337,13 +335,13 @@ class SearchCommands:
         """
 
         res = self.client.execute_command(INFO_CMD, self.index_name)
-        it = six.moves.map(to_string, res)
-        return dict(six.moves.zip(it, it))
+        it = map(to_string, res)
+        return dict(zip(it, it))
 
     def _mk_query_args(self, query):
         args = [self.index_name]
 
-        if isinstance(query, six.string_types):
+        if isinstance(query, str):
             # convert the query from a text to a query object
             query = Query(query)
         if not isinstance(query, Query):
@@ -448,7 +446,7 @@ class SearchCommands:
             return corrections
 
         for _correction in raw:
-            if isinstance(_correction, six.integer_types) and _correction == 0:
+            if isinstance(_correction, int) and _correction == 0:
                 continue
 
             if len(_correction) != 3:

--- a/redis/commands/search/document.py
+++ b/redis/commands/search/document.py
@@ -1,6 +1,3 @@
-import six
-
-
 class Document(object):
     """
     Represents a single document in a result set
@@ -9,7 +6,7 @@ class Document(object):
     def __init__(self, id, payload=None, **fields):
         self.id = id
         self.payload = payload
-        for k, v in six.iteritems(fields):
+        for k, v in fields.items():
             setattr(self, k, v)
 
     def __repr__(self):

--- a/redis/commands/search/query.py
+++ b/redis/commands/search/query.py
@@ -1,6 +1,3 @@
-import six
-
-
 class Query(object):
     """
     Query is used to build complex queries that have more parameters than just
@@ -66,7 +63,7 @@ class Query(object):
         if not fields:
             return []
         return  \
-            [fields] if isinstance(fields, six.string_types) else list(fields)
+            [fields] if isinstance(fields, str) else list(fields)
 
     def summarize(self, fields=None, context_len=None,
                   num_frags=None, sep=None):

--- a/redis/commands/search/querystring.py
+++ b/redis/commands/search/querystring.py
@@ -1,6 +1,3 @@
-from six import string_types, integer_types
-
-
 def tags(*t):
     """
     Indicate that the values should be matched to a tag field
@@ -186,7 +183,7 @@ class Node(object):
         kvparams = {}
         for k, v in kwparams.items():
             curvals = kvparams.setdefault(k, [])
-            if isinstance(v, (string_types, integer_types, float)):
+            if isinstance(v, (str, int, float)):
                 curvals.append(Value.make_value(v))
             elif isinstance(v, Value):
                 curvals.append(v)

--- a/redis/commands/search/result.py
+++ b/redis/commands/search/result.py
@@ -1,5 +1,3 @@
-from six.moves import xrange, zip as izip
-
 from .document import Document
 from ._util import to_string
 
@@ -32,7 +30,7 @@ class Result(object):
 
         offset = 2 if with_scores else 1
 
-        for i in xrange(1, len(res), step):
+        for i in range(1, len(res), step):
             id = to_string(res[i])
             payload = to_string(res[i + offset]) if has_payload else None
             # fields_offset = 2 if has_payload else 1
@@ -44,7 +42,7 @@ class Result(object):
                 fields = (
                     dict(
                         dict(
-                            izip(
+                            zip(
                                 map(to_string, res[i + fields_offset][::2]),
                                 map(to_string, res[i + fields_offset][1::2]),
                             )

--- a/redis/commands/search/suggestion.py
+++ b/redis/commands/search/suggestion.py
@@ -1,4 +1,3 @@
-from six.moves import xrange
 from ._util import to_string
 
 
@@ -45,7 +44,7 @@ class SuggestionParser(object):
         self._sugs = ret
 
     def __iter__(self):
-        for i in xrange(0, len(self._sugs), self.sugsize):
+        for i in range(0, len(self._sugs), self.sugsize):
             ss = self._sugs[i]
             score = float(self._sugs[i + self._scoreidx]) \
                 if self.with_scores else 1.0


### PR DESCRIPTION
In stanadalone installs, redis-py, starting in 4.0.0beta3 relied on six, this cleans that