### PR TITLE
ck testfixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ from urllib.parse import urlparse
 
 REDIS_INFO = {}
 default_redis_url = "redis://localhost:6379/9"
-default_redismod_url = "redis://localhost:36379/9"
 
 default_redismod_url = "redis://localhost:36379"
 
@@ -44,10 +43,13 @@ def pytest_sessionstart(session):
     REDIS_INFO["version"] = version
     REDIS_INFO["arch_bits"] = arch_bits
 
-    # module info
-    redismod_url = session.config.getoption("--redismod-url")
-    info = _get_info(redismod_url)
-    REDIS_INFO["modules"] = info["modules"]
+    # module info, if the second redis is running
+    try:
+        redismod_url = session.config.getoption("--redismod-url")
+        info = _get_info(redismod_url)
+        REDIS_INFO["modules"] = info["modules"]
+    except redis.exceptions.ConnectionError:
+        pass
 
 
 def skip_if_server_version_lt(min_version):
@@ -72,7 +74,11 @@ def skip_unless_arch_bits(arch_bits):
 
 
 def skip_ifmodversion_lt(min_version: str, module_name: str):
-    modules = REDIS_INFO["modules"]
+    try:
+        modules = REDIS_INFO["modules"]
+    except KeyError:
+        return pytest.mark.skipif(True,
+                                  reason="No redismod-url server running")
     if modules == []:
         return pytest.mark.skipif(True, reason="No redis modules found")
 
@@ -218,7 +224,7 @@ def mock_cluster_resp_slaves(request, **kwargs):
 def master_host(request):
     url = request.config.getoption("--redis-url")
     parts = urlparse(url)
-    yield parts.hostname
+    yield parts.hostname, parts.port
 
 
 def wait_for_command(client, monitor, command):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def skip_ifmodversion_lt(min_version: str, module_name: str):
         modules = REDIS_INFO["modules"]
     except KeyError:
         return pytest.mark.skipif(True,
-                                  reason="No redismod-url server running")
+                                  reason="Redis server does not have modules")
     if modules == []:
         return pytest.mark.skipif(True, reason="No redis modules found")
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -18,12 +18,14 @@ def test_invalid_response(r):
 
 
 @skip_if_server_version_lt('4.0.0')
+@pytest.mark.redismod
 def test_loaded_modules(r, modclient):
     assert r.loaded_modules == []
     assert 'rejson' in modclient.loaded_modules.keys()
 
 
 @skip_if_server_version_lt('4.0.0')
+@pytest.mark.redismod
 def test_loading_external_modules(r, modclient):
     def inner():
         pass

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -44,14 +44,14 @@ class TestConnectionPool:
         assert connection.kwargs == connection_kwargs
 
     def test_multiple_connections(self, master_host):
-        connection_kwargs = {'host': master_host}
+        connection_kwargs = {'host': master_host[0], 'port': master_host[1]}
         pool = self.get_pool(connection_kwargs=connection_kwargs)
         c1 = pool.get_connection('_')
         c2 = pool.get_connection('_')
         assert c1 != c2
 
     def test_max_connections(self, master_host):
-        connection_kwargs = {'host': master_host}
+        connection_kwargs = {'host': master_host[0], 'port': master_host[1]}
         pool = self.get_pool(max_connections=2,
                              connection_kwargs=connection_kwargs)
         pool.get_connection('_')
@@ -60,7 +60,7 @@ class TestConnectionPool:
             pool.get_connection('_')
 
     def test_reuse_previously_released_connection(self, master_host):
-        connection_kwargs = {'host': master_host}
+        connection_kwargs = {'host': master_host[0], 'port': master_host[1]}
         pool = self.get_pool(connection_kwargs=connection_kwargs)
         c1 = pool.get_connection('_')
         pool.release(c1)
@@ -103,14 +103,15 @@ class TestBlockingConnectionPool:
         return pool
 
     def test_connection_creation(self, master_host):
-        connection_kwargs = {'foo': 'bar', 'biz': 'baz', 'host': master_host}
+        connection_kwargs = {'foo': 'bar', 'biz': 'baz',
+                             'host': master_host[0], 'port': master_host[1]}
         pool = self.get_pool(connection_kwargs=connection_kwargs)
         connection = pool.get_connection('_')
         assert isinstance(connection, DummyConnection)
         assert connection.kwargs == connection_kwargs
 
     def test_multiple_connections(self, master_host):
-        connection_kwargs = {'host': master_host}
+        connection_kwargs = {'host': master_host[0], 'port': master_host[1]}
         pool = self.get_pool(connection_kwargs=connection_kwargs)
         c1 = pool.get_connection('_')
         c2 = pool.get_connection('_')
@@ -118,7 +119,7 @@ class TestBlockingConnectionPool:
 
     def test_connection_pool_blocks_until_timeout(self, master_host):
         "When out of connections, block for timeout seconds, then raise"
-        connection_kwargs = {'host': master_host}
+        connection_kwargs = {'host': master_host[0], 'port': master_host[1]}
         pool = self.get_pool(max_connections=1, timeout=0.1,
                              connection_kwargs=connection_kwargs)
         pool.get_connection('_')
@@ -134,7 +135,7 @@ class TestBlockingConnectionPool:
         When out of connections, block until another connection is released
         to the pool
         """
-        connection_kwargs = {'host': master_host}
+        connection_kwargs = {'host': master_host[0], 'port': master_host[1]}
         pool = self.get_pool(max_connections=1, timeout=2,
                              connection_kwargs=connection_kwargs)
         c1 = pool.get_connection('_')
@@ -149,7 +150,7 @@ class TestBlockingConnectionPool:
         assert time.time() - start >= 0.1
 
     def test_reuse_previously_released_connection(self, master_host):
-        connection_kwargs = {'host': master_host}
+        connection_kwargs = {'host': master_host[0], 'port': master_host[1]}
         pool = self.get_pool(connection_kwargs=connection_kwargs)
         c1 = pool.get_connection('_')
         pool.release(c1)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -9,11 +9,12 @@ class TestMonitor:
             assert response is None
 
     def test_response_values(self, r):
+        db = r.connection_pool.connection_kwargs.get('db', 0)
         with r.monitor() as m:
             r.ping()
             response = wait_for_command(r, m, 'PING')
             assert isinstance(response['time'], float)
-            assert response['db'] == 9
+            assert response['db'] == db
             assert response['client_type'] in ('tcp', 'unix')
             assert isinstance(response['client_address'], str)
             assert isinstance(response['client_port'], str)

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -35,7 +35,7 @@ class TestMultiprocessing:
         A connection owned by a parent and closed by a child doesn't
         destroy the file descriptors so a parent can still use it.
         """
-        conn = Connection(host=master_host)
+        conn = Connection(host=master_host[0], port=master_host[1])
         conn.send_command('ping')
         assert conn.read_response() == b'PONG'
 
@@ -61,7 +61,7 @@ class TestMultiprocessing:
         A connection owned by a parent is unusable by a child if the parent
         (the owning process) closes the connection.
         """
-        conn = Connection(host=master_host)
+        conn = Connection(host=master_host[0], port=master_host[1])
         conn.send_command('ping')
         assert conn.read_response() == b'PONG'
 
@@ -89,7 +89,9 @@ class TestMultiprocessing:
         A child will create its own connections when using a pool created
         by a parent.
         """
-        pool = ConnectionPool.from_url('redis://{}'.format(master_host),
+        pool = ConnectionPool.from_url('redis://{}:{}'.format(master_host[0],
+                                                              master_host[1],
+                                                              ),
                                        max_connections=max_connections)
 
         conn = pool.get_connection('ping')
@@ -124,7 +126,8 @@ class TestMultiprocessing:
         A child process that uses the same pool as its parent isn't affected
         when the parent disconnects all connections within the pool.
         """
-        pool = ConnectionPool.from_url('redis://{}'.format(master_host),
+        pool = ConnectionPool.from_url('redis://{}:{}'.format(master_host[0],
+                                                              master_host[1]),
                                        max_connections=max_connections)
 
         conn = pool.get_connection('ping')

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -575,7 +575,8 @@ class TestPubSubWorkerThread:
 class TestPubSubDeadlock:
     @pytest.mark.timeout(30, method='thread')
     def test_pubsub_deadlock(self, master_host):
-        pool = redis.ConnectionPool(host=master_host)
+        pool = redis.ConnectionPool(host=master_host[0],
+                                    port=master_host[1])
         r = redis.Redis(connection_pool=pool)
 
         for i in range(60):

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -10,7 +10,7 @@ import redis.sentinel
 
 @pytest.fixture(scope="module")
 def master_ip(master_host):
-    yield socket.gethostbyname(master_host)
+    yield socket.gethostbyname(master_host[0])
 
 
 class SentinelTestClient:


### PR DESCRIPTION
- Fixing multiprocessing tests to respect redisurl ports
- test improvement: do not fill modules information if no modules present
- Marking module loader as redismod
