### PR TITLE
Restoring ZRANGE desc for Redis < 6.2.0

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -2520,10 +2520,13 @@ class CoreCommands:
         ``offset`` and ``num`` are specified, then return a slice of the range.
         Can't be provided when using ``bylex``.
         """
-        # Supports old implementation: need to support ``desc`` also for version < 6.2.0
-        if not byscore and not bylex and (offset is None and num is None) and desc:
+        # Need to support ``desc`` also when using old redis version
+        # because it was supported in 3.5.3 (of redis-py)
+        if not byscore and not bylex and (offset is None and num is None) \
+                and desc:
             return self.zrevrange(name, start, end, withscores,
                                   score_cast_func)
+
         return self._zrange('ZRANGE', None, name, start, end, desc, byscore,
                             bylex, withscores, score_cast_func, offset, num)
 

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -2520,6 +2520,10 @@ class CoreCommands:
         ``offset`` and ``num`` are specified, then return a slice of the range.
         Can't be provided when using ``bylex``.
         """
+        # Supports old implementation: need to support ``desc`` also for version < 6.2.0
+        if not byscore and not bylex and (offset is None and num is None) and desc:
+            return self.zrevrange(name, start, end, withscores,
+                                  score_cast_func)
         return self._zrange('ZRANGE', None, name, start, end, desc, byscore,
                             bylex, withscores, score_cast_func, offset, num)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1867,6 +1867,7 @@ class TestRedisCommands:
         assert r.zrange('a', 0, 1) == [b'a1', b'a2']
         assert r.zrange('a', 1, 2) == [b'a2', b'a3']
         assert r.zrange('a', 0, 2) == [b'a1', b'a2', b'a3']
+        assert r.zrange('a', 0, 2, desc=True) == [b'a3', b'a2', b'a1']
 
         # withscores
         assert r.zrange('a', 0, 1, withscores=True) == \


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

closes #1669

In the previous implementation of **zrange**, the user could use ``desc`` by calling to **zrevrange** behind the scene. Since redis 6.2.0, **zrange** supports ``REV`` label (and other new labels e.g LIMIT).
We want to be able to use desc without any other params (that will execute **zrevrange**), or to use ``desc`` with other new params, and then **zrange** will be called, but that can be done only when using redis > 6.2.0.
