### PR TITLE
fix: adding sentinelcommands to redis client

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -6,7 +6,8 @@ import re
 import threading
 import time
 import warnings
-from redis.commands import CoreCommands, RedisModuleCommands, list_or_args
+from redis.commands import (CoreCommands, RedisModuleCommands,
+                            SentinelCommands, list_or_args)
 from redis.connection import (ConnectionPool, UnixDomainSocketConnection,
                               SSLConnection)
 from redis.lock import Lock
@@ -606,7 +607,7 @@ def parse_set_result(response, **options):
     return response and str_if_bytes(response) == 'OK'
 
 
-class Redis(RedisModuleCommands, CoreCommands, object):
+class Redis(RedisModuleCommands, CoreCommands, SentinelCommands, object):
     """
     Implementation of the Redis protocol.
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ x ] Does `$ tox` pass with this change (including linting)?
- [ x ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ x ] Is the new or changed code fully tested?
- [ n/a ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

SentinalCommands have not been available to the Redis client since v3.5.3, this change re-adds the functionality to run SentinelCommands using the Redis client returned when setting up the Sentinel class.

closes #1714 
