### PR TITLE
Better removal of hiredis warning

### DIFF
--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -37,7 +37,7 @@ def int_or_str(value):
         return value
 
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 
 
 VERSION = tuple(map(int_or_str, __version__.split('.')))

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -67,9 +67,6 @@ if HIREDIS_AVAILABLE:
     # only use byte buffer if hiredis supports it
     if not HIREDIS_SUPPORTS_BYTE_BUFFER:
         HIREDIS_USE_BYTE_BUFFER = False
-else:
-    msg = "redis-py works best with hiredis. Please consider installing"
-    warnings.warn(msg)
 
 SYM_STAR = b'*'
 SYM_DOLLAR = b'$'

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -9,7 +9,6 @@ import io
 import os
 import socket
 import threading
-import warnings
 import weakref
 
 from redis.exceptions import (


### PR DESCRIPTION
### Pull Request check-list

It looks like #1721 intended to remove the hiredis warning, but didn't fully remove it when byte buffers aren't available. 

This PR tries to do the same thing, but remove the error message in the other case. 

Closes #1725

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
