### PR TITLE
Adding support for non-decodable commands

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -27,6 +27,9 @@ from redis.utils import safe_str, str_if_bytes
 SYM_EMPTY = b''
 EMPTY_RESPONSE = 'EMPTY_RESPONSE'
 
+# some responses (ie. dump) are binary, and just meant to never be decoded
+NEVER_DECODE = 'NEVER_DECODE'
+
 
 def timestamp_to_datetime(response):
     "Converts a unix timestamp to a Python datetime object"
@@ -1081,7 +1084,10 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands, object):
     def parse_response(self, connection, command_name, **options):
         "Parses a response from the Redis server"
         try:
-            response = connection.read_response()
+            if NEVER_DECODE in options:
+                response = connection.read_response(disable_decoding=True)
+            else:
+                response = connection.read_response()
         except ResponseError:
             if EMPTY_RESPONSE in options:
                 return options[EMPTY_RESPONSE]

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -801,7 +801,10 @@ class CoreCommands:
         Return a serialized version of the value stored at the specified key.
         If key does not exist a nil bulk reply is returned.
         """
-        return self.execute_command('DUMP', name)
+        from redis.client import NEVER_DECODE
+        options = {}
+        options[NEVER_DECODE] = []
+        return self.execute_command('DUMP', name, **options)
 
     def exists(self, *names):
         "Returns the number of ``names`` that exist"

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -51,9 +51,9 @@ class SentinelManagedConnection(Connection):
                     continue
             raise SlaveNotFoundError  # Never be here
 
-    def read_response(self):
+    def read_response(self, disable_decoding=False):
         try:
-            return super().read_response()
+            return super().read_response(disable_decoding=disable_decoding)
         except ReadOnlyError:
             if self.connection_pool.is_master:
                 # When talking to a master, a ReadOnlyError when likely


### PR DESCRIPTION
Some commands (i.e DUMP) should never have their response decoded, as they return binaries, not encoded blobs

fixes #1254
