### PR TITLE
Changed the PubSub's health check command to be performed only on the…

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1415,10 +1415,6 @@ class PubSub:
         before returning. Timeout should be specified as a floating point
         number.
         """
-        if self.cmd_execution_health_check is True:
-            # Health checks will be done within the parse_response method,
-            # cancel health checks from the command_execution method
-            self.cmd_execution_health_check = False
         response = self.parse_response(block=False, timeout=timeout)
         if response:
             return self.handle_message(response, ignore_subscribe_messages)

--- a/redis/client.py
+++ b/redis/client.py
@@ -1215,6 +1215,7 @@ class PubSub:
         self.pending_unsubscribe_channels = set()
         self.patterns = {}
         self.pending_unsubscribe_patterns = set()
+        self.cmd_execution_health_check = True
 
     def close(self):
         self.reset()
@@ -1258,8 +1259,11 @@ class PubSub:
             # were listening to when we were disconnected
             self.connection.register_connect_callback(self.on_connect)
         connection = self.connection
-        kwargs = {'check_health': not self.subscribed}
+        kwargs = {'check_health': self.cmd_execution_health_check}
         self._execute(connection, connection.send_command, *args, **kwargs)
+        if self.cmd_execution_health_check is True:
+            # Run a health check only on the first command execution
+            self.cmd_execution_health_check = False
 
     def _disconnect_raise_connect(self, conn, error):
         """
@@ -1411,6 +1415,10 @@ class PubSub:
         before returning. Timeout should be specified as a floating point
         number.
         """
+        if self.cmd_execution_health_check is True:
+            # Health checks will be done within the parse_response method,
+            # cancel health checks from the command_execution method
+            self.cmd_execution_health_check = False
         response = self.parse_response(block=False, timeout=timeout)
         if response:
             return self.handle_message(response, ignore_subscribe_messages)


### PR DESCRIPTION
… first command execution.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [V ] Does `$ tox` pass with this change (including linting)?
- [V ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ V] Is the new or changed code fully tested?
- [ V] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Closing #1720:

I reproduced the PubSub bug described in #1720 and was able to find the RC.
When the PubSub's 'execute_command' method is being called it passes a 'health_check' bool to determine if it needs to run a health check. The 'health_check' value is set to **not self.subscribed**, which checks if the pubsub instance has any items in the channels/patterns lists. That means, that we perform a health check within the execute_command function only if we are not yet subscribed. All subsequent commands, after the first subscription, should be executed without performing a health check, since the channels/patterns list is no longer empty.
The pubsub's 'get_messages()' method can be used to poll published messages after a pubsub instance has been created. If a poller thread is created (thread that waits on get_message()) it will listen on the same socket as the pubsub execute_command is listening to when it performs a health check. Hence, we should not send a healthcheck using the pubsub execute_command function after the poller thread is initiated, since then it will be racing the poller thread to read the response from the socket.

In the example in #1720 we see the following flow:

1. PubSub instance is being created
2. Channel 'foo' is being subscribed - health check is performed since self.channels is empty
3. 'PONG' is received 
4. A poller thread is being started, looping on 'get_messages()'
5. The poller thread polls the 'subscribe' response
6. Channel 'foo' is being unsubscribed, health check is not being performed since self.channels still contains 'foo'. 'foo' is removed from self.channels
7. The poller thread polls the 'unsubscribe' response
8. Channel 'baz' is being subscribed - health check is performed since self.channels is empty again
9. The poller thread tries to poll the 'subscribe' response and gets the 'PONG' response instead
10. The health check waits for a PONG response that has already been received by the poller thread, and is therefore timed out

Therefore, we shouldn't use self.channels and self.patterns to determine whether a health check needs to be executed, but we should have another variable to indicate whether this is the first command execution, and if so, to run a health check. 

However, a poller thread may be started before subscribing to a channel, e.g. :

1. ps = r.pubsub()
2. poller = threading.Thread(target=poll, args=(ps,))
3. ps.subscribe('foo')

In this case, the health check will be performed and we will still get a race reading from the socket with the poller thread. 
So, my suggestion is to add a new 'cmd_execution_health_check' variable initiated with 'True' to the pubsub class and to set it to False on: 
1. The end of execute_command method, so the health check will be performed only on the first execution), or
2. get_message() function, so the health check will not be performed from the execute_command function at all.
health checks are being done by the get_message() method, so no need to execute it also from the main command execution.  

This change fixes the reported bug.