### PR TITLE
Fixing read race condition during pubsub

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1366,7 +1366,6 @@ class PubSub:
             self.clean_health_check_responses()
         self._execute(connection, connection.send_command, *args, **kwargs)
 
-
     def clean_health_check_responses(self):
         """
         If any health check responses are present, clean them

--- a/redis/client.py
+++ b/redis/client.py
@@ -1480,6 +1480,8 @@ class PubSub:
         if not self.subscribed:
             # Set the subscribed_event flag to True
             self.subscribed_event.set()
+            # Clear the health check counter
+            self.health_check_response_counter = 0
         self.pending_unsubscribe_patterns.difference_update(new_patterns)
         return ret_val
 
@@ -1517,6 +1519,8 @@ class PubSub:
         if not self.subscribed:
             # Set the subscribed_event flag to True
             self.subscribed_event.set()
+            # Clear the health check counter
+            self.health_check_response_counter = 0
         self.pending_unsubscribe_channels.difference_update(new_channels)
         return ret_val
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -1508,10 +1508,29 @@ class PubSub:
         before returning. Timeout should be specified as a floating point
         number.
         """
+        if not self.subscribed and \
+                self.wait_for_subscription(timeout) is False:
+            # The connection isn't subscribed to any channels or patterns, so
+            # no messages are available
+            return None
+
         response = self.parse_response(block=False, timeout=timeout)
         if response:
             return self.handle_message(response, ignore_subscribe_messages)
         return None
+
+    def wait_for_subscription(self, timeout, period=0.25):
+        """
+        Wait until this pubsub connection has been subscribed.
+        Return True if the connection was subscribed during the timeout
+        frametime. Otherwise, return False.
+        """
+        mustend = time.time() + timeout
+        while time.time() < mustend:
+            if self.subscribed:
+                return True
+            time.sleep(period)
+        return False
 
     def ping(self, message=None):
         """

--- a/redis/client.py
+++ b/redis/client.py
@@ -1370,7 +1370,7 @@ class PubSub:
         ttl = 10
         conn = self.connection
         while self.health_check_response_counter > 0 and ttl > 0:
-            if self._execute(conn, conn.can_read, timeout=1):
+            if self._execute(conn, conn.can_read, timeout=conn.socket_timeout):
                 response = self._execute(conn, conn.read_response)
                 if self.is_health_check_response(response):
                     self.health_check_response_counter -= 1

--- a/redis/client.py
+++ b/redis/client.py
@@ -1518,12 +1518,12 @@ class PubSub:
         """
         if not self.subscribed:
             # Wait for subscription
-            deadline = time.time() + timeout
+            start_time = time.time()
             if self.subscribed_event.wait(timeout) is True:
                 # The connection was subscribed during the timeout frametime.
-                # The timeout should be adjusted for the time spent waiting
-                # for subscription
-                time_spent = deadline - time.time()
+                # The timeout should be adjusted based on the time spent
+                # waiting for the subscription
+                time_spent = time.time() - start_time
                 timeout = timeout - time_spent
             else:
                 # The connection isn't subscribed to any channels or patterns,

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -6,7 +6,6 @@ from unittest import mock
 import pytest
 
 import redis
-from redis.client import PubSub
 from redis.exceptions import ConnectionError
 
 from .conftest import (

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2,17 +2,14 @@ import platform
 import threading
 import time
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 
 import redis
 from redis.exceptions import ConnectionError
 
-from .conftest import (
-    _get_client,
-    skip_if_redis_enterprise,
-    skip_if_server_version_lt
-)
+from .conftest import _get_client, skip_if_redis_enterprise, skip_if_server_version_lt
 
 
 def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False):
@@ -20,7 +17,8 @@ def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False):
     timeout = now + timeout
     while now < timeout:
         message = pubsub.get_message(
-            ignore_subscribe_messages=ignore_subscribe_messages)
+            ignore_subscribe_messages=ignore_subscribe_messages
+        )
         if message is not None:
             return message
         time.sleep(0.01)
@@ -351,15 +349,6 @@ class TestPubSubMessages:
             "pmessage", channel, "test message", pattern=pattern
         )
 
-    def test_get_message_without_subscribe(self, r):
-        p = r.pubsub()
-        with pytest.raises(RuntimeError) as info:
-            p.get_message()
-        expect = (
-            "connection not set: " "did you forget to call subscribe() or psubscribe()?"
-        )
-        assert expect in info.exconly()
-
 
 class TestPubSubAutoDecoding:
     "These tests only validate that we get unicode values back"
@@ -557,7 +546,7 @@ class TestPubSubTimeouts:
         assert p.subscribed is False
         assert p.get_message() is None
         assert p.get_message(timeout=0.1) is None
-        with patch.object(threading.Event, 'wait') as mock:
+        with patch.object(threading.Event, "wait") as mock:
             mock.return_value = False
             assert p.get_message(timeout=0.01) is None
             assert mock.called
@@ -570,19 +559,19 @@ class TestPubSubTimeouts:
             message = ps.get_message(timeout=1)
             assert message == expected_res
 
-        subscribe_response = make_message('subscribe', 'foo', 1)
+        subscribe_response = make_message("subscribe", "foo", 1)
         poller = threading.Thread(target=poll, args=(p, subscribe_response))
         poller.start()
         time.sleep(0.2)
-        p.subscribe('foo')
+        p.subscribe("foo")
         poller.join()
 
     def test_get_message_wait_for_subscription_not_being_called(self, r):
         p = r.pubsub()
-        p.subscribe('foo')
-        with patch.object(threading.Event, 'wait') as mock:
+        p.subscribe("foo")
+        with patch.object(threading.Event, "wait") as mock:
             assert p.subscribed is True
-            assert wait_for_message(p) == make_message('subscribe', 'foo', 1)
+            assert wait_for_message(p) == make_message("subscribe", "foo", 1)
             assert mock.called is False
 
 

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -558,7 +558,7 @@ class TestPubSubTimeouts:
         assert p.subscribed is False
         assert p.get_message() is None
         assert p.get_message(timeout=0.1) is None
-        with patch.object(PubSub, 'wait_for_subscription') as mock:
+        with patch.object(threading.Event, 'wait') as mock:
             mock.return_value = False
             assert p.get_message(timeout=0.01) is None
             assert mock.called
@@ -581,7 +581,7 @@ class TestPubSubTimeouts:
     def test_get_message_wait_for_subscription_not_being_called(self, r):
         p = r.pubsub()
         p.subscribe('foo')
-        with patch.object(PubSub, 'wait_for_subscription') as mock:
+        with patch.object(threading.Event, 'wait') as mock:
             assert p.subscribed is True
             assert wait_for_message(p) == make_message('subscribe', 'foo', 1)
             assert mock.called is False


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X ] Does `$ tox` pass with this change (including linting)?
- [ X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X ] Is the new or changed code fully tested?
- [ X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

closes #1720 
closes #1740 
closes #1733 

Another implementation to #1720 (first impl: #1733)
In this PR i'm adding an option to call pubsub's method get_message() without subscribing first.
If get_message is called and no channel/pattern is subscribed, the method will return None without trying to read from the connection.
When timeout is passed and no channels are yet subscribed, the get_message() function will wait for the first to arrive - either a subscription has been made or the time has expired.