### PR TITLE
Allow overriding connection class via keyword arguments

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1084,6 +1084,10 @@ class ConnectionPool:
         arguments always win.
         """
         url_options = parse_url(url)
+
+        if "connection_class" in kwargs:
+            url_options["connection_class"] = kwargs["connection_class"]
+
         kwargs.update(url_options)
         return cls(**kwargs)
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -430,6 +430,15 @@ class TestConnectionPoolUnixSocketURLParsing:
             'b': '2'
         }
 
+    def test_connection_class_override(self):
+        class MyConnection(redis.UnixDomainSocketConnection):
+            pass
+
+        pool = redis.ConnectionPool.from_url(
+            'unix:///socket', connection_class=MyConnection
+        )
+        assert pool.connection_class == MyConnection
+
 
 @pytest.mark.skipif(not ssl_available, reason="SSL not installed")
 class TestSSLConnectionURLParsing:
@@ -439,6 +448,15 @@ class TestSSLConnectionURLParsing:
         assert pool.connection_kwargs == {
             'host': 'my.host',
         }
+
+    def test_connection_class_override(self):
+        class MyConnection(redis.SSLConnection):
+            pass
+
+        pool = redis.ConnectionPool.from_url(
+            'rediss://my.host', connection_class=MyConnection
+        )
+        assert pool.connection_class == MyConnection
 
     def test_cert_reqs_options(self):
         import ssl


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This allows overriding the connection class which is implicitly guessed by the schema provided in the URI. 
While other arguments parsed from URI have precedence, current behavior is inconsistent, user can override class for default `redis://` but not `rediss://` and `unix://`.
Closes:  redis#1739
