### PR TITLE
Improved RedisCluster's reinitialize_steps and documentation

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -745,8 +745,7 @@ class RedisCluster(RedisClusterCommands):
         if self.moved_reinitialize_steps == 0:
             return False
         else:
-            return self.moved_reinitialize_counter % \
-                   self.moved_reinitialize_steps == 0
+            return self.moved_reinitialize_counter % self.moved_reinitialize_steps == 0
 
     def keyslot(self, key):
         """
@@ -1068,6 +1067,10 @@ class ClusterNode:
 
     def __eq__(self, obj):
         return isinstance(obj, ClusterNode) and obj.name == self.name
+
+    def __del__(self):
+        if self.redis_connection is not None:
+            self.redis_connection.close()
 
 
 class LoadBalancer:

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2576,14 +2576,14 @@ class TestReadOnlyPipeline:
                     raise MovedError(moved_error)
 
                 mock_node_resp_func(replica, raise_moved_error)
-            assert readwrite_pipe.reinitialize_counter == 0
+            assert readwrite_pipe.moved_reinitialize_counter == 0
             readwrite_pipe.get(key).get(key)
             assert readwrite_pipe.execute() == ["MOCK_FOO", "MOCK_FOO"]
             if replica is not None:
                 # the slot has a replica as well, so MovedError should have
                 # occurred. If MovedError occurs, we should see the
                 # reinitialize_counter increase.
-                assert readwrite_pipe.reinitialize_counter == 1
+                assert readwrite_pipe.moved_reinitialize_counter == 1
                 conn = replica.redis_connection.connection
                 assert conn.read_response.called is True
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -93,10 +93,11 @@ def get_mocked_redis_client(func=None, *args, **kwargs):
                 return mock_cluster_slots
             elif _args[0] == "COMMAND":
                 return {"get": [], "set": []}
-            elif len(_args) > 1 and _args[1] == "cluster-require-full-coverage":
-                return {"cluster-require-full-coverage": coverage_res}
             elif _args[0] == "INFO":
                 return {"cluster_enabled": cluster_enabled}
+            elif len(_args) > 1 and \
+                    _args[1] == "cluster-require-full-coverage":
+                return {"cluster-require-full-coverage": coverage_res}
             elif func is not None:
                 return func(*args, **kwargs)
             else:
@@ -2058,6 +2059,8 @@ class TestNodesManager:
                 def execute_command(*args, **kwargs):
                     if args[0] == "CLUSTER SLOTS":
                         return result
+                    elif args[0] == "INFO":
+                        return {"cluster_enabled": True}
                     elif args[1] == "cluster-require-full-coverage":
                         return {"cluster-require-full-coverage": "yes"}
                     else:
@@ -2122,6 +2125,8 @@ class TestNodesManager:
                                 ["127.0.0.1", 7002, "node_2"],
                             ],
                         ]
+                    elif args[0] == "INFO":
+                        return {"cluster_enabled": True}
                     elif args[1] == "cluster-require-full-coverage":
                         return {"cluster-require-full-coverage": "yes"}
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2594,14 +2594,14 @@ class TestReadOnlyPipeline:
                     raise MovedError(moved_error)
 
                 mock_node_resp_func(replica, raise_moved_error)
-            assert readwrite_pipe.moved_reinitialize_counter == 0
+            assert readwrite_pipe.reinitialize_counter == 0
             readwrite_pipe.get(key).get(key)
             assert readwrite_pipe.execute() == ["MOCK_FOO", "MOCK_FOO"]
             if replica is not None:
                 # the slot has a replica as well, so MovedError should have
                 # occurred. If MovedError occurs, we should see the
                 # reinitialize_counter increase.
-                assert readwrite_pipe.moved_reinitialize_counter == 1
+                assert readwrite_pipe.reinitialize_counter == 1
                 conn = replica.redis_connection.connection
                 assert conn.read_response.called is True
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -95,8 +95,7 @@ def get_mocked_redis_client(func=None, *args, **kwargs):
                 return {"get": [], "set": []}
             elif _args[0] == "INFO":
                 return {"cluster_enabled": cluster_enabled}
-            elif len(_args) > 1 and \
-                    _args[1] == "cluster-require-full-coverage":
+            elif len(_args) > 1 and _args[1] == "cluster-require-full-coverage":
                 return {"cluster-require-full-coverage": coverage_res}
             elif func is not None:
                 return func(*args, **kwargs)

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -450,7 +450,7 @@ class TestConnectionPoolUnixSocketURLParsing:
             pass
 
         pool = redis.ConnectionPool.from_url(
-            'unix:///socket', connection_class=MyConnection
+            "unix:///socket", connection_class=MyConnection
         )
         assert pool.connection_class == MyConnection
 
@@ -469,7 +469,7 @@ class TestSSLConnectionURLParsing:
             pass
 
         pool = redis.ConnectionPool.from_url(
-            'rediss://my.host', connection_class=MyConnection
+            "rediss://my.host", connection_class=MyConnection
         )
         assert pool.connection_class == MyConnection
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
1. RedisCluster's reinitialize_steps have been refactored to moved_reinitialize_steps and the documentation has been improved
2. Destructor added to ClusterNode to close connection pool when deleted
3. Added a check to make sure the startup nodes have cluster mode enabled