### PR TITLE
Single sourcing the package version

### DIFF
--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -1,5 +1,6 @@
 import sys
-if sys.version_info >= (3,8):
+
+if sys.version_info >= (3, 8):
     from importlib import metadata
 else:
     import importlib_metadata as metadata
@@ -44,7 +45,10 @@ def int_or_str(value):
         return value
 
 
-__version__ = metadata.version('redis')
+try:
+    __version__ = metadata.version("redis")
+except metadata.PackageNotFoundError:
+    __version__ = "99.99.99"
 
 
 VERSION = tuple(map(int_or_str, __version__.split(".")))

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -1,3 +1,9 @@
+import sys
+if sys.version_info >= (3,8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
 from redis.client import Redis, StrictRedis
 from redis.cluster import RedisCluster
 from redis.connection import (
@@ -38,7 +44,7 @@ def int_or_str(value):
         return value
 
 
-__version__ = "4.1.0rc2"
+__version__ = metadata.version('redis')
 
 
 VERSION = tuple(map(int_or_str, __version__.split(".")))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords=["Redis", "key-value store", "database"],
     license="MIT",
-    version=redis.__version__,
+    version="4.1.0rc2",
     packages=find_packages(
         include=[
             "redis",
@@ -26,12 +26,10 @@ setup(
     author="Redis Inc.",
     author_email="oss@redis.com",
     python_requires=">=3.6",
-    setup_requires=[
-        "packaging>=21.3",
-    ],
     install_requires=[
         "deprecated>=1.2.3",
         "packaging>=21.3",
+        'importlib-metadata >= 1.0; python_version < "3.8"',
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 from setuptools import find_packages, setup
 
-import redis
-
 setup(
     name="redis",
     description="Python client for Redis database and key-value store",


### PR DESCRIPTION
This PR single-sources the package version via setup.py's version, and for cases where the package is not installed (i.e local development), rely on 99.99.99.

closes #1784 