### PR TITLE
Ensure redis_connect_func is set on uds connection

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -552,8 +552,8 @@ class Connection:
             self.retry = Retry(NoBackoff(), 0)
         self.health_check_interval = health_check_interval
         self.next_health_check = 0
-        self.encoder = Encoder(encoding, encoding_errors, decode_responses)
         self.redis_connect_func = redis_connect_func
+        self.encoder = Encoder(encoding, encoding_errors, decode_responses)
         self._sock = None
         self._socket_read_size = socket_read_size
         self.set_parser(parser_class)
@@ -942,6 +942,7 @@ class UnixDomainSocketConnection(Connection):
         health_check_interval=0,
         client_name=None,
         retry=None,
+        redis_connect_func=None,
     ):
         """
         Initialize a new UnixDomainSocketConnection.
@@ -966,6 +967,7 @@ class UnixDomainSocketConnection(Connection):
             self.retry = Retry(NoBackoff(), 0)
         self.health_check_interval = health_check_interval
         self.next_health_check = 0
+        self.redis_connect_func = redis_connect_func
         self.encoder = Encoder(encoding, encoding_errors, decode_responses)
         self._sock = None
         self._socket_read_size = socket_read_size


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
Fixes a regression introduced in #1660 when adding the `redis_connect_func` kwarg to the `Connection` base class which results in `UnixDomainSocketConnection` not being usable.

#### Testing
To reproduce on master:
```
>>> import redis
>>> redis.Redis.from_url("unix:///tmp/dirty.sock").ping()
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    redis.Redis.from_url("unix:///tmp/dirty.sock").ping()
  File "/var/tmp/redis-py/redis/commands/core.py", line 805, in ping
    return self.execute_command("PING", **kwargs)
  File "/var/tmp/redis-py/redis/client.py", line 1156, in execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
  File "/var/tmp/redis-py/redis/connection.py", line 1245, in get_connection
    connection.connect()
  File "/var/tmp/redis-py/redis/connection.py", line 606, in connect
    if self.redis_connect_func is None:
AttributeError: 'UnixDomainSocketConnection' object has no attribute 'redis_connect_func'
```

