### PR TITLE
JSON set_file and set_path support

### DIFF
--- a/redis/commands/json/commands.py
+++ b/redis/commands/json/commands.py
@@ -231,7 +231,7 @@ class JSONCommands:
         with open(file_name, "r") as fp:
             file_content = loads(fp.read())
 
-        return self.set(name, path, file_content, nx, xx, decode_keys)
+        return self.set(name, path, file_content, nx=nx, xx=xx, decode_keys=decode_keys)
 
     def set_path(self, json_path, root_folder, nx=False, xx=False, decode_keys=False):
         """
@@ -247,13 +247,20 @@ class JSONCommands:
         set_files_result = {}
         for root, dirs, files in os.walk(root_folder):
             for file in files:
+                file_path = os.path.join(root, file)
                 try:
-                    file_name = os.path.join(root, file).rsplit(".")[0]
-                    file_path = os.path.join(root, file)
-                    self.set_file(file_name, json_path, file_path, nx, xx, decode_keys)
-                    set_files_result[os.path.join(root, file)] = True
+                    file_name = file_path.rsplit(".")[0]
+                    self.set_file(
+                        file_name,
+                        json_path,
+                        file_path,
+                        nx=nx,
+                        xx=xx,
+                        decode_keys=decode_keys,
+                    )
+                    set_files_result[file_path] = True
                 except JSONDecodeError:
-                    set_files_result[os.path.join(root, file)] = False
+                    set_files_result[file_path] = False
 
         return set_files_result
 

--- a/redis/commands/json/commands.py
+++ b/redis/commands/json/commands.py
@@ -1,11 +1,12 @@
+import os
+from json import JSONDecodeError, loads
+
 from deprecated import deprecated
 
 from redis.exceptions import DataError
 
 from .decoders import decode_dict_keys
 from .path import Path
-from json import loads, JSONDecodeError
-import os
 
 
 class JSONCommands:
@@ -217,7 +218,8 @@ class JSONCommands:
 
     def set_file(self, name, path, file_name, nx=False, xx=False, decode_keys=False):
         """
-        Set the JSON value at key ``name`` under the ``path`` to the contents of the json file ``file_name``.
+        Set the JSON value at key ``name`` under the ``path`` to the content
+        of the json file ``file_name``.
 
         ``nx`` if set to True, set ``value`` only if it does not exist.
         ``xx`` if set to True, set ``value`` only if it exists.
@@ -225,23 +227,28 @@ class JSONCommands:
         with utf-8.
 
         """
-        try:
-            file_content = loads(file_name)
-        except JSONDecodeError:
-            raise JSONDecodeError("Inappropriate file type, set_file() requires json file")
-        
+
+        with open(file_name, "r") as fp:
+            file_content = loads(fp.read())
+
         return self.set(name, path, file_content, nx, xx, decode_keys)
 
+    def set_path(self, json_path, root_folder, nx=False, xx=False, decode_keys=False):
+        """
+        Iterate over ``root_folder`` and set each JSON file to a value
+        under ``json_path`` with the file name as the key.
 
-    def set_path(self, json_path, root_directory , nx=False, xx=False, decode_keys=False):
-        """ 
+        ``nx`` if set to True, set ``value`` only if it does not exist.
+        ``xx`` if set to True, set ``value`` only if it exists.
+        ``decode_keys`` If set to True, the keys of ``obj`` will be decoded
+        with utf-8.
 
         """
         set_files_result = {}
-        for root, dirs, files in os.walk(root_directory):
+        for root, dirs, files in os.walk(root_folder):
             for file in files:
                 try:
-                    file_name = file.rsplit('.')[0]
+                    file_name = os.path.join(root, file).rsplit(".")[0]
                     file_path = os.path.join(root, file)
                     self.set_file(file_name, json_path, file_path, nx, xx, decode_keys)
                     set_files_result[os.path.join(root, file)] = True
@@ -249,8 +256,6 @@ class JSONCommands:
                     set_files_result[os.path.join(root, file)] = False
 
         return set_files_result
-
-
 
     def strlen(self, name, path=None):
         """Return the length of the string JSON value under ``path`` at key

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1392,3 +1392,15 @@ def test_custom_decoder(client):
     assert client.exists("foo") == 0
     assert not isinstance(cj.__encoder__, json.JSONEncoder)
     assert not isinstance(cj.__decoder__, json.JSONDecoder)
+
+
+@pytest.mark.redismod
+def test_set_file(client):
+    import tempfile
+    import json
+
+    jsonfile = tempfile.NamedTemporaryFile(suffix=".json")
+    with open(jsonfile.name, 'w+') as fp:
+        fp.write(json.dumps({"hello": "world"}))
+
+    assert client.json().set("test", Path.rootPath(), jsonfile.name)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1416,18 +1416,18 @@ def test_set_file(client):
 @pytest.mark.redismod
 def test_set_path(client):
     import json
-    import os
     import tempfile
 
     root = tempfile.mkdtemp()
     sub = tempfile.mkdtemp(dir=root)
-    ospointer, jsonfile = tempfile.mkstemp(suffix=".json", dir=sub)
-    ospointer2, nojsonfile = tempfile.mkstemp(dir=root)
+    jsonfile = tempfile.mktemp(suffix=".json", dir=sub)
+    nojsonfile = tempfile.mktemp(dir=root)
 
     with open(jsonfile, "w+") as fp:
         fp.write(json.dumps({"hello": "world"}))
     open(nojsonfile, "a+").write("hello")
 
-    result = {"/private" + jsonfile: True, "/private" + nojsonfile: False}
-    assert client.json().set_path(Path.rootPath(), os.path.realpath(root)) == result
-    assert client.json().get("/private" + jsonfile.rsplit(".")[0]) == {"hello": "world"}
+    result = {jsonfile: True, nojsonfile: False}
+    print(result)
+    assert client.json().set_path(Path.rootPath(), root) == result
+    assert client.json().get(jsonfile.rsplit(".")[0]) == {"hello": "world"}


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Adding the ability to use json.set with a file from disk, or a directory containing multiple json files.

closes #1785