### PR TITLE
get_connection: catch OSError too

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1303,7 +1303,7 @@ class ConnectionPool:
             try:
                 if connection.can_read():
                     raise ConnectionError("Connection has data")
-            except ConnectionError:
+            except (ConnectionError, OSError):
                 connection.disconnect()
                 connection.connect()
                 if connection.can_read():


### PR DESCRIPTION
which covers built-in ConnectionError, to recover from connection issues such as `ConnectionResetError` and `ConnectionAbortedError`. Closes #1772.

### Pull Request check-list

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
