### PR TITLE
Allowing poetry and redis-py to install together

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "deprecated>=1.2.3",
-        "packaging>=21.3",
+        "packaging>=20.4",
         'importlib-metadata >= 1.0; python_version < "3.8"',
     ],
     classifiers=[


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Poetry is stuck with packaging ^20.4 (https://github.com/python-poetry/poetry/issues/4752) for a while yet.
I don't see any pressing need for exactly >=21.3 in redis-py at the moment. This change would allow poetry==1.1.12 and redis-py==4.1.0 to be installed together 
