### PR TITLE
`setup.py`: Add project_urls for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,12 @@ setup(
         ]
     ),
     url="https://github.com/redis/redis-py",
+    project_urls={
+        "Documentation": "https://redis.readthedocs.io/en/latest/",
+        "Changes": "https://github.com/redis/redis-py/releases",
+        "Code": "https://github.com/redis/redis-py",
+        "Issue tracker": "https://github.com/redis/redis-py/issues",
+    },
     author="Redis Inc.",
     author_email="oss@redis.com",
     python_requires=">=3.6",


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)? N/A
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? N/A
- [x] Is there an example added to the examples folder (if applicable)? N/A


### Description of change
This adds [`project_urls`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls) to setup.py. They do not take effect until the package is published

Example:

![image](https://user-images.githubusercontent.com/26336/148386844-b8941c2c-7129-4203-9fbe-246a09b671aa.png)

