### PR TITLE
Define incr/decr as aliases of incrby/decrby

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -1159,17 +1159,6 @@ class BasicKeyCommands:
             params.append("REPLACE")
         return self.execute_command("COPY", *params)
 
-    def decr(self, name, amount=1):
-        """
-        Decrements the value of ``key`` by ``amount``.  If no key exists,
-        the value will be initialized as 0 - ``amount``
-
-        For more information check https://redis.io/commands/decr
-        """
-        # An alias for ``decr()``, because it is already implemented
-        # as DECRBY redis command.
-        return self.decrby(name, amount)
-
     def decrby(self, name, amount=1):
         """
         Decrements the value of ``key`` by ``amount``.  If no key exists,
@@ -1178,6 +1167,8 @@ class BasicKeyCommands:
         For more information check https://redis.io/commands/decrby
         """
         return self.execute_command("DECRBY", name, amount)
+
+    decr = decrby
 
     def delete(self, *names):
         """
@@ -1350,15 +1341,6 @@ class BasicKeyCommands:
         """
         return self.execute_command("GETSET", name, value)
 
-    def incr(self, name, amount=1):
-        """
-        Increments the value of ``key`` by ``amount``.  If no key exists,
-        the value will be initialized as ``amount``
-
-        For more information check https://redis.io/commands/incr
-        """
-        return self.incrby(name, amount)
-
     def incrby(self, name, amount=1):
         """
         Increments the value of ``key`` by ``amount``.  If no key exists,
@@ -1366,9 +1348,9 @@ class BasicKeyCommands:
 
         For more information check https://redis.io/commands/incrby
         """
-        # An alias for ``incr()``, because it is already implemented
-        # as INCRBY redis command.
         return self.execute_command("INCRBY", name, amount)
+
+    incr = incrby
 
     def incrbyfloat(self, name, amount=1.0):
         """


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

(I would welcome some help on how to set up the CI tests on my forked repo, if this is necessary (it's already running in this PR). I couldn't figure it out, and the Contributing guide wasn't helpful)

### Description of change

Currently, `incr` and `decr` are implemented as identical wrappers of the functions `incrby` and `decrby`.

Their documentation is also identical to the other functions, with the difference of linking to the original command's Redis reference. `repr` is documented as:
>Increments the value of ``key`` by ``amount``.  If no key exists, the value will be initialized as ``amount``
> For more information check https://redis.io/commands/incr

This is incorrect and misleading, since Redis's documentation of `incr` contains no mention of `amount`.

This change sets up `incr` and `decr` as direct aliases of `incrby` and `decrby` by assignment. This also means they share docstrings, so that both will lead to `incrby` and `decrby`'s original references. I think this makes more sense given the function signatures. (I checked the generated Sphinx documentation and it is identical, other than the Redis URLs).

I also removed the comment in `incrby` that claims it is an alias of `incr`. I think it's the other way around, and I don't think the comment is adding much. Perhaps it's more useful to document the fact that `incr` is an alias of `incrby` for backwards compatibility...?