### PR TITLE
Increased pubsub's wait_for_messages timeout to prevent flaky tests

### DIFF
--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -12,7 +12,7 @@ from redis.exceptions import ConnectionError
 from .conftest import _get_client, skip_if_redis_enterprise, skip_if_server_version_lt
 
 
-def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False):
+def wait_for_message(pubsub, timeout=0.5, ignore_subscribe_messages=False):
     now = time.time()
     timeout = now + timeout
     while now < timeout:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Increased the timeout of wait_for_messages function in test_pubsub.py from 0.1 to 0.5 sec to prevent flaky tests