### PR TITLE
Fix flushdb and flushall

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -118,6 +118,7 @@ REDIS_ALLOWED_KEYS = (
     "ssl_certfile",
     "ssl_cert_reqs",
     "ssl_keyfile",
+    "ssl_password",
     "unix_socket_path",
     "username",
 )

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -290,7 +290,7 @@ class RedisCluster(RedisClusterCommands):
                 "FLUSHALL",
                 "FLUSHDB",
             ],
-            ALL_NODES,
+            PRIMARIES,
         ),
         list_keys_to_dict(
             [

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -241,8 +241,6 @@ class RedisCluster(RedisClusterCommands):
                 "SHUTDOWN",
                 "KEYS",
                 "SCAN",
-                "FLUSHALL",
-                "FLUSHDB",
                 "DBSIZE",
                 "BGSAVE",
                 "SLOWLOG GET",
@@ -285,6 +283,13 @@ class RedisCluster(RedisClusterCommands):
                 "TIME",
             ],
             DEFAULT_NODE,
+        ),
+        list_keys_to_dict(
+            [
+                "FLUSHALL",
+                "FLUSHDB",
+            ],
+            ALL_NODES,
         ),
         list_keys_to_dict(
             [

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2640,3 +2640,10 @@ class TestClusterMonitor:
             r.get(byte_string)
             response = wait_for_command(r, m, "GET {foo}bar\\\\x92", key=key)
             assert response["command"] == "GET {foo}bar\\\\x92"
+
+    def test_flush(self, r):
+        r.set('x', '1')
+        r.set('z', '1')
+        r.flushall()
+        assert r.get('x') == None
+        assert r.get('y') == None

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2642,8 +2642,8 @@ class TestClusterMonitor:
             assert response["command"] == "GET {foo}bar\\\\x92"
 
     def test_flush(self, r):
-        r.set('x', '1')
-        r.set('z', '1')
+        r.set("x", "1")
+        r.set("z", "1")
         r.flushall()
-        assert r.get('x') == None
-        assert r.get('y') == None
+        assert r.get("x") is None
+        assert r.get("y") is None


### PR DESCRIPTION
Both commands should be broadcasted to all the shards.
In addition, support `ssl_password` on cluster.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
