### PR TITLE
Handle upper case commands in cluster

### DIFF
--- a/redis/commands/parser.py
+++ b/redis/commands/parser.py
@@ -60,7 +60,10 @@ class CommandsParser:
                     # We'll try to reinitialize the commands cache, if the engine
                     # version has changed, the commands may not be current
                     self.initialize(redis_conn)
-                    if cmd_name not in self.commands:
+                    if (
+                        lower_main_cmd_name not in self.commands
+                        and upper_main_cmd_name not in self.commands
+                    ):
                         raise RedisError(
                             f"{cmd_name.upper()} command doesn't exist in \
                                 Redis commands"

--- a/redis/commands/parser.py
+++ b/redis/commands/parser.py
@@ -19,23 +19,6 @@ class CommandsParser:
     def initialize(self, r):
         self.commands = r.execute_command("COMMAND")
 
-    def check_cmd_name_in_commands(self, redis_conn, cmd_name, args):
-        if cmd_name not in self.commands:
-            # try to split the command name and to take only the main command,
-            # e.g. 'memory' for 'memory usage'
-            cmd_name_split = cmd_name.split()
-            cmd_name = cmd_name_split[0]
-            if cmd_name in self.commands:
-                # save the splitted command to args
-                args = cmd_name_split + list(args[1:])
-                return True
-            else:
-                # We'll try to reinitialize the commands cache, if the engine
-                # version has changed, the commands may not be current
-                self.initialize(redis_conn)
-                if cmd_name not in self.commands:
-                    return False
-
 
     # As soon as this PR is merged into Redis, we should reimplement
     # our logic to use COMMAND INFO changes to determine the key positions

--- a/redis/commands/parser.py
+++ b/redis/commands/parser.py
@@ -60,10 +60,11 @@ class CommandsParser:
                     # We'll try to reinitialize the commands cache, if the engine
                     # version has changed, the commands may not be current
                     self.initialize(redis_conn)
-                    if (
-                        lower_main_cmd_name not in self.commands
-                        and upper_main_cmd_name not in self.commands
-                    ):
+                    if lower_main_cmd_name in self.commands:
+                        cmd_name = lower_main_cmd_name
+                    elif upper_main_cmd_name in self.commands:
+                        cmd_name = upper_main_cmd_name
+                    else:
                         raise RedisError(
                             f"{cmd_name.upper()} command doesn't exist in \
                                 Redis commands"


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Is the changes added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This PR aims to fix handling of upper case commands (like "FT.CREATE") on cluster. 
When in cluster, `_determine_nodes` is called since there is a need to check the right shard to execute the command, by calling `determine_slot`. This command calls `_get_command_keys` which in return calls the parser's `get_keys` with a default node connection.

an example of such calls with `FT.SEARCH`:
```python
r = redis_conn.get_default_node().redis_connection
"FT.SEARCH" in r.execute_command("COMMAND")
```
returns `True`
while
```python
r = redis_conn.get_default_node().redis_connection
"ft.search" in r.execute_command("COMMAND")
```
returns `False`

A thing to discuss:
should we leave `args = cmd_name_split + list(args[1:])`
or modify it to `args = cmd_name_split[1:] + list(args[1:])`