### PR TITLE
Remove verbose logging from cluster initializers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
   	* Create codeql-analysis.yml (#1988). Thanks @chayim
     * Add limited support for Lua scripting with RedisCluster
     * Implement `.lock()` method on RedisCluster
+    * Remove verbose logging when initializing ClusterPubSub, ClusterPipeline or RedisCluster
 
 * 4.1.3 (Feb 8, 2022)
     * Fix flushdb and flushall (#1926)

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -518,8 +518,6 @@ class RedisCluster(RedisClusterCommands):
              RedisClusterException:
                  - db (Redis do not support database SELECT in cluster mode)
         """
-        log.info("Creating a new instance of RedisCluster client")
-
         if startup_nodes is None:
             startup_nodes = []
 
@@ -1670,7 +1668,6 @@ class ClusterPubSub(PubSub):
         :type host: str
         :type port: int
         """
-        log.info("Creating new instance of ClusterPubSub")
         self.node = None
         self.set_pubsub_node(redis_cluster, node, host, port)
         connection_pool = (
@@ -1802,7 +1799,6 @@ class ClusterPipeline(RedisCluster):
         **kwargs,
     ):
         """ """
-        log.info("Creating new instance of ClusterPipeline")
         self.command_stack = []
         self.nodes_manager = nodes_manager
         self.commands_parser = commands_parser


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

We are using ClusterPipeline and noticed that our logs are filled with "Creating new instance of ClusterPipeline" entries. I am not sure if these entries provide much value so I thought we could either remove them completely or change the log level to debug.

Another thing that we noticed was that cluster.py is the only module that's doing any kind of logging at all.