### PR TITLE
Make typing_extensions conditional to Python < 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 async-timeout>=4.0.2
 deprecated>=1.2.3
 packaging>=20.4
-typing-extensions
+typing-extensions; python_version<"3.8"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "deprecated>=1.2.3",
         "packaging>=20.4",
         'importlib-metadata >= 1.0; python_version < "3.8"',
-        "typing-extensions",
+        'typing-extensions; python_version<"3.8"',
         "async-timeout>=4.0.2",
     ],
     classifiers=[


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

All the typing features used by redis-py are available in Python 3.8+,
so typing_extensions is not used at all in newer versions of Python.
Adjust the dependencies accordingly.