### PR TITLE
always clear reference to closed reader/writer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
     * Fix cursor returned by SCAN for RedisCluster & change default target to PRIMARIES
     * Fix scan_iter for RedisCluster
     * Remove verbose logging when initializing ClusterPubSub, ClusterPipeline or RedisCluster
+    * Fix broken connection writer lock-up for asyncio (#2065)
 
 * 4.1.3 (Feb 8, 2022)
     * Fix flushdb and flushall (#1926)

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -827,8 +827,9 @@ class Connection:
                             await self._writer.wait_closed()  # type: ignore[union-attr]
                 except OSError:
                     pass
-                self._reader = None
-                self._writer = None
+                finally:
+                    self._reader = None
+                    self._writer = None
         except asyncio.TimeoutError:
             raise TimeoutError(
                 f"Timed out closing connection after {self.socket_connect_timeout}"


### PR DESCRIPTION
### Description of change

Fixes #2065 - makes sure we always discard closed/closing writers


### Pull Request check-list

- [x] ~Does `$ tox` pass with this change (including linting)?~  (tox doesn't pass on master and this doesn't attempt to fix any of those issues)
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] ~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~
- [x] ~Is there an example added to the examples folder (if applicable)?~
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._