### PR TITLE
Extended "CLUSTER NODES" parser to support special slot entries

### DIFF
--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -954,6 +954,42 @@ class TestClusterRedisCommands:
             == "c8253bae761cb1ecb2b61857d85dfe455a0fec8b"
         )
 
+    def test_cluster_nodes_importing_migrating(self, r):
+        response = (
+            "488ead2fcce24d8c0f158f9172cb1f4a9e040fe5 127.0.0.1:16381@26381 "
+            "master - 0 1648975557664 3 connected 10923-16383\n"
+            "8ae2e70812db80776f739a72374e57fc4ae6f89d 127.0.0.1:16380@26380 "
+            "master - 0 1648975555000 2 connected 1 5461-10922 ["
+            "2-<-ed8007ccfa2d91a7b76f8e6fba7ba7e257034a16]\n"
+            "ed8007ccfa2d91a7b76f8e6fba7ba7e257034a16 127.0.0.1:16379@26379 "
+            "myself,master - 0 1648975556000 1 connected 0 2-5460 ["
+            "2->-8ae2e70812db80776f739a72374e57fc4ae6f89d]\n"
+        )
+        mock_all_nodes_resp(r, response)
+        nodes = r.cluster_nodes()
+        assert len(nodes) == 3
+        node_16379 = nodes.get("127.0.0.1:16379")
+        node_16380 = nodes.get("127.0.0.1:16380")
+        node_16381 = nodes.get("127.0.0.1:16381")
+        assert node_16379.get("migrations") == [
+            {
+                "slot": "2",
+                "node_id": "8ae2e70812db80776f739a72374e57fc4ae6f89d",
+                "state": "migrating",
+            }
+        ]
+        assert node_16379.get("slots") == [["0"], ["2", "5460"]]
+        assert node_16380.get("migrations") == [
+            {
+                "slot": "2",
+                "node_id": "ed8007ccfa2d91a7b76f8e6fba7ba7e257034a16",
+                "state": "importing",
+            }
+        ]
+        assert node_16380.get("slots") == [["1"], ["5461", "10922"]]
+        assert node_16381.get("slots") == [["10923", "16383"]]
+        assert node_16381.get("migrations") == []
+
     def test_cluster_replicate(self, r):
         node = r.get_random_node()
         all_replicas = r.get_replicas()


### PR DESCRIPTION

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Extended "CLUSTER NODES" parser to support special slot entries (importing, migrating).
The returned dictionary will also contain another field called 'migrations' that will hold slots that are in migration process.
See https://redis.io/commands/cluster-nodes/#special-slot-entries for more info.

For example, for the following cluster:
```
49962d9126b7e587c7c93e9899df075055846123 127.0.0.1:16381@26381 master - 0 1648980066000 3 connected 10923-16383
bcded50bc75187199679b0cc7380b3240724b834 127.0.0.1:16379@26379 myself,master - 0 1648980062000 1 connected 0-5460 [1->-a0bb8017ee950c73510741f866f5ebf2aebc5662]
a0bb8017ee950c73510741f866f5ebf2aebc5662 127.0.0.1:16380@26380 master - 0 1648980065000 2 connected 5461-10922
```
the returned entry for node 16379 is:
```
print(r.cluster_nodes().get("127.0.0.1:16379"))
{'node_id': 'bcded50bc75187199679b0cc7380b3240724b834', 
'flags': 'myself,master', 
'master_id': '-', 
'last_ping_sent': '0', 
'last_pong_rcvd': '1648980178000', 
'epoch': '1',
 'slots': [['0', '5460']],
 'migrations': [{'slot': '1', 'node_id': 'a0bb8017ee950c73510741f866f5ebf2aebc5662', 'state': 'migrating'}],
 'connected': True}
```