### PR TITLE
Fix incorrect return statement in auth (#2086)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
     * Fix scan_iter for RedisCluster
     * Remove verbose logging when initializing ClusterPubSub, ClusterPipeline or RedisCluster
     * Fix broken connection writer lock-up for asyncio (#2065)
+    * Fix auth bug when provided with no username (#2086)
 
 * 4.1.3 (Feb 8, 2022)
     * Fix flushdb and flushall (#1926)

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -369,16 +369,14 @@ class ManagementCommands(CommandsProtocol):
     Redis management commands
     """
 
-    def auth(self, password, username=None, **kwargs):
+    def auth(self, password, username="default", **kwargs):
         """
         Authenticates the user. If you do not pass username, Redis will try to
         authenticate for the "default" user. If you do pass username, it will
         authenticate for the given user.
         For more information see https://redis.io/commands/auth
         """
-        if username:
-            return self.execute_command("AUTH", username, password, **kwargs)
-        return self.execute_command
+        return self.execute_command("AUTH", username, password, **kwargs)
 
     def bgrewriteaof(self, **kwargs):
         """Tell the Redis server to rewrite the AOF file from data in memory.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -67,6 +67,13 @@ class TestResponseCallbacks:
 class TestRedisCommands:
     @skip_if_redis_enterprise()
     def test_auth(self, r, request):
+        # first, test for default user (`username` is supposed to be optional)
+        username = "default"
+
+        assert r.auth("", username) is True
+        assert r.auth("") is True
+
+        # test for other users
         username = "redis-py-auth"
 
         def teardown():


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Fix a bug in commands.core.ManagementCommands.auth that returned a function handler when provided with a None username
