### PR TITLE
Fix incorrect return statement in auth (#2086)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
     * Fix scan_iter for RedisCluster
     * Remove verbose logging when initializing ClusterPubSub, ClusterPipeline or RedisCluster
     * Fix broken connection writer lock-up for asyncio (#2065)
+    * Fix auth bug when provided with no username (#2086)
 
 * 4.1.3 (Feb 8, 2022)
     * Fix flushdb and flushall (#1926)

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -376,9 +376,11 @@ class ManagementCommands(CommandsProtocol):
         authenticate for the given user.
         For more information see https://redis.io/commands/auth
         """
-        if username:
-            return self.execute_command("AUTH", username, password, **kwargs)
-        return self.execute_command
+        pieces = []
+        if username is not None:
+            pieces.append(username)
+        pieces.append(password)
+        return self.execute_command("AUTH", *pieces, **kwargs)
 
     def bgrewriteaof(self, **kwargs):
         """Tell the Redis server to rewrite the AOF file from data in memory.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -67,9 +67,23 @@ class TestResponseCallbacks:
 class TestRedisCommands:
     @skip_if_redis_enterprise()
     def test_auth(self, r, request):
+        # first, test for default user (`username` is supposed to be optional)
+        default_username = "default"
+        temp_pass = "temp_pass"
+        r.config_set("requirepass", temp_pass)
+
+        assert r.auth(temp_pass, default_username) is True
+        assert r.auth(temp_pass) is True
+
+        # test for other users
         username = "redis-py-auth"
 
         def teardown():
+            try:
+                r.auth(temp_pass)
+            except exceptions.ResponseError:
+                r.auth("default", "")
+            r.config_set("requirepass", "")
             r.acl_deluser(username)
 
         request.addfinalizer(teardown)


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Was the change added to CHANGES file?

### Description of change
Fix a bug in commands.core.ManagementCommands.auth that returned a function handler when provided with a None username