### PR TITLE
Catch `Exception` and not `BaseException` in the `Connection`

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -502,8 +502,6 @@ class HiredisParser(BaseParser):
             # data was read from the socket and added to the buffer.
             # return True to indicate that data was read.
             return True
-        except asyncio.CancelledError:
-            raise
         except (socket.timeout, asyncio.TimeoutError):
             if raise_on_timeout:
                 raise TimeoutError("Timeout reading from socket") from None
@@ -721,7 +719,7 @@ class Connection:
                 lambda: self._connect(), lambda error: self.disconnect()
             )
         except asyncio.CancelledError:
-            raise
+            raise  # in 3.7 and earlier, this is an Exception, not BaseException
         except (socket.timeout, asyncio.TimeoutError):
             raise TimeoutError("Timeout connecting to server")
         except OSError as e:

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -916,7 +916,7 @@ class Connection:
             raise ConnectionError(
                 f"Error {err_no} while writing to socket. {errmsg}."
             ) from e
-        except BaseException:
+        except Exception:
             await self.disconnect()
             raise
 
@@ -958,7 +958,7 @@ class Connection:
             raise ConnectionError(
                 f"Error while reading from {self.host}:{self.port} : {e.args}"
             )
-        except BaseException:
+        except Exception:
             await self.disconnect()
             raise
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -766,7 +766,7 @@ class Connection:
                 errno = e.args[0]
                 errmsg = e.args[1]
             raise ConnectionError(f"Error {errno} while writing to socket. {errmsg}.")
-        except BaseException:
+        except Exception:
             self.disconnect()
             raise
 
@@ -804,7 +804,7 @@ class Connection:
         except OSError as e:
             self.disconnect()
             raise ConnectionError(f"Error while reading from {hosterr}" f" : {e.args}")
-        except BaseException:
+        except Exception:
             self.disconnect()
             raise
 

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -918,7 +918,6 @@ class TestPubSubAutoReconnect:
             return False
 
             
-@pytest.mark.xfail
 @pytest.mark.onlynoncluster
 class TestBaseException:
     @pytest.mark.skipif(

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -917,7 +917,7 @@ class TestPubSubAutoReconnect:
         except asyncio.TimeoutError:
             return False
 
-            
+
 @pytest.mark.onlynoncluster
 class TestBaseException:
     @pytest.mark.skipif(

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -735,3 +735,46 @@ class TestPubSubAutoReconnect:
         for message in self.pubsub.listen():
             self.messages.put(message)
             return True
+
+
+@pytest.mark.xfail
+@pytest.mark.onlynoncluster
+class TestBaseException:
+    def test_base_exception(self, r: redis.Redis):
+        """
+        Manually trigger a BaseException inside the parser's .read_response method
+        and verify that it isn't caught
+        """
+        pubsub = r.pubsub()
+        pubsub.subscribe("foo")
+
+        def is_connected():
+            return pubsub.connection._sock is not None
+
+        assert is_connected()
+
+        def get_msg():
+            # blocking method to return messages
+            while True:
+                response = pubsub.parse_response(block=True)
+                message = pubsub.handle_message(
+                    response, ignore_subscribe_messages=False
+                )
+                if message is not None:
+                    return message
+
+        # get subscribe message
+        msg = get_msg()
+        assert msg is not None
+        # timeout waiting for another message which never arrives
+        assert is_connected()
+        with patch("redis.connection.PythonParser.read_response") as mock1:
+            mock1.side_effect = BaseException("boom")
+            with patch("redis.connection.HiredisParser.read_response") as mock2:
+                mock2.side_effect = BaseException("boom")
+
+                with pytest.raises(BaseException):
+                    get_msg()
+
+        # the timeout on the read should not cause disconnect
+        assert is_connected()

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -737,7 +737,6 @@ class TestPubSubAutoReconnect:
             return True
 
 
-@pytest.mark.xfail
 @pytest.mark.onlynoncluster
 class TestBaseException:
     def test_base_exception(self, r: redis.Redis):


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

### Description of change

Fixes Issue #2103:
Raising a BaseException inside a `Connection`'s send or receive oprations causes a `disconnect`().  BaseExceptions are commonly used for _out of band_ messages in Python and normally not be expecially acted upon, only be handled at the top-level 

See also:  #2356 which focuses on a different aspcect of error handling.