### PR TITLE
`Retry()`: Support negative `retries` value

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 
+    * Allow negative `retries` for `Retry` class to retry forever
     * Add `items` parameter to `hset` signature
     * Create codeql-analysis.yml (#1988). Thanks @chayim
     * Add limited support for Lua scripting with RedisCluster

--- a/redis/asyncio/retry.py
+++ b/redis/asyncio/retry.py
@@ -27,6 +27,7 @@ class Retry:
         """
         Initialize a `Retry` object with a `Backoff` object
         that retries a maximum of `retries` times.
+        `retries` can be negative to retry forever.
         You can specify the types of supported errors which trigger
         a retry with the `supported_errors` parameter.
         """
@@ -51,7 +52,7 @@ class Retry:
             except self._supported_errors as error:
                 failures += 1
                 await fail(error)
-                if failures > self._retries:
+                if self._retries >= 0 and failures > self._retries:
                     raise error
                 backoff = self._backoff.compute(failures)
                 if backoff > 0:

--- a/redis/retry.py
+++ b/redis/retry.py
@@ -16,6 +16,7 @@ class Retry:
         """
         Initialize a `Retry` object with a `Backoff` object
         that retries a maximum of `retries` times.
+        `retries` can be negative to retry forever.
         You can specify the types of supported errors which trigger
         a retry with the `supported_errors` parameter.
         """
@@ -46,7 +47,7 @@ class Retry:
             except self._supported_errors as error:
                 failures += 1
                 fail(error)
-                if failures > self._retries:
+                if self._retries >= 0 and failures > self._retries:
                     raise error
                 backoff = self._backoff.compute(failures)
                 if backoff > 0:

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -56,6 +56,11 @@ class TestRetry:
     async def _fail(self, error):
         self.actual_failures += 1
 
+    async def _fail_inf(self, error):
+        self.actual_failures += 1
+        if self.actual_failures == 5:
+            raise ConnectionError()
+
     @pytest.mark.parametrize("retries", range(10))
     @pytest.mark.asyncio
     async def test_retry(self, retries: int):
@@ -68,3 +73,14 @@ class TestRetry:
         assert self.actual_failures == 1 + retries
         assert backoff.reset_calls == 1
         assert backoff.calls == retries
+
+    @pytest.mark.asyncio
+    async def test_infinite_retry(self):
+        backoff = BackoffMock()
+        # specify infinite retries, but give up after 5
+        retry = Retry(backoff, -1)
+        with pytest.raises(ConnectionError):
+            await retry.call_with_retry(self._do, self._fail_inf)
+
+        assert self.actual_attempts == 5
+        assert self.actual_failures == 5

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -95,6 +95,11 @@ class TestRetry:
     def _fail(self, error):
         self.actual_failures += 1
 
+    def _fail_inf(self, error):
+        self.actual_failures += 1
+        if self.actual_failures == 5:
+            raise ConnectionError()
+
     @pytest.mark.parametrize("retries", range(10))
     def test_retry(self, retries):
         backoff = BackoffMock()
@@ -106,6 +111,16 @@ class TestRetry:
         assert self.actual_failures == 1 + retries
         assert backoff.reset_calls == 1
         assert backoff.calls == retries
+
+    def test_infinite_retry(self):
+        backoff = BackoffMock()
+        # specify infinite retries, but give up after 5
+        retry = Retry(backoff, -1)
+        with pytest.raises(ConnectionError):
+            retry.call_with_retry(self._do, self._fail_inf)
+
+        assert self.actual_attempts == 5
+        assert self.actual_failures == 5
 
 
 @pytest.mark.onlynoncluster


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

### Description of change

The `Retry` class now accepts a negative value for `retries` indicating no upper limit on the number of retries; the action
will be retried until it succeeds.