### PR TITLE
Replace OSError exceptions from `can_read` with `redis.ConnectionError`

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -916,7 +916,7 @@ class Connection:
         except OSError as e:
             await self.disconnect()
             raise ConnectionError(
-                f"Error while reading from {self.host}:{self.port} : {e.args}"
+                f"Error while reading from {self.host}:{self.port}: {e.args}"
             )
 
     async def read_response(self, disable_decoding: bool = False):

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -911,7 +911,13 @@ class Connection:
         """Poll the socket to see if there's data that can be read."""
         if not self.is_connected:
             await self.connect()
-        return await self._parser.can_read(timeout)
+        try:
+            return await self._parser.can_read(timeout)
+        except OSError as e:
+            await self.disconnect()
+            raise ConnectionError(
+                f"Error while reading from {self.host}:{self.port} : {e.args}"
+            )
 
     async def read_response(self, disable_decoding: bool = False):
         """Read the response from a previously sent command"""

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1288,7 +1288,7 @@ class ConnectionPool:
     def __init__(
         self, connection_class=Connection, max_connections=None, **connection_kwargs
     ):
-        max_connections = max_connections or 2**31
+        max_connections = max_connections or 2 ** 31
         if not isinstance(max_connections, int) or max_connections < 0:
             raise ValueError('"max_connections" must be a positive integer')
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -812,7 +812,9 @@ class Connection:
             return self._parser.can_read(timeout)
         except OSError as e:
             self.disconnect()
-            raise ConnectionError(f"Error while reading from {self.host}:{self.port} : {e.args}")
+            raise ConnectionError(
+                f"Error while reading from {self.host}:{self.port}: {e.args}"
+            )
 
     def read_response(self, disable_decoding=False):
         """Read the response from a previously sent command"""

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -808,7 +808,11 @@ class Connection:
         sock = self._sock
         if not sock:
             self.connect()
-        return self._parser.can_read(timeout)
+        try:
+            return self._parser.can_read(timeout)
+        except OSError as e:
+            self.disconnect()
+            raise ConnectionError(f"Error while reading from {self.host}:{self.port} : {e.args}")
 
     def read_response(self, disable_decoding=False):
         """Read the response from a previously sent command"""
@@ -1282,7 +1286,7 @@ class ConnectionPool:
     def __init__(
         self, connection_class=Connection, max_connections=None, **connection_kwargs
     ):
-        max_connections = max_connections or 2 ** 31
+        max_connections = max_connections or 2**31
         if not isinstance(max_connections, int) or max_connections < 0:
             raise ValueError('"max_connections" must be a positive integer')
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This change catches OS errors in `Connection.can_read`, closes connection and raises a `redis.ConnectionError`.
Fixes #2138 
