### PR TITLE
Rename 'update_supported_erros' to 'update_supported_errors' in Retry module

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -563,7 +563,7 @@ class Connection:
                 # deep-copy the Retry object as it is mutable
                 self.retry = copy.deepcopy(retry)
             # Update the retry's supported errors with the specified errors
-            self.retry.update_supported_erros(retry_on_error)
+            self.retry.update_supported_errors(retry_on_error)
         else:
             self.retry = Retry(NoBackoff(), 0)
         self.health_check_interval = health_check_interval
@@ -1099,7 +1099,7 @@ class UnixDomainSocketConnection(Connection):
                 # deep-copy the Retry object as it is mutable
                 self.retry = copy.deepcopy(retry)
             # Update the retry's supported errors with the specified errors
-            self.retry.update_supported_erros(retry_on_error)
+            self.retry.update_supported_errors(retry_on_error)
         else:
             self.retry = Retry(NoBackoff(), 0)
         self.health_check_interval = health_check_interval

--- a/redis/retry.py
+++ b/redis/retry.py
@@ -23,7 +23,7 @@ class Retry:
         self._retries = retries
         self._supported_errors = supported_errors
 
-    def update_supported_erros(self, specified_errors: list):
+    def update_supported_errors(self, specified_errors: list):
         """
         Updates the supported errors with the specified error types
         """


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

In the Retry module, a function was named `update_supported_erros`. I rename it to `update_supported_errors`