### PR TITLE
Async Connection:  Allow `PubSub.run()` without previous `subscribe()`

### DIFF
--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 from typing import Optional
 
+import async_timeout
 import pytest
 
 if sys.version_info[0:2] == (3, 6):
@@ -658,3 +659,35 @@ class TestPubSubRun:
             except asyncio.CancelledError:
                 pass
         assert str(e) == "error"
+
+    @pytest.mark.xfail
+    async def test_late_subscribe(self, r: redis.Redis):
+        def callback(message):
+            messages.put_nowait(message)
+
+        messages = asyncio.Queue()
+        p = r.pubsub()
+        task = asyncio.get_event_loop().create_task(p.run())
+        # wait until loop gets settled.  Add a subscription
+        await asyncio.sleep(0.1)
+        await p.subscribe(foo=callback)
+        # wait tof the subscribe to finish.  Cannot use _subscribe() because
+        # p.run() is already accepting messages
+        await asyncio.sleep(0.1)
+        await r.publish("foo", "bar")
+        message = None
+        try:
+            async with async_timeout.timeout(0.1):
+                message = await messages.get()
+        except asyncio.TimeoutError:
+            pass
+        task.cancel()
+        # we expect a cancelled error, not the Runtime error ("did you forget to call subscribe()"")
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert message == {
+            "channel": b"foo",
+            "data": b"bar",
+            "pattern": None,
+            "type": "message",
+        }

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -660,7 +660,6 @@ class TestPubSubRun:
                 pass
         assert str(e) == "error"
 
-    @pytest.mark.xfail
     async def test_late_subscribe(self, r: redis.Redis):
         def callback(message):
             messages.put_nowait(message)

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -681,7 +681,8 @@ class TestPubSubRun:
         except asyncio.TimeoutError:
             pass
         task.cancel()
-        # we expect a cancelled error, not the Runtime error ("did you forget to call subscribe()"")
+        # we expect a cancelled error, not the Runtime error
+        # ("did you forget to call subscribe()"")
         with pytest.raises(asyncio.CancelledError):
             await task
         assert message == {


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

This change adds a "connect()" method to the PubSub class and employs that in the `run` method.
This makes it possible to start a `run()` task without knowing beforehand which subscriptions are required,
for example, when running a server that dynamically listens to various channels. 

PR is provided as a suggested feature, and so there is no documentation or non-async implementation yet.
