### PR TITLE
Fix incorrect return annotation in asyncio.lock

### DIFF
--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -3,7 +3,7 @@ import sys
 import threading
 import uuid
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Awaitable, NoReturn, Optional, Union
+from typing import TYPE_CHECKING, Awaitable, Optional, Union
 
 from redis.exceptions import LockError, LockNotOwnedError
 
@@ -243,7 +243,7 @@ class Lock:
             stored_token = encoder.encode(stored_token)
         return self.local.token is not None and stored_token == self.local.token
 
-    def release(self) -> Awaitable[NoReturn]:
+    def release(self) -> Awaitable[None]:
         """Releases the already acquired lock"""
         expected_token = self.local.token
         if expected_token is None:
@@ -251,7 +251,7 @@ class Lock:
         self.local.token = None
         return self.do_release(expected_token)
 
-    async def do_release(self, expected_token: bytes):
+    async def do_release(self, expected_token: bytes) -> None:
         if not bool(
             await self.lua_release(
                 keys=[self.name], args=[expected_token], client=self.redis


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

NoReturn should be used only when the function never returns. In this case, the awaitable returns None if releasing the lock succeeds, so `Awaitable[None]` is right.

Noticed this while reviewing python/typeshed#7676
