### PR TITLE
set default response_callbacks to redis.asyncio.cluster.ClusterNode

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -725,7 +725,7 @@ class ClusterNode:
         server_type: Optional[str] = None,
         max_connections: int = 2 ** 31,
         connection_class: Type[Connection] = Connection,
-        response_callbacks: Dict = None,
+        response_callbacks: Dict = RedisCluster.RESPONSE_CALLBACKS,
         **connection_kwargs,
     ) -> None:
         if host == "localhost":

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -2230,3 +2230,20 @@ class TestNodesManager:
                 async with RedisCluster(startup_nodes=[node_1, node_2]) as rc:
                     assert rc.get_node(host=default_host, port=7001) is not None
                     assert rc.get_node(host=default_host, port=7002) is not None
+
+
+@pytest.mark.onlycluster
+class TestClusterNode:
+    """
+    Tests for the ClusterNode class
+    """
+
+    async def test_valid_response_callbacks(self) -> None:
+        """
+        ClusterNode must have valid default response_callbacks.
+        """
+
+        startup_nodes = [ClusterNode("127.0.0.1", 16379)]
+        async with RedisCluster(startup_nodes=startup_nodes) as rc:
+            assert await rc.set("A", 1)
+            assert await rc.get("A") == b'1'

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -244,6 +244,11 @@ class TestRedisClusterObj:
 
         await cluster.close()
 
+        startup_nodes = [ClusterNode("127.0.0.1", 16379)]
+        async with RedisCluster(startup_nodes=startup_nodes) as rc:
+            assert await rc.set("A", 1)
+            assert await rc.get("A") == b"1"
+
     async def test_empty_startup_nodes(self) -> None:
         """
         Test that exception is raised when empty providing empty startup_nodes
@@ -2230,20 +2235,3 @@ class TestNodesManager:
                 async with RedisCluster(startup_nodes=[node_1, node_2]) as rc:
                     assert rc.get_node(host=default_host, port=7001) is not None
                     assert rc.get_node(host=default_host, port=7002) is not None
-
-
-@pytest.mark.onlycluster
-class TestClusterNode:
-    """
-    Tests for the ClusterNode class
-    """
-
-    async def test_valid_response_callbacks(self) -> None:
-        """
-        ClusterNode must have valid default response_callbacks.
-        """
-
-        startup_nodes = [ClusterNode("127.0.0.1", 16379)]
-        async with RedisCluster(startup_nodes=startup_nodes) as rc:
-            assert await rc.set("A", 1)
-            assert await rc.get("A") == b"1"

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -2246,4 +2246,4 @@ class TestClusterNode:
         startup_nodes = [ClusterNode("127.0.0.1", 16379)]
         async with RedisCluster(startup_nodes=startup_nodes) as rc:
             assert await rc.set("A", 1)
-            assert await rc.get("A") == b'1'
+            assert await rc.get("A") == b"1"


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._

`asyncio.cluster.ClusterNode` needs default response_callbacks, not `None`.

When I initialize `RedisCluster` with `startup_nodes`(instead `host=` and `port=`), `response_callbacks` of ClusterNode will be `None`, unless I specify `response_callbacks`.
It could be assigned when create ClusterNode, but having default value looks more reasonable.