### PR TITLE
Fix incorrect assertion for json.clear

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -904,10 +904,10 @@ def test_clear_dollar(client):
         },
     )
     # Test multi
-    assert client.json().clear("doc1", "$..a") == 3
+    assert client.json().clear("doc1", "$..a") == 4
 
     assert client.json().get("doc1", "$") == [
-        {"nested1": {"a": {}}, "a": [], "nested2": {"a": "claro"}, "nested3": {"a": {}}}
+        {"nested1": {"a": {}}, "a": [], "nested2": {"a": ""}, "nested3": {"a": {}}}
     ]
 
     # Test single


### PR DESCRIPTION
### Pull Request check-list


- [ ] Does `$ tox` pass with this change (including linting)?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?

### Description of change

Update assertion for `client.json().clear` for nested structures. Given the example json:
```json
{
    "nested1": {"a": {"foo": 10, "bar": 20}},
    "a": ["foo"],
    "nested2": {"a": "claro"},
    "nested3": {"a": {"baz": 50}}
}
```
the following matches for path `$..a`:
```json
[
  [
    "foo"
  ],
  {
    "foo": 10,
    "bar": 20
  },
  "claro",
  {
    "baz": 50
  }
]
```

The specific test does indeed fail locally without the updated assertions, so I'm not sure why CI is green with/without it.