### PR TITLE
commands/cluster: use pipeline to execute split commands

### DIFF
--- a/redis/commands/__init__.py
+++ b/redis/commands/__init__.py
@@ -1,4 +1,4 @@
-from .cluster import AsyncRedisClusterCommands, RedisClusterCommands
+from .cluster import READ_COMMANDS, AsyncRedisClusterCommands, RedisClusterCommands
 from .core import AsyncCoreCommands, CoreCommands
 from .helpers import list_or_args
 from .parser import CommandsParser
@@ -6,14 +6,15 @@ from .redismodules import AsyncRedisModuleCommands, RedisModuleCommands
 from .sentinel import AsyncSentinelCommands, SentinelCommands
 
 __all__ = [
-    "AsyncRedisClusterCommands",
-    "RedisClusterCommands",
-    "CommandsParser",
     "AsyncCoreCommands",
-    "CoreCommands",
-    "list_or_args",
+    "AsyncRedisClusterCommands",
     "AsyncRedisModuleCommands",
-    "RedisModuleCommands",
     "AsyncSentinelCommands",
+    "CommandsParser",
+    "CoreCommands",
+    "READ_COMMANDS",
+    "RedisClusterCommands",
+    "RedisModuleCommands",
     "SentinelCommands",
+    "list_or_args",
 ]

--- a/redis/commands/helpers.py
+++ b/redis/commands/helpers.py
@@ -1,9 +1,12 @@
 import copy
 import random
 import string
+from typing import List, Tuple
+
+from redis.typing import KeysT, KeyT
 
 
-def list_or_args(keys, args):
+def list_or_args(keys: KeysT, args: Tuple[KeyT, ...]) -> List[KeyT]:
     # returns a single new list combining keys and args
     try:
         iter(keys)


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

Since commands are split by slots, using a pipeline to send keys from the same node together provides a massive speedup, especially for the sync version.

Benchmarks using a batch of MGET 100 keys, MSET 100 keys, DEL 100 keys:

- Sync (10 batches): 6.34s -> 0.26s
- Async (100 batches): 9.34s -> 3.15s

Other changes:

- allow passing target_nodes to pipeline commands
- pass target_nodes for split commands
- move READ_COMMANDS to commands/cluster to avoid import cycle
- add types to list_or_args