### PR TITLE
async_cluster: fix simultaneous initialize

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -323,14 +323,13 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         if self._initialize:
             async with self._lock:
                 if self._initialize:
-                    self._initialize = False
                     try:
                         await self.nodes_manager.initialize()
                         await self.commands_parser.initialize(
                             self.nodes_manager.default_node
                         )
+                        self._initialize = False
                     except BaseException:
-                        self._initialize = True
                         await self.nodes_manager.close()
                         await self.nodes_manager.close("startup_nodes")
                         raise
@@ -343,6 +342,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
                 if not self._initialize:
                     self._initialize = True
                     await self.nodes_manager.close()
+                    await self.nodes_manager.close("startup_nodes")
 
     async def __aenter__(self) -> "RedisCluster":
         return await self.initialize()

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -680,13 +680,15 @@ class TestRedisClusterObj:
                 else:
                     raise e
 
-    async def test_can_run_concurrent_commands(self, r: RedisCluster) -> None:
-        assert await r.ping(target_nodes=RedisCluster.ALL_NODES) is True
+    async def test_can_run_concurrent_commands(self, request: FixtureRequest) -> None:
+        url = request.config.getoption("--redis-url")
+        rc = RedisCluster.from_url(url)
         assert all(
             await asyncio.gather(
-                *(r.ping(target_nodes=RedisCluster.ALL_NODES) for _ in range(100))
+                *(rc.echo("i", target_nodes=RedisCluster.ALL_NODES) for i in range(100))
             )
         )
+        await rc.close()
 
 
 @pytest.mark.onlycluster


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

`_initialize` should be set to True only after the initialization is complete. Otherwise, it can cause a race condition if the client is executing multiple commands at a time, for eg. in `asyncio.gather`