### PR TITLE
Correct retention_msecs value

### DIFF
--- a/docs/redismodules.rst
+++ b/docs/redismodules.rst
@@ -134,7 +134,7 @@ These are the commands for interacting with the `RedisTimeSeries module <https:/
 
     import redis
     r = redis.Redis()
-    r.ts().create(2, retension_msecs=5)
+    r.ts().create(2, retension_msecs=5000)
 
 .. automodule:: redis.commands.timeseries.commands
     :members: TimeSeriesCommands


### PR DESCRIPTION
### Description of change

The `retention_msecs` takes a millisecond value not a seconds value, having checked and tested redis/commands/timeseries/commands.py is not adjusting seconds to milliseconds it is passing it through as is, therefore the statement in this doc is incorrect as it creates a time series with a retention period of 5 milliseconds not 5 seconds as stated.
