### PR TITLE
Uppercase commands in CommandsParser.get_keys

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 
+    * Compare commands case-insensitively in the asyncio command parser
     * Allow negative `retries` for `Retry` class to retry forever
     * Add `items` parameter to `hset` signature
     * Create codeql-analysis.yml (#1988). Thanks @chayim

--- a/redis/asyncio/parser.py
+++ b/redis/asyncio/parser.py
@@ -55,14 +55,14 @@ class CommandsParser:
             # try to split the command name and to take only the main command
             # e.g. 'memory' for 'memory usage'
             args = args[0].split() + list(args[1:])
-            cmd_name = args[0]
+            cmd_name = args[0].upper()
             if cmd_name not in self.commands:
                 # We'll try to reinitialize the commands cache, if the engine
                 # version has changed, the commands may not be current
                 await self.initialize()
                 if cmd_name not in self.commands:
                     raise RedisError(
-                        f"{cmd_name.upper()} command doesn't exist in Redis commands"
+                        f"{cmd_name} command doesn't exist in Redis commands"
                     )
 
             command = self.commands[cmd_name]


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

I haven't been able to get `tox` to pass locally. I'm unsure what the problem is, but it seems like it's related to `uvloop`. I'm sure it's just a problem with my dev environment as everything passes in CI.

### Description of change

I ran into issues when migrating from the blocking `RedisCluster` to `asyncio.RedisCluster` where `asyncio.CommandsParser.get_keys` would raise errors about commands not existing, even though everything worked with the blocking client. Passing the commands to `asyncio.RedisCluster.execute_command` as uppercase strings fixed the problem.

This change makes sure that commands passed to `asyncio.CommandsParser.get_keys` are always uppercased when used with the `self.commands` dict. This behavior is consistent with the blocking client. I thought that the commands maybe should be uppercased before being passed to `get_keys` but I haven't been able to find any code that looks like it does that. For reference, I was using commands from a proprietary Redis module.