### PR TITLE
Docs: Add a note about client_setname and client_name difference

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -687,6 +687,12 @@ class ManagementCommands(CommandsProtocol):
         Sets the current connection name
 
         For more information see https://redis.io/commands/client-setname
+
+        .. note::
+           This method sets client name only for **current** connection.
+
+           If you want to set a common name for all connections managed
+           by this client, use ``client_name`` constructor argument.
         """
         return self.execute_command("CLIENT SETNAME", name, **kwargs)
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] ~~Is the new or changed code fully tested?~~ Documentation was built and checked if note appear correctly
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] ~~Is there an example added to the examples folder (if applicable)?~~
- [ ] ~~Was the change added to CHANGES file?~~ Change applies only to the documentation

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._

Added note in documentation on `client_setname` command. It applies only to the current connection and in some cases `client_name` argument should be used instead.

closes #2245