### PR TITLE
late eval of the skip condition

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,8 @@ def pytest_sessionstart(session):
     REDIS_INFO["arch_bits"] = arch_bits
     REDIS_INFO["cluster_enabled"] = cluster_enabled
     REDIS_INFO["enterprise"] = info["enterprise"]
+    # store REDIS_INFO in config so that it is available from "condition strings"
+    session.config.REDIS_INFO = REDIS_INFO
 
     # module info, if the second redis is running
     try:

--- a/tests/test_asyncio/conftest.py
+++ b/tests/test_asyncio/conftest.py
@@ -39,14 +39,14 @@ async def _get_info(redis_url):
         pytest.param(
             (True, PythonParser),
             marks=pytest.mark.skipif(
-                'REDIS_INFO["cluster_enabled"]', reason="cluster mode enabled"
+                'config.REDIS_INFO["cluster_enabled"]', reason="cluster mode enabled"
             ),
         ),
         (False, PythonParser),
         pytest.param(
             (True, HiredisParser),
             marks=pytest.mark.skipif(
-                not HIREDIS_AVAILABLE or 'REDIS_INFO["cluster_enabled"]',
+                not HIREDIS_AVAILABLE or 'config.REDIS_INFO["cluster_enabled"]',
                 reason="hiredis is not installed or cluster mode enabled",
             ),
         ),

--- a/tests/test_asyncio/conftest.py
+++ b/tests/test_asyncio/conftest.py
@@ -39,14 +39,14 @@ async def _get_info(redis_url):
         pytest.param(
             (True, PythonParser),
             marks=pytest.mark.skipif(
-                REDIS_INFO["cluster_enabled"], reason="cluster mode enabled"
+                'REDIS_INFO["cluster_enabled"]', reason="cluster mode enabled"
             ),
         ),
         (False, PythonParser),
         pytest.param(
             (True, HiredisParser),
             marks=pytest.mark.skipif(
-                not HIREDIS_AVAILABLE or REDIS_INFO["cluster_enabled"],
+                not HIREDIS_AVAILABLE or 'REDIS_INFO["cluster_enabled"]',
                 reason="hiredis is not installed or cluster mode enabled",
             ),
         ),

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -73,7 +73,7 @@ async def test_add(modclient: redis.Redis):
         4, 4, 2, retention_msecs=10, labels={"Redis": "Labs", "Time": "Series"}
     )
     res = await modclient.ts().add(5, "*", 1)
-    assert round(time.time()) == round(float(res) / 1000)
+    assert abs(time.time() - round(float(res) / 1000)) < 1.0
 
     info = await modclient.ts().info(4)
     assert 10 == info.retention_msecs

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -70,7 +70,8 @@ def test_add(client):
     assert 4 == client.ts().add(
         4, 4, 2, retention_msecs=10, labels={"Redis": "Labs", "Time": "Series"}
     )
-    assert round(time.time()) == round(float(client.ts().add(5, "*", 1)) / 1000)
+
+    assert abs(time.time() - float(client.ts().add(5, "*", 1)) / 1000) < 1.0
 
     info = client.ts().info(4)
     assert 10 == info.retention_msecs


### PR DESCRIPTION
at module import time, the REDIS_INFO dict hasn't been initialized.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

when running the unittests manually, e.g. with `pytest tests` from the command line, test discovery would fail because the
`REDIS_INFO` dict, although existing, hadn't been initialized at import time.  The skip tests need to evaluate the REDIS_INFO as initialized during session setup, hence the need for a late init (done via skip string)

Additionally, changed two instances of 

```python
assert round(time1) == round(time2)
``` 
to

```python
assert abs(time1 - time2) < 1.0
```

The former will fail, if for example, `time1==1000.4999` and `time2==1000.5001` which is clearly not what is intended.