### PR TITLE
Fix: `start_id` type for `XAUTOCLAIM`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 
+    * Fix start_id type for XAUTOCLAIM
     * Compare commands case-insensitively in the asyncio command parser
     * Allow negative `retries` for `Retry` class to retry forever
     * Add `items` parameter to `hset` signature

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3420,7 +3420,7 @@ class StreamCommands(CommandsProtocol):
         groupname: GroupT,
         consumername: ConsumerT,
         min_idle_time: int,
-        start_id: int = 0,
+        start_id: StreamIdT = "0-0",
         count: Union[int, None] = None,
         justid: bool = False,
     ) -> ResponseT:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Current XAUTOCLAIM implementation [expects](https://github.com/redis/redis-py/blob/master/redis/commands/core.py#L3423) `start_id` typed as `int` which loses second half of stream ID. This PR fixes the problem by making `start_id` type `StreamIdT`.
