### PR TITLE
Fix crash: key expire while search

### DIFF
--- a/redis/commands/search/result.py
+++ b/redis/commands/search/result.py
@@ -38,7 +38,7 @@ class Result:
             score = float(res[i + 1]) if with_scores else None
 
             fields = {}
-            if hascontent:
+            if hascontent and res[i + fields_offset] is not None:
                 fields = (
                     dict(
                         dict(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1698,3 +1698,16 @@ def test_dialect(modclient: redis.Redis):
     with pytest.raises(redis.ResponseError) as err:
         modclient.ft().explain(Query("@title:(@num:[0 10])").dialect(2))
     assert "Syntax error" in str(err)
+
+
+@pytest.mark.redismod
+def test_expire_while_search(modclient: redis.Redis):
+    modclient.ft().create_index((TextField("txt"),))
+    modclient.hset("hset:1", "txt", "a")
+    modclient.hset("hset:2", "txt", "b")
+    modclient.hset("hset:3", "txt", "c")
+    assert 3 == modclient.ft().search(Query("*")).total
+    modclient.pexpire("hset:2", 300)
+    for _ in range(500):
+        modclient.ft().search(Query("*")).docs[1]
+    assert 2 == modclient.ft().search(Query("*")).total

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1710,4 +1710,5 @@ def test_expire_while_search(modclient: redis.Redis):
     modclient.pexpire("hset:2", 300)
     for _ in range(500):
         modclient.ft().search(Query("*")).docs[1]
+    time.sleep(1)
     assert 2 == modclient.ft().search(Query("*")).total


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

See the expected behaviour when hash expiry time is reached after the start of the query process here:
https://redis.io/commands/ft.search/#return (in the current behaviour it crashes)