### PR TITLE
Graph - add counters for removed labels and properties

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -24,7 +24,7 @@ jobs:
      steps:
        - uses: actions/checkout@v2
        - name: install python
-         uses: actions/setup-python@v3
+         uses: actions/setup-python@v4
          with:
            python-version: 3.9
            cache: 'pip'
@@ -39,7 +39,7 @@ jobs:
      strategy:
        max-parallel: 15
        matrix:
-         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
+         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
          test-type: ['standalone', 'cluster']
          connection-type: ['hiredis', 'plain']
      env:
@@ -48,7 +48,7 @@ jobs:
      steps:
        - uses: actions/checkout@v2
        - name: install python
-         uses: actions/setup-python@v3
+         uses: actions/setup-python@v4
          with:
            python-version: ${{ matrix.python-version }}
            cache: 'pip'

--- a/redis/commands/graph/query_result.py
+++ b/redis/commands/graph/query_result.py
@@ -325,50 +325,61 @@ class QueryResult:
     def _get_stat(self, stat):
         return self.statistics[stat] if stat in self.statistics else 0
 
+    '''Returns the number of labels added in the query'''
     @property
     def labels_added(self):
         return self._get_stat(LABELS_ADDED)
 
+    '''Returns the number of labels removed in the query'''
     @property
     def labels_removed(self):
         return self._get_stat(LABELS_REMOVED)
-
+    '''Returns the number of nodes created in the query'''
     @property
     def nodes_created(self):
         return self._get_stat(NODES_CREATED)
 
+    '''Returns the number of nodes deleted in the query'''
     @property
     def nodes_deleted(self):
         return self._get_stat(NODES_DELETED)
 
+    '''Returns the number of properties set in the query'''
     @property
     def properties_set(self):
         return self._get_stat(PROPERTIES_SET)
 
+    '''Returns the number of properties removed in the query'''
     @property
     def properties_removed(self):
         return self._get_stat(PROPERTIES_REMOVED)
 
+    '''Returns the number of relationships created in the query'''
     @property
     def relationships_created(self):
         return self._get_stat(RELATIONSHIPS_CREATED)
 
+    '''Returns the number of relationships deleted in the query'''
     @property
     def relationships_deleted(self):
         return self._get_stat(RELATIONSHIPS_DELETED)
 
+    '''Returns the number of indices created in the query'''
     @property
     def indices_created(self):
         return self._get_stat(INDICES_CREATED)
 
+    '''Returns the number of indices deleted in the query'''
     @property
     def indices_deleted(self):
         return self._get_stat(INDICES_DELETED)
 
+    '''Returns whether or not the query execution plan was cached'''
     @property
     def cached_execution(self):
         return self._get_stat(CACHED_EXECUTION) == 1
 
+    '''Returns the server execution time of the query'''
     @property
     def run_time_ms(self):
         return self._get_stat(INTERNAL_EXECUTION_TIME)

--- a/redis/commands/graph/query_result.py
+++ b/redis/commands/graph/query_result.py
@@ -325,61 +325,74 @@ class QueryResult:
     def _get_stat(self, stat):
         return self.statistics[stat] if stat in self.statistics else 0
 
-    '''Returns the number of labels added in the query'''
+    """Returns the number of labels added in the query"""
+
     @property
     def labels_added(self):
         return self._get_stat(LABELS_ADDED)
 
-    '''Returns the number of labels removed in the query'''
+    """Returns the number of labels removed in the query"""
+
     @property
     def labels_removed(self):
         return self._get_stat(LABELS_REMOVED)
-    '''Returns the number of nodes created in the query'''
+
+    """Returns the number of nodes created in the query"""
+
     @property
     def nodes_created(self):
         return self._get_stat(NODES_CREATED)
 
-    '''Returns the number of nodes deleted in the query'''
+    """Returns the number of nodes deleted in the query"""
+
     @property
     def nodes_deleted(self):
         return self._get_stat(NODES_DELETED)
 
-    '''Returns the number of properties set in the query'''
+    """Returns the number of properties set in the query"""
+
     @property
     def properties_set(self):
         return self._get_stat(PROPERTIES_SET)
 
-    '''Returns the number of properties removed in the query'''
+    """Returns the number of properties removed in the query"""
+
     @property
     def properties_removed(self):
         return self._get_stat(PROPERTIES_REMOVED)
 
-    '''Returns the number of relationships created in the query'''
+    """Returns the number of relationships created in the query"""
+
     @property
     def relationships_created(self):
         return self._get_stat(RELATIONSHIPS_CREATED)
 
-    '''Returns the number of relationships deleted in the query'''
+    """Returns the number of relationships deleted in the query"""
+
     @property
     def relationships_deleted(self):
         return self._get_stat(RELATIONSHIPS_DELETED)
 
-    '''Returns the number of indices created in the query'''
+    """Returns the number of indices created in the query"""
+
     @property
     def indices_created(self):
         return self._get_stat(INDICES_CREATED)
 
-    '''Returns the number of indices deleted in the query'''
+    """Returns the number of indices deleted in the query"""
+
     @property
     def indices_deleted(self):
         return self._get_stat(INDICES_DELETED)
 
-    '''Returns whether or not the query execution plan was cached'''
+    """Returns whether or not the query execution plan was cached"""
+
     @property
     def cached_execution(self):
         return self._get_stat(CACHED_EXECUTION) == 1
 
-    '''Returns the server execution time of the query'''
+    """Returns the server execution time of the query"""
+
     @property
     def run_time_ms(self):
         return self._get_stat(INTERNAL_EXECUTION_TIME)

--- a/redis/commands/graph/query_result.py
+++ b/redis/commands/graph/query_result.py
@@ -325,74 +325,62 @@ class QueryResult:
     def _get_stat(self, stat):
         return self.statistics[stat] if stat in self.statistics else 0
 
-    """Returns the number of labels added in the query"""
-
     @property
     def labels_added(self):
+        """Returns the number of labels added in the query"""
         return self._get_stat(LABELS_ADDED)
-
-    """Returns the number of labels removed in the query"""
 
     @property
     def labels_removed(self):
+        """Returns the number of labels removed in the query"""
         return self._get_stat(LABELS_REMOVED)
-
-    """Returns the number of nodes created in the query"""
 
     @property
     def nodes_created(self):
+        """Returns the number of nodes created in the query"""
         return self._get_stat(NODES_CREATED)
-
-    """Returns the number of nodes deleted in the query"""
 
     @property
     def nodes_deleted(self):
+        """Returns the number of nodes deleted in the query"""
         return self._get_stat(NODES_DELETED)
-
-    """Returns the number of properties set in the query"""
 
     @property
     def properties_set(self):
+        """Returns the number of properties set in the query"""
         return self._get_stat(PROPERTIES_SET)
-
-    """Returns the number of properties removed in the query"""
 
     @property
     def properties_removed(self):
+        """Returns the number of properties removed in the query"""
         return self._get_stat(PROPERTIES_REMOVED)
-
-    """Returns the number of relationships created in the query"""
 
     @property
     def relationships_created(self):
+        """Returns the number of relationships created in the query"""
         return self._get_stat(RELATIONSHIPS_CREATED)
-
-    """Returns the number of relationships deleted in the query"""
 
     @property
     def relationships_deleted(self):
+        """Returns the number of relationships deleted in the query"""
         return self._get_stat(RELATIONSHIPS_DELETED)
-
-    """Returns the number of indices created in the query"""
 
     @property
     def indices_created(self):
+        """Returns the number of indices created in the query"""
         return self._get_stat(INDICES_CREATED)
-
-    """Returns the number of indices deleted in the query"""
 
     @property
     def indices_deleted(self):
+        """Returns the number of indices deleted in the query"""
         return self._get_stat(INDICES_DELETED)
-
-    """Returns whether or not the query execution plan was cached"""
 
     @property
     def cached_execution(self):
+        """Returns whether or not the query execution plan was cached"""
         return self._get_stat(CACHED_EXECUTION) == 1
-
-    """Returns the server execution time of the query"""
 
     @property
     def run_time_ms(self):
+        """Returns the server execution time of the query"""
         return self._get_stat(INTERNAL_EXECUTION_TIME)

--- a/redis/commands/graph/query_result.py
+++ b/redis/commands/graph/query_result.py
@@ -9,10 +9,12 @@ from .node import Node
 from .path import Path
 
 LABELS_ADDED = "Labels added"
+LABELS_REMOVED = "Labels removed"
 NODES_CREATED = "Nodes created"
 NODES_DELETED = "Nodes deleted"
 RELATIONSHIPS_DELETED = "Relationships deleted"
 PROPERTIES_SET = "Properties set"
+PROPERTIES_REMOVED = "Properties removed"
 RELATIONSHIPS_CREATED = "Relationships created"
 INDICES_CREATED = "Indices created"
 INDICES_DELETED = "Indices deleted"
@@ -21,8 +23,10 @@ INTERNAL_EXECUTION_TIME = "internal execution time"
 
 STATS = [
     LABELS_ADDED,
+    LABELS_REMOVED,
     NODES_CREATED,
     PROPERTIES_SET,
+    PROPERTIES_REMOVED,
     RELATIONSHIPS_CREATED,
     NODES_DELETED,
     RELATIONSHIPS_DELETED,
@@ -326,6 +330,10 @@ class QueryResult:
         return self._get_stat(LABELS_ADDED)
 
     @property
+    def labels_removed(self):
+        return self._get_stat(LABELS_REMOVED)
+
+    @property
     def nodes_created(self):
         return self._get_stat(NODES_CREATED)
 
@@ -336,6 +344,10 @@ class QueryResult:
     @property
     def properties_set(self):
         return self._get_stat(PROPERTIES_SET)
+
+    @property
+    def properties_removed(self):
+        return self._get_stat(PROPERTIES_REMOVED)
 
     @property
     def relationships_created(self):

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,8 +2,10 @@ import pytest
 
 from redis.commands.graph import Edge, Node, Path
 from redis.commands.graph.execution_plan import Operation
+from redis.commands.graph.query_result import *
 from redis.exceptions import ResponseError
 from tests.conftest import skip_if_redis_enterprise
+from unittest.mock import patch
 
 
 @pytest.fixture
@@ -575,3 +577,32 @@ Project
     assert result.structured_plan == expected
 
     redis_graph.delete()
+
+@pytest.mark.redismod
+def test_resultset_statistics(client):
+    with patch.object(target = QueryResult, attribute = "_get_stat") as mock_get_stats:
+        result = client.graph().query("RETURN 1")
+        result.labels_added
+        mock_get_stats.assert_called_with(LABELS_ADDED)
+        result.labels_removed
+        mock_get_stats.assert_called_with(LABELS_REMOVED)
+        result.nodes_created
+        mock_get_stats.assert_called_with(NODES_CREATED)
+        result.nodes_deleted
+        mock_get_stats.assert_called_with(NODES_DELETED)
+        result.properties_set
+        mock_get_stats.assert_called_with(PROPERTIES_SET)
+        result.properties_removed
+        mock_get_stats.assert_called_with(PROPERTIES_REMOVED)
+        result.relationships_created
+        mock_get_stats.assert_called_with(RELATIONSHIPS_CREATED)
+        result.relationships_deleted
+        mock_get_stats.assert_called_with(RELATIONSHIPS_DELETED)
+        result.indices_created
+        mock_get_stats.assert_called_with(INDICES_CREATED)
+        result.indices_deleted
+        mock_get_stats.assert_called_with(INDICES_DELETED)
+        result.cached_execution
+        mock_get_stats.assert_called_with(CACHED_EXECUTION)
+        result.run_time_ms
+        mock_get_stats.assert_called_with(INTERNAL_EXECUTION_TIME)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,25 +1,26 @@
+from unittest.mock import patch
+
 import pytest
 
 from redis.commands.graph import Edge, Node, Path
 from redis.commands.graph.execution_plan import Operation
 from redis.commands.graph.query_result import (
-    QueryResult,
+    CACHED_EXECUTION,
+    INDICES_CREATED,
+    INDICES_DELETED,
+    INTERNAL_EXECUTION_TIME,
     LABELS_ADDED,
     LABELS_REMOVED,
     NODES_CREATED,
     NODES_DELETED,
+    PROPERTIES_REMOVED,
+    PROPERTIES_SET,
     RELATIONSHIPS_CREATED,
     RELATIONSHIPS_DELETED,
-    PROPERTIES_SET,
-    PROPERTIES_REMOVED,
-    CACHED_EXECUTION,
-    INTERNAL_EXECUTION_TIME,
-    INDICES_CREATED,
-    INDICES_DELETED,
+    QueryResult,
 )
 from redis.exceptions import ResponseError
 from tests.conftest import skip_if_redis_enterprise
-from unittest.mock import patch
 
 
 @pytest.fixture

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,7 +2,21 @@ import pytest
 
 from redis.commands.graph import Edge, Node, Path
 from redis.commands.graph.execution_plan import Operation
-from redis.commands.graph.query_result import *
+from redis.commands.graph.query_result import (
+    QueryResult,
+    LABELS_ADDED,
+    LABELS_REMOVED,
+    NODES_CREATED,
+    NODES_DELETED,
+    RELATIONSHIPS_CREATED,
+    RELATIONSHIPS_DELETED,
+    PROPERTIES_SET,
+    PROPERTIES_REMOVED,
+    CACHED_EXECUTION,
+    INTERNAL_EXECUTION_TIME,
+    INDICES_CREATED,
+    INDICES_DELETED,
+)
 from redis.exceptions import ResponseError
 from tests.conftest import skip_if_redis_enterprise
 from unittest.mock import patch
@@ -578,9 +592,10 @@ Project
 
     redis_graph.delete()
 
+
 @pytest.mark.redismod
 def test_resultset_statistics(client):
-    with patch.object(target = QueryResult, attribute = "_get_stat") as mock_get_stats:
+    with patch.object(target=QueryResult, attribute="_get_stat") as mock_get_stats:
         result = client.graph().query("RETURN 1")
         result.labels_added
         mock_get_stats.assert_called_with(LABELS_ADDED)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This PR adds counters of removed labels and properties in graph result set statistics.
For those code changes to be applicable https://github.com/RedisGraph/RedisGraph/pull/2481 and https://github.com/RedisGraph/RedisGraph/pull/2379 should be merged into RedisGraph `master` branch
