### PR TITLE
Fix special response parsing options handling

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -501,12 +501,17 @@ class Redis(
         try:
             if NEVER_DECODE in options:
                 response = await connection.read_response(disable_decoding=True)
+                options.pop(NEVER_DECODE)
             else:
                 response = await connection.read_response()
         except ResponseError:
             if EMPTY_RESPONSE in options:
                 return options[EMPTY_RESPONSE]
             raise
+
+        if EMPTY_RESPONSE in options:
+            options.pop(EMPTY_RESPONSE)
+
         if command_name in self.response_callbacks:
             # Mypy bug: https://github.com/python/mypy/issues/10977
             command_name = cast(str, command_name)

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -867,7 +867,7 @@ class ClusterNode:
         try:
             if NEVER_DECODE in kwargs:
                 response = await connection.read_response(disable_decoding=True)
-                options.pop(NEVER_DECODE)
+                kwargs.pop(NEVER_DECODE)
             else:
                 response = await connection.read_response()
         except ResponseError:
@@ -876,7 +876,7 @@ class ClusterNode:
             raise
 
         if EMPTY_RESPONSE in options:
-            options.pop(EMPTY_RESPONSE)
+            kwargs.pop(EMPTY_RESPONSE)
 
         # Return response
         if command in self.response_callbacks:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -867,12 +867,16 @@ class ClusterNode:
         try:
             if NEVER_DECODE in kwargs:
                 response = await connection.read_response(disable_decoding=True)
+                options.pop(NEVER_DECODE)
             else:
                 response = await connection.read_response()
         except ResponseError:
             if EMPTY_RESPONSE in kwargs:
                 return kwargs[EMPTY_RESPONSE]
             raise
+
+        if EMPTY_RESPONSE in options:
+            options.pop(EMPTY_RESPONSE)
 
         # Return response
         if command in self.response_callbacks:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -875,7 +875,7 @@ class ClusterNode:
                 return kwargs[EMPTY_RESPONSE]
             raise
 
-        if EMPTY_RESPONSE in options:
+        if EMPTY_RESPONSE in kwargs:
             kwargs.pop(EMPTY_RESPONSE)
 
         # Return response

--- a/redis/client.py
+++ b/redis/client.py
@@ -1258,12 +1258,17 @@ class Redis(AbstractRedis, RedisModuleCommands, CoreCommands, SentinelCommands):
         try:
             if NEVER_DECODE in options:
                 response = connection.read_response(disable_decoding=True)
+                options.pop(NEVER_DECODE)
             else:
                 response = connection.read_response()
         except ResponseError:
             if EMPTY_RESPONSE in options:
                 return options[EMPTY_RESPONSE]
             raise
+
+        if EMPTY_RESPONSE in options:
+            options.pop(EMPTY_RESPONSE)
+
         if command_name in self.response_callbacks:
             return self.response_callbacks[command_name](response, **options)
         return response

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -11,7 +11,7 @@ import pytest_asyncio
 
 import redis
 from redis import exceptions
-from redis.client import parse_info
+from redis.client import EMPTY_RESPONSE, NEVER_DECODE, parse_info
 from tests.conftest import (
     skip_if_server_version_gte,
     skip_if_server_version_lt,
@@ -541,6 +541,16 @@ class TestRedisCommands:
         assert len(t) == 2
         assert isinstance(t[0], int)
         assert isinstance(t[1], int)
+
+    async def test_never_decode_option(self, r: redis.Redis):
+        opts = {NEVER_DECODE: []}
+        await r.delete("a")
+        assert await r.execute_command("EXISTS", "a", **opts) == 0
+
+    async def test_empty_response_option(self, r: redis.Redis):
+        opts = {EMPTY_RESPONSE: []}
+        await r.delete("a")
+        assert await r.execute_command("EXISTS", "a", **opts) == 0
 
     # BASIC KEY COMMANDS
     async def test_append(self, r: redis.Redis):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,7 +9,7 @@ import pytest
 
 import redis
 from redis import exceptions
-from redis.client import parse_info
+from redis.client import EMPTY_RESPONSE, NEVER_DECODE, parse_info
 
 from .conftest import (
     _get_client,
@@ -916,6 +916,16 @@ class TestRedisCommands:
         assert r.bgsave()
         time.sleep(0.3)
         assert r.bgsave(True)
+
+    def test_never_decode_option(self, r: redis.Redis):
+        opts = {NEVER_DECODE: []}
+        r.delete("a")
+        assert r.execute_command("EXISTS", "a", **opts) == 0
+
+    def test_empty_response_option(self, r: redis.Redis):
+        opts = {EMPTY_RESPONSE: []}
+        r.delete("a")
+        assert r.execute_command("EXISTS", "a", **opts) == 0
 
     # BASIC KEY COMMANDS
     def test_append(self, r):


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
Suggested fix for #2113

When using special response parsing options like `NEVER_DECODE` and
`EMPTY_RESPONSE`, don't pass them to the response callbacks because some
of them are not prepared for receiving named arguments.

Instead, redis-py should use them before calling the callbacks and then discard them.
