### PR TITLE
Remove python2-only `__nonzero__` method from `cluster.py`

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1755,10 +1755,6 @@ class ClusterPipeline(RedisCluster):
         """ """
         return len(self.command_stack)
 
-    def __nonzero__(self):
-        "Pipeline instances should  always evaluate to True on Python 2.7"
-        return True
-
     def __bool__(self):
         "Pipeline instances should  always evaluate to True on Python 3+"
         return True


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

`__nonzero__` is not used in python3. And since currenct [`setup.py` specifies](https://github.com/redis/redis-py/blob/master/setup.py#L33) that `>= 3.7` is required, there's no need for this method.
