### PR TITLE
Document Redis(single_connection_client)

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -945,6 +945,12 @@ class Redis(AbstractRedis, RedisModuleCommands, CoreCommands, SentinelCommands):
         `retry_on_error` to a list of the error/s to retry on, then set
         `retry` to a valid `Retry` object.
         To retry on TimeoutError, `retry_on_timeout` can also be set to `True`.
+
+        Args:
+
+        single_connection_client:
+            if `True`, connection pool is not used. In that case `Redis`
+            instance use is not thread safe.
         """
         if not connection_pool:
             if charset is not None:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?
   WON'T DO: too insignificant.


### Description of change

I spent a significant portion of time debugging concurrency issues not knowing that `Redis` is not thread safe with `single_connection_client=True`.
Found this comment on GitHub issues: https://github.com/redis/redis-py/issues/1426#issuecomment-740298873
Hopefully will save the trouble for others :)
