### PR TITLE
Do not implicitly default to localhost when using from_url

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1219,6 +1219,9 @@ def parse_url(url):
         if url.scheme == "rediss":
             kwargs["connection_class"] = SSLConnection
 
+    if url.scheme != "unix" and "host" not in kwargs:
+        raise ValueError("Redis URL must specify an explicit hostname")
+
     return kwargs
 
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -308,7 +308,7 @@ class TestConnectionPoolURLParsing:
             assert expected is to_bool(value)
 
     def test_client_name_in_querystring(self):
-        pool = redis.ConnectionPool.from_url("redis://location?client_name=test-client")
+        pool = redis.ConnectionPool.from_url("redis://host/loc?client_name=test-client")
         assert pool.connection_kwargs["client_name"] == "test-client"
 
     def test_invalid_extra_typed_querystring_options(self):
@@ -330,6 +330,11 @@ class TestConnectionPoolURLParsing:
         r = redis.Redis.from_url("redis://myhost")
         assert r.connection_pool.connection_class == redis.Connection
         assert r.connection_pool.connection_kwargs == {"host": "myhost"}
+
+    def test_missing_hostname_raises_error(self):
+        with pytest.raises(ValueError) as cm:
+            redis.ConnectionPool.from_url("redis://")
+        assert str(cm.value) == "Redis URL must specify an explicit hostname"
 
     def test_invalid_scheme_raises_error(self):
         with pytest.raises(ValueError) as cm:
@@ -448,19 +453,19 @@ class TestSSLConnectionURLParsing:
             def get_connection(self, *args, **kwargs):
                 return self.make_connection()
 
-        pool = DummyConnectionPool.from_url("rediss://?ssl_cert_reqs=none")
+        pool = DummyConnectionPool.from_url("rediss://host/?ssl_cert_reqs=none")
         assert pool.get_connection("_").cert_reqs == ssl.CERT_NONE
 
-        pool = DummyConnectionPool.from_url("rediss://?ssl_cert_reqs=optional")
+        pool = DummyConnectionPool.from_url("rediss://host/?ssl_cert_reqs=optional")
         assert pool.get_connection("_").cert_reqs == ssl.CERT_OPTIONAL
 
-        pool = DummyConnectionPool.from_url("rediss://?ssl_cert_reqs=required")
+        pool = DummyConnectionPool.from_url("rediss://host/?ssl_cert_reqs=required")
         assert pool.get_connection("_").cert_reqs == ssl.CERT_REQUIRED
 
-        pool = DummyConnectionPool.from_url("rediss://?ssl_check_hostname=False")
+        pool = DummyConnectionPool.from_url("rediss://host/?ssl_check_hostname=False")
         assert pool.get_connection("_").check_hostname is False
 
-        pool = DummyConnectionPool.from_url("rediss://?ssl_check_hostname=True")
+        pool = DummyConnectionPool.from_url("rediss://host/?ssl_check_hostname=True")
         assert pool.get_connection("_").check_hostname is True
 
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Do not implicitly default to `localhost` when using from_url. 

This avoids much confusion when `from_url` is passed a url without an explicit hostname because of some error in the passed url. Passed urls could be incorrect for any number of reasons, e.g. when they are incorrectly constructed using environment variables in some CI/CD process. Whatever the reason, simply trying to connect to localhost (and getting a connection error, or worse: no error at all) will not be helpful in finding the root cause of the problem.

A counterpoint to this PR could be: strictly speaking urls without explicit hosts are valid, and a case could be made that relying on that behavior is perfectly valid.
