### PR TITLE
Add `nowait` flag to `asyncio.Connection.disconnect()`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * add `nowait` flag to `asyncio.Connection.disconnect()`
     * Update README.md links
     * Fix timezone handling for datetime to unixtime conversions
     * Fix start_id type for XAUTOCLAIM

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -847,7 +847,7 @@ class Connection:
                     if os.getpid() == self.pid:
                         self._writer.close()  # type: ignore[union-attr]
                         # wait for close to finish, except when handling errors and
-                        # forcecully disconnecting.
+                        # forcefully disconnecting.
                         if not nowait:
                             await self._writer.wait_closed()  # type: ignore[union-attr]
                 except OSError:

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -836,7 +836,7 @@ class Connection:
             if str_if_bytes(await self.read_response()) != "OK":
                 raise ConnectionError("Invalid Database")
 
-    async def disconnect(self) -> None:
+    async def disconnect(self, nowait: bool = False) -> None:
         """Disconnects from the Redis server"""
         try:
             async with async_timeout.timeout(self.socket_connect_timeout):
@@ -846,8 +846,9 @@ class Connection:
                 try:
                     if os.getpid() == self.pid:
                         self._writer.close()  # type: ignore[union-attr]
-                        # py3.6 doesn't have this method
-                        if hasattr(self._writer, "wait_closed"):
+                        # wait for close to finish, except when handling errors and
+                        # forcecully disconnecting.
+                        if not nowait:
                             await self._writer.wait_closed()  # type: ignore[union-attr]
                 except OSError:
                     pass
@@ -902,10 +903,10 @@ class Connection:
                 self._writer.writelines(command)
                 await self._writer.drain()
         except asyncio.TimeoutError:
-            await self.disconnect()
+            await self.disconnect(nowait=True)
             raise TimeoutError("Timeout writing to socket") from None
         except OSError as e:
-            await self.disconnect()
+            await self.disconnect(nowait=True)
             if len(e.args) == 1:
                 err_no, errmsg = "UNKNOWN", e.args[0]
             else:
@@ -915,7 +916,7 @@ class Connection:
                 f"Error {err_no} while writing to socket. {errmsg}."
             ) from e
         except Exception:
-            await self.disconnect()
+            await self.disconnect(nowait=True)
             raise
 
     async def send_command(self, *args: Any, **kwargs: Any) -> None:
@@ -931,7 +932,7 @@ class Connection:
         try:
             return await self._parser.can_read(timeout)
         except OSError as e:
-            await self.disconnect()
+            await self.disconnect(nowait=True)
             raise ConnectionError(
                 f"Error while reading from {self.host}:{self.port}: {e.args}"
             )
@@ -949,15 +950,15 @@ class Connection:
                     disable_decoding=disable_decoding
                 )
         except asyncio.TimeoutError:
-            await self.disconnect()
+            await self.disconnect(nowait=True)
             raise TimeoutError(f"Timeout reading from {self.host}:{self.port}")
         except OSError as e:
-            await self.disconnect()
+            await self.disconnect(nowait=True)
             raise ConnectionError(
                 f"Error while reading from {self.host}:{self.port} : {e.args}"
             )
         except Exception:
-            await self.disconnect()
+            await self.disconnect(nowait=True)
             raise
 
         if self.health_check_interval:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

When the `asyncio.Connection` object encounters an exception, it often performs a `self.disconnect()`.  This change
adds a `nowait` flag to this method, so that in the error case, `disconnect()` does not attempt to await a `wait_closed()` on the output stream.  Awaiting a buffer method at this point can cause other errors to occur.
Notably an `asyncio.CancelledError` could happen, in case the entire operation is enclosed in a `async_timeout.timeout()` context manager.

At any rate, if the connection is in an error state, there is no need to wait for the write buffer flush.

This PR is separate from a related pr, #2104, both about making exception handling and cancelling (via Timeout) possible.


