### PR TITLE
Dev/no can read

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -756,19 +756,21 @@ class PubSub:
 
         await self.check_health()
 
-        async def try_read():
-            if not conn.is_connected:
-                await conn.connect()
-            if not block:
+        if not conn.is_connected:
+            await conn.connect()
+
+        if not block:
+
+            async def read_with_timeout():
                 try:
                     async with async_timeout.timeout(timeout):
                         return await conn.read_response()
                 except asyncio.TimeoutError:
                     return None
-            else:
-                return await conn.read_response()
 
-        response = await self._execute(conn, try_read)
+            response = await self._execute(conn, read_with_timeout)
+        else:
+            response = await self._execute(conn, conn.read_response)
 
         if conn.health_check_interval and response == self.health_check_response:
             # ignore the health check message as user might not expect it

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -942,6 +942,10 @@ class Connection:
             raise ConnectionError(
                 f"Error while reading from {self.host}:{self.port} : {e.args}"
             )
+        except asyncio.CancelledError:
+            # need this check for 3.7, where CancelledError
+            # is subclass of Exception, not BaseException
+            raise
         except Exception:
             await self.disconnect(nowait=True)
             raise

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -433,7 +433,7 @@ class TestRedisClusterObj:
                     Connection,
                     send_packed_command=mock.DEFAULT,
                     connect=mock.DEFAULT,
-                    can_read=mock.DEFAULT,
+                    can_read_destructive=mock.DEFAULT,
                 ) as mocks:
                     # simulate 7006 as a failed node
                     def execute_command_mock(self, *args, **options):
@@ -473,7 +473,7 @@ class TestRedisClusterObj:
                     execute_command.successful_calls = 0
                     execute_command.failed_calls = 0
                     initialize.side_effect = initialize_mock
-                    mocks["can_read"].return_value = False
+                    mocks["can_read_destructive"].return_value = False
                     mocks["send_packed_command"].return_value = "MOCK_OK"
                     mocks["connect"].return_value = None
                     with mock.patch.object(
@@ -514,7 +514,7 @@ class TestRedisClusterObj:
             send_command=mock.DEFAULT,
             read_response=mock.DEFAULT,
             _connect=mock.DEFAULT,
-            can_read=mock.DEFAULT,
+            can_read_destructive=mock.DEFAULT,
             on_connect=mock.DEFAULT,
         ) as mocks:
             with mock.patch.object(
@@ -546,7 +546,7 @@ class TestRedisClusterObj:
                 mocks["send_command"].return_value = True
                 mocks["read_response"].return_value = "OK"
                 mocks["_connect"].return_value = True
-                mocks["can_read"].return_value = False
+                mocks["can_read_destructive"].return_value = False
                 mocks["on_connect"].return_value = True
 
                 # Create a cluster with reading from replications

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -103,7 +103,7 @@ class DummyConnection(Connection):
     async def disconnect(self):
         pass
 
-    async def can_read(self, timeout: float = 0):
+    async def can_read_destructive(self, timeout: float = 0):
         return False
 
 

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -847,7 +847,7 @@ class TestPubSubAutoReconnect:
                     self.state = 1
                     with mock.patch.object(self.pubsub.connection, "_parser") as m:
                         m.read_response.side_effect = socket.error
-                        m.can_read.side_effect = socket.error
+                        m.can_read_destructive.side_effect = socket.error
                         # wait until task noticies the disconnect until we
                         # undo the patch
                         await self.cond.wait_for(lambda: self.state >= 2)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

The `asyncio.Connection.can_read()` API is unnecessary in async-io, since polling a connection is best done with timeout.
Keeping this api adds complexity in the lower layers of the asyncio.Connection since it requires reading data and then "unreading" them for subsequent `read` operations.

Further, this code is almost exclusively used by assertion macros, to make sure that there is no data present on a  connection pulled from a connection pool.  For this use case, it is fine that the read data is discarded.

The only remaining use case was in the `PubSub` implementation, but that can be done differently.

Renaming the method to `can_read_destructive()` and simplifying it, getting rid of the "keep any read data for next read" logic, paves the way for further simplifications of the asyncio connection code, and other pull requests in the same ares (getting rid of locking, buffering, simplifying timeouts, etc)

The PR contains elements from Pull Requests #2356 and #2104 as necessary for it to work properly