### PR TITLE
Fixing async test for module list

### DIFF
--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -2986,7 +2986,8 @@ class TestRedisCommands:
     @pytest.mark.onlynoncluster
     async def test_module_list(self, r: redis.Redis):
         assert isinstance(await r.module_list(), list)
-        assert not await r.module_list()
+        for x in await r.module_list():
+            assert isinstance(x, dict)
 
 
 @pytest.mark.onlynoncluster


### PR DESCRIPTION
Ensuring the async test for module list behaves like the sync tests. This means that if the command is run against a redis-stack, or a redis instance, we now can assert that outputs are proper.