### PR TITLE
Failover handling improvements for RedisCluster and Async RedisCluster

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@
     * ClusterPipeline Doesn't Handle ConnectionError for Dead Hosts (#2225)
     * Remove compatibility code for old versions of Hiredis, drop Packaging dependency
     * The `deprecated` library is no longer a dependency
+    * Failover handling improvements for RedisCluster and Async RedisCluster (#2377)
+    * Fixed "cannot pickle '_thread.lock' object" bug (#2354, #2297)
 
 * 4.1.3 (Feb 8, 2022)
     * Fix flushdb and flushall (#1926)

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-from redis.backoff import get_default_backoff
+from redis.backoff import default_backoff
 from redis.client import Redis, StrictRedis
 from redis.cluster import RedisCluster
 from redis.connection import (
@@ -65,7 +65,7 @@ __all__ = [
     "ConnectionPool",
     "DataError",
     "from_url",
-    "get_default_backoff",
+    "default_backoff",
     "InvalidResponse",
     "PubSubError",
     "ReadOnlyError",

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -1,5 +1,6 @@
 import sys
 
+from redis.backoff import get_default_backoff
 from redis.client import Redis, StrictRedis
 from redis.cluster import RedisCluster
 from redis.connection import (
@@ -64,6 +65,7 @@ __all__ = [
     "ConnectionPool",
     "DataError",
     "from_url",
+    "get_default_backoff",
     "InvalidResponse",
     "PubSubError",
     "ReadOnlyError",

--- a/redis/asyncio/__init__.py
+++ b/redis/asyncio/__init__.py
@@ -15,6 +15,7 @@ from redis.asyncio.sentinel import (
     SentinelManagedSSLConnection,
 )
 from redis.asyncio.utils import from_url
+from redis.backoff import get_default_backoff
 from redis.exceptions import (
     AuthenticationError,
     AuthenticationWrongNumberOfArgsError,
@@ -43,6 +44,7 @@ __all__ = [
     "ConnectionPool",
     "DataError",
     "from_url",
+    "get_default_backoff",
     "InvalidResponse",
     "PubSubError",
     "ReadOnlyError",

--- a/redis/asyncio/__init__.py
+++ b/redis/asyncio/__init__.py
@@ -15,7 +15,7 @@ from redis.asyncio.sentinel import (
     SentinelManagedSSLConnection,
 )
 from redis.asyncio.utils import from_url
-from redis.backoff import get_default_backoff
+from redis.backoff import default_backoff
 from redis.exceptions import (
     AuthenticationError,
     AuthenticationWrongNumberOfArgsError,
@@ -44,7 +44,7 @@ __all__ = [
     "ConnectionPool",
     "DataError",
     "from_url",
-    "get_default_backoff",
+    "default_backoff",
     "InvalidResponse",
     "PubSubError",
     "ReadOnlyError",

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -273,6 +273,12 @@ class Redis(
         """Get the connection's key-word arguments"""
         return self.connection_pool.connection_kwargs
 
+    def get_retry(self) -> Optional["Retry"]:
+        return self.get_connection_kwargs().get("retry")
+
+    def set_retry(self, retry: "Retry") -> None:
+        self.get_connection_kwargs().update({"retry": retry})
+
     def load_external_module(self, funcname, func):
         """
         This function can be used to add externally defined redis modules,

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -278,6 +278,7 @@ class Redis(
 
     def set_retry(self, retry: "Retry") -> None:
         self.get_connection_kwargs().update({"retry": retry})
+        self.connection_pool.set_retry(retry)
 
     def load_external_module(self, funcname, func):
         """

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -110,10 +110,10 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
     :param startup_nodes:
         | :class:`~.ClusterNode` to used as a startup node
     :param require_full_coverage:
-        | When set to ``False``: the client will not require a full coverage of the
-          slots. However, if not all slots are covered, and at least one node has
-          ``cluster-require-full-coverage`` set to ``yes``, the server will throw a
-          :class:`~.ClusterDownError` for some key-based commands.
+        | When set to ``False``: the client will not require a full coverage of
+          the slots. However, if not all slots are covered, and at least one node
+          has ``cluster-require-full-coverage`` set to ``yes``, the server will throw
+          a :class:`~.ClusterDownError` for some key-based commands.
         | When set to ``True``: all slots must be covered to construct the cluster
           client. If not all slots are covered, :class:`~.RedisClusterException` will be
           thrown.

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -707,7 +707,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
                 return await target_node.execute_command(*args, **kwargs)
             except (BusyLoadingError, MaxConnectionsError):
                 raise
-            except (ConnectionError, TimeoutError) as e:
+            except (ConnectionError, TimeoutError):
                 # Connection retries are being handled in the node's
                 # Retry object.
                 # Remove the failed node from the startup nodes before we try
@@ -1163,8 +1163,8 @@ class NodesManager:
 
         if not startup_nodes_reachable:
             raise RedisClusterException(
-                f"Redis Cluster cannot be connected. Please provide at least "
-                f"one reachable node"
+                "Redis Cluster cannot be connected. Please provide at least "
+                "one reachable node"
             ) from exception
 
         # Check if the slots are not fully covered

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -238,7 +238,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         socket_keepalive_options: Optional[Mapping[int, Union[int, bytes]]] = None,
         socket_timeout: Optional[float] = None,
         retry: Optional["Retry"] = None,
-        retry_on_error: Optional[list[Exception]] = None,
+        retry_on_error: Optional[List[Exception]] = None,
         # SSL related kwargs
         ssl: bool = False,
         ssl_ca_certs: Optional[str] = None,
@@ -1163,8 +1163,8 @@ class NodesManager:
 
         if not startup_nodes_reachable:
             raise RedisClusterException(
-                "Redis Cluster cannot be connected. Please provide at least "
-                "one reachable node"
+                f"Redis Cluster cannot be connected. Please provide at least "
+                f"one reachable node: {str(exception)}"
             ) from exception
 
         # Check if the slots are not fully covered

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -217,7 +217,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         startup_nodes: Optional[List["ClusterNode"]] = None,
         require_full_coverage: bool = True,
         read_from_replicas: bool = False,
-        reinitialize_steps: int = 10,
+        reinitialize_steps: int = 5,
         cluster_error_retry_attempts: int = 3,
         connection_error_retry_attempts: int = 3,
         max_connections: int = 2**31,

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -207,6 +207,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         "reinitialize_steps",
         "response_callbacks",
         "result_callbacks",
+        "retry",
     )
 
     def __init__(
@@ -337,6 +338,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         self.read_from_replicas = read_from_replicas
         self.reinitialize_steps = reinitialize_steps
         self.cluster_error_retry_attempts = cluster_error_retry_attempts
+        self.connection_error_retry_attempts = connection_error_retry_attempts
         self.retry = retry
         self.reinitialize_counter = 0
         self.commands_parser = CommandsParser()

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -495,6 +495,14 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         """Get the kwargs passed to :class:`~redis.asyncio.connection.Connection`."""
         return self.connection_kwargs
 
+    def get_retry(self) -> Optional["Retry"]:
+        return self.retry
+
+    def set_retry(self, retry: "Retry") -> None:
+        self.retry = retry
+        for node in self.get_nodes():
+            node.connection_kwargs.update({"retry": retry})
+
     def set_response_callback(self, command: str, callback: ResponseCallbackT) -> None:
         """Set a custom response callback."""
         self.response_callbacks[command] = callback

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -207,7 +207,6 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         "reinitialize_steps",
         "response_callbacks",
         "result_callbacks",
-        "retry",
     )
 
     def __init__(
@@ -504,6 +503,8 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         self.retry = retry
         for node in self.get_nodes():
             node.connection_kwargs.update({"retry": retry})
+            for conn in node._connections:
+                conn.retry = retry
 
     def set_response_callback(self, command: str, callback: ResponseCallbackT) -> None:
         """Set a custom response callback."""

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -306,12 +306,13 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             # Call our on_connect function to configure READONLY mode
             kwargs["redis_connect_func"] = self.on_connect
 
+        self.retry = retry
         if retry or retry_on_error or connection_error_retry_attempts > 0:
             # Set a retry object for all cluster nodes
             self.retry = retry or Retry(
                 default_backoff(), connection_error_retry_attempts
             )
-            if retry_on_error is None:
+            if not retry_on_error:
                 # Default errors for retrying
                 retry_on_error = [ConnectionError, TimeoutError]
             self.retry.update_supported_errors(retry_on_error)
@@ -338,7 +339,6 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         self.reinitialize_steps = reinitialize_steps
         self.cluster_error_retry_attempts = cluster_error_retry_attempts
         self.connection_error_retry_attempts = connection_error_retry_attempts
-        self.retry = retry
         self.reinitialize_counter = 0
         self.commands_parser = CommandsParser()
         self.node_flags = self.__class__.NODE_FLAGS.copy()

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -486,7 +486,7 @@ class Connection:
             retry_on_error.append(socket.timeout)
             retry_on_error.append(asyncio.TimeoutError)
         self.retry_on_error = retry_on_error
-        if retry_on_error:
+        if retry or retry_on_error:
             if not retry:
                 self.retry = Retry(NoBackoff(), 1)
             else:

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1426,6 +1426,12 @@ class ConnectionPool:
             if exc:
                 raise exc
 
+    def set_retry(self, retry: "Retry") -> None:
+        for conn in self._available_connections:
+            conn.retry = retry
+        for conn in self._in_use_connections:
+            conn.retry = retry
+
 
 class BlockingConnectionPool(ConnectionPool):
     """

--- a/redis/backoff.py
+++ b/redis/backoff.py
@@ -1,6 +1,9 @@
 import random
 from abc import ABC, abstractmethod
 
+DEFAULT_CAP = 0.512
+DEFAULT_BASE = 0.008
+
 
 class AbstractBackoff(ABC):
     """Backoff interface"""
@@ -40,7 +43,7 @@ class NoBackoff(ConstantBackoff):
 class ExponentialBackoff(AbstractBackoff):
     """Exponential backoff upon failure"""
 
-    def __init__(self, cap, base):
+    def __init__(self, cap=DEFAULT_CAP, base=DEFAULT_BASE):
         """
         `cap`: maximum backoff time in seconds
         `base`: base backoff time in seconds
@@ -55,7 +58,7 @@ class ExponentialBackoff(AbstractBackoff):
 class FullJitterBackoff(AbstractBackoff):
     """Full jitter backoff upon failure"""
 
-    def __init__(self, cap, base):
+    def __init__(self, cap=DEFAULT_CAP, base=DEFAULT_BASE):
         """
         `cap`: maximum backoff time in seconds
         `base`: base backoff time in seconds
@@ -70,7 +73,7 @@ class FullJitterBackoff(AbstractBackoff):
 class EqualJitterBackoff(AbstractBackoff):
     """Equal jitter backoff upon failure"""
 
-    def __init__(self, cap, base):
+    def __init__(self, cap=DEFAULT_CAP, base=DEFAULT_BASE):
         """
         `cap`: maximum backoff time in seconds
         `base`: base backoff time in seconds
@@ -86,7 +89,7 @@ class EqualJitterBackoff(AbstractBackoff):
 class DecorrelatedJitterBackoff(AbstractBackoff):
     """Decorrelated jitter backoff upon failure"""
 
-    def __init__(self, cap, base):
+    def __init__(self, cap=DEFAULT_CAP, base=DEFAULT_BASE):
         """
         `cap`: maximum backoff time in seconds
         `base`: base backoff time in seconds
@@ -103,3 +106,7 @@ class DecorrelatedJitterBackoff(AbstractBackoff):
         temp = random.uniform(self._base, max_backoff)
         self._previous_backoff = min(self._cap, temp)
         return self._previous_backoff
+
+
+def get_default_backoff():
+    return EqualJitterBackoff()

--- a/redis/backoff.py
+++ b/redis/backoff.py
@@ -1,7 +1,9 @@
 import random
 from abc import ABC, abstractmethod
 
+# Maximum backoff between each retry in seconds
 DEFAULT_CAP = 0.512
+# Minimum backoff between each retry in seconds
 DEFAULT_BASE = 0.008
 
 
@@ -108,5 +110,5 @@ class DecorrelatedJitterBackoff(AbstractBackoff):
         return self._previous_backoff
 
 
-def get_default_backoff():
+def default_backoff():
     return EqualJitterBackoff()

--- a/redis/client.py
+++ b/redis/client.py
@@ -25,6 +25,7 @@ from redis.exceptions import (
     WatchError,
 )
 from redis.lock import Lock
+from redis.retry import Retry
 from redis.utils import safe_str, str_if_bytes
 
 SYM_EMPTY = b""

--- a/redis/client.py
+++ b/redis/client.py
@@ -1050,6 +1050,7 @@ class Redis(AbstractRedis, RedisModuleCommands, CoreCommands, SentinelCommands):
 
     def set_retry(self, retry: "Retry") -> None:
         self.get_connection_kwargs().update({"retry": retry})
+        self.connection_pool.set_retry(retry)
 
     def set_response_callback(self, command, callback):
         """Set a custom Response Callback"""

--- a/redis/client.py
+++ b/redis/client.py
@@ -5,6 +5,7 @@ import threading
 import time
 import warnings
 from itertools import chain
+from typing import Optional
 
 from redis.commands import (
     CoreCommands,
@@ -1042,6 +1043,12 @@ class Redis(AbstractRedis, RedisModuleCommands, CoreCommands, SentinelCommands):
     def get_connection_kwargs(self):
         """Get the connection's key-word arguments"""
         return self.connection_pool.connection_kwargs
+
+    def get_retry(self) -> Optional["Retry"]:
+        return self.get_connection_kwargs().get("retry")
+
+    def set_retry(self, retry: "Retry") -> None:
+        self.get_connection_kwargs().update({"retry": retry})
 
     def set_response_callback(self, command, callback):
         """Set a custom Response Callback"""

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1,4 +1,3 @@
-import copy
 import random
 import socket
 import sys
@@ -474,8 +473,9 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
              If you use dynamic DNS endpoints for startup nodes but CLUSTER SLOTS lists
              specific IP addresses, it is best to set it to false.
         :param cluster_error_retry_attempts:
-             Number of times to retry before raising an error when :class:`~.TimeoutError`
-             or :class:`~.ConnectionError` or :class:`~.ClusterDownError` are encountered
+             Number of times to retry before raising an error when
+             :class:`~.TimeoutError` or :class:`~.ConnectionError` or
+             :class:`~.ClusterDownError` are encountered
         :param connection_error_retry_attempts:
             Number of times to retry before reinitializing when :class:`~.TimeoutError`
             or :class:`~.ConnectionError` are encountered.
@@ -1510,8 +1510,8 @@ class NodesManager:
 
         if not startup_nodes_reachable:
             raise RedisClusterException(
-                f"Redis Cluster cannot be connected. Please provide at least "
-                f"one reachable node"
+                "Redis Cluster cannot be connected. Please provide at least "
+                "one reachable node"
             ) from exception
 
         # Create Redis connections to all nodes

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -687,6 +687,14 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         self.nodes_manager.default_node = node
         return True
 
+    def get_retry(self) -> Optional["Retry"]:
+        return self.retry
+
+    def set_retry(self, retry: "Retry") -> None:
+        self.retry = retry
+        for node in self.get_nodes():
+            node.redis_connection.set_retry(retry)
+
     def monitor(self, target_node=None):
         """
         Returns a Monitor object for the specified target node.

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -432,7 +432,7 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         cluster_error_retry_attempts: int = 3,
         retry: Optional["Retry"] = None,
         require_full_coverage: bool = False,
-        reinitialize_steps: int = 10,
+        reinitialize_steps: int = 5,
         read_from_replicas: bool = False,
         dynamic_startup_nodes: bool = True,
         url: Optional[str] = None,
@@ -1698,7 +1698,7 @@ class ClusterPipeline(RedisCluster):
         startup_nodes: Optional[List["ClusterNode"]] = None,
         read_from_replicas: bool = False,
         cluster_error_retry_attempts: int = 3,
-        reinitialize_steps: int = 10,
+        reinitialize_steps: int = 5,
         lock=None,
         **kwargs,
     ):

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -4,7 +4,7 @@ import sys
 import threading
 import time
 from collections import OrderedDict
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from redis.backoff import get_default_backoff
 from redis.client import CaseInsensitiveDict, PubSub, Redis, parse_scan
@@ -428,11 +428,11 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         self,
         host: Optional[str] = None,
         port: int = 6379,
-        startup_nodes: Optional[list["ClusterNode"]] = None,
+        startup_nodes: Optional[List["ClusterNode"]] = None,
         cluster_error_retry_attempts: int = 3,
         connection_error_retry_attempts: int = 3,
         retry: Optional["Retry"] = None,
-        retry_on_error: Optional[list[Exception]] = None,
+        retry_on_error: Optional[List[Exception]] = None,
         require_full_coverage: bool = False,
         reinitialize_steps: int = 10,
         read_from_replicas: bool = False,
@@ -1510,8 +1510,8 @@ class NodesManager:
 
         if not startup_nodes_reachable:
             raise RedisClusterException(
-                "Redis Cluster cannot be connected. Please provide at least "
-                "one reachable node"
+                f"Redis Cluster cannot be connected. Please provide at least "
+                f"one reachable node: {str(exception)}"
             ) from exception
 
         # Create Redis connections to all nodes
@@ -1697,9 +1697,9 @@ class ClusterPipeline(RedisCluster):
         self,
         nodes_manager: "NodesManager",
         commands_parser: "CommandsParser",
-        result_callbacks: Optional[dict[str, Callable]] = None,
-        cluster_response_callbacks: Optional[dict[str, Callable]] = None,
-        startup_nodes: Optional[list["ClusterNode"]] = None,
+        result_callbacks: Optional[Dict[str, Callable]] = None,
+        cluster_response_callbacks: Optional[Dict[str, Callable]] = None,
+        startup_nodes: Optional[List["ClusterNode"]] = None,
         read_from_replicas: bool = False,
         cluster_error_retry_attempts: int = 3,
         reinitialize_steps: int = 10,

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -6,7 +6,7 @@ import time
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from redis.backoff import default_backoff, NoBackoff
+from redis.backoff import default_backoff
 from redis.client import CaseInsensitiveDict, PubSub, Redis, parse_scan
 from redis.commands import READ_COMMANDS, CommandsParser, RedisClusterCommands
 from redis.connection import ConnectionPool, DefaultParser, Encoder, parse_url

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -5,8 +5,9 @@ import sys
 import threading
 import time
 from collections import OrderedDict
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
+from redis.backoff import get_default_backoff
 from redis.client import CaseInsensitiveDict, PubSub, Redis, parse_scan
 from redis.commands import READ_COMMANDS, CommandsParser, RedisClusterCommands
 from redis.connection import ConnectionPool, DefaultParser, Encoder, parse_url
@@ -29,6 +30,7 @@ from redis.exceptions import (
     TryAgainError,
 )
 from redis.lock import Lock
+from redis.retry import Retry
 from redis.utils import (
     dict_merge,
     list_keys_to_dict,
@@ -425,27 +427,30 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
 
     def __init__(
         self,
-        host=None,
-        port=6379,
-        startup_nodes=None,
-        cluster_error_retry_attempts=3,
-        require_full_coverage=False,
-        reinitialize_steps=10,
-        read_from_replicas=False,
-        dynamic_startup_nodes=True,
-        url=None,
+        host: Optional[str] = None,
+        port: int = 6379,
+        startup_nodes: Optional[list["ClusterNode"]] = None,
+        cluster_error_retry_attempts: int = 3,
+        connection_error_retry_attempts: int = 3,
+        retry: Optional["Retry"] = None,
+        retry_on_error: Optional[list[Exception]] = None,
+        require_full_coverage: bool = False,
+        reinitialize_steps: int = 10,
+        read_from_replicas: bool = False,
+        dynamic_startup_nodes: bool = True,
+        url: Optional[str] = None,
         **kwargs,
     ):
         """
          Initialize a new RedisCluster client.
 
-         :startup_nodes: 'list[ClusterNode]'
+         :param startup_nodes:
              List of nodes from which initial bootstrapping can be done
-         :host: 'str'
+         :param host:
              Can be used to point to a startup node
-         :port: 'int'
+         :param port:
              Can be used to point to a startup node
-         :require_full_coverage: 'bool'
+         :param require_full_coverage:
             When set to False (default value): the client will not require a
             full coverage of the slots. However, if not all slots are covered,
             and at least one node has 'cluster-require-full-coverage' set to
@@ -455,12 +460,12 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
             When set to True: all slots must be covered to construct the
             cluster client. If not all slots are covered, RedisClusterException
             will be thrown.
-        :read_from_replicas: 'bool'
+        :param read_from_replicas:
              Enable read from replicas in READONLY mode. You can read possibly
              stale data.
              When set to true, read commands will be assigned between the
              primary and its replications in a Round-Robin manner.
-         :dynamic_startup_nodes: 'bool'
+         :param dynamic_startup_nodes:
              Set the RedisCluster's startup nodes to all of the discovered nodes.
              If true (default value), the cluster's discovered nodes will be used to
              determine the cluster nodes-slots mapping in the next topology refresh.
@@ -468,9 +473,15 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
              listed in the CLUSTER SLOTS output.
              If you use dynamic DNS endpoints for startup nodes but CLUSTER SLOTS lists
              specific IP addresses, it is best to set it to false.
-        :cluster_error_retry_attempts: 'int'
-             Retry command execution attempts when encountering ClusterDownError
-             or ConnectionError
+        :param cluster_error_retry_attempts:
+             Number of times to retry before raising an error when :class:`~.TimeoutError`
+             or :class:`~.ConnectionError` or :class:`~.ClusterDownError` are encountered
+        :param connection_error_retry_attempts:
+            Number of times to retry before reinitializing when :class:`~.TimeoutError`
+            or :class:`~.ConnectionError` are encountered.
+            The default backoff strategy will be set if Retry object is not passed (see
+            get_default_backoff in backoff.py). To change it, pass a custom Retry object
+            using the "retry" keyword.
         :reinitialize_steps: 'int'
             Specifies the number of MOVED errors that need to occur before
             reinitializing the whole cluster topology. If a MOVED error occurs
@@ -539,6 +550,17 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         self.user_on_connect_func = kwargs.pop("redis_connect_func", None)
         kwargs.update({"redis_connect_func": self.on_connect})
         kwargs = cleanup_kwargs(**kwargs)
+
+        if retry or retry_on_error or connection_error_retry_attempts > 0:
+            # Set a retry object for all cluster nodes
+            self.retry = retry or Retry(
+                get_default_backoff(), connection_error_retry_attempts
+            )
+            if retry_on_error is None:
+                # Default errors for retrying
+                retry_on_error = [ConnectionError, TimeoutError]
+            self.retry.update_supported_errors(retry_on_error)
+            kwargs.update({"retry": self.retry})
 
         self.encoder = Encoder(
             kwargs.get("encoding", "utf-8"),
@@ -985,12 +1007,11 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         # nodes were passed to this function, we cannot retry the command
         # execution since the nodes may not be valid anymore after the tables
         # were reinitialized. So in case of passed target nodes,
-        # retry_attempts will be set to 1.
+        # retry_attempts will be set to 0.
         retry_attempts = (
-            1 if target_nodes_specified else self.cluster_error_retry_attempts
+            0 if target_nodes_specified else self.cluster_error_retry_attempts
         )
-        exception = None
-        for _ in range(0, retry_attempts):
+        while True:
             try:
                 res = {}
                 if not target_nodes_specified:
@@ -1007,17 +1028,14 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
                 # Return the processed result
                 return self._process_result(args[0], res, **kwargs)
             except Exception as e:
-                if type(e) in self.__class__.ERRORS_ALLOW_RETRY:
+                if retry_attempts > 0 and type(e) in self.__class__.ERRORS_ALLOW_RETRY:
                     # The nodes and slots cache were reinitialized.
                     # Try again with the new cluster setup.
-                    exception = e
+                    retry_attempts -= 1
+                    continue
                 else:
-                    # All other errors should be raised.
+                    # raise the exception
                     raise e
-
-        # If it fails the configured number of times then raise exception back
-        # to caller of this method
-        raise exception
 
     def _execute_command(self, target_node, *args, **kwargs):
         """
@@ -1030,7 +1048,6 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         asking = False
         moved = False
         ttl = int(self.RedisClusterRequestTTL)
-        connection_error_retry_counter = 0
 
         while ttl > 0:
             ttl -= 1
@@ -1063,25 +1080,21 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
             except AuthenticationError:
                 raise
             except (ConnectionError, TimeoutError) as e:
+                # Connection retries are being handled in the node's
+                # Retry object.
                 # ConnectionError can also be raised if we couldn't get a
                 # connection from the pool before timing out, so check that
                 # this is an actual connection before attempting to disconnect.
                 if connection is not None:
                     connection.disconnect()
-                connection_error_retry_counter += 1
 
-                # Give the node 0.25 seconds to get back up and retry again
-                # with same node and configuration. After 5 attempts then try
-                # to reinitialize the cluster and see if the nodes
-                # configuration has changed or not
-                if connection_error_retry_counter < 5:
-                    time.sleep(0.25)
-                else:
-                    # Hard force of reinitialize of the node/slots setup
-                    # and try again with the new setup
-                    target_node.redis_connection = None
-                    self.nodes_manager.initialize()
-                    raise e
+                # Remove the failed node from the startup nodes before we try
+                # to reinitialize the cluster
+                self.nodes_manager.startup_nodes.pop(target_node.name, None)
+                # Reset the cluster node's connection
+                target_node.redis_connection = None
+                self.nodes_manager.initialize()
+                raise e
             except MovedError as e:
                 # First, we will try to patch the slots/nodes cache with the
                 # redirected node output and try again. If MovedError exceeds
@@ -1405,17 +1418,15 @@ class NodesManager:
         startup_nodes_reachable = False
         fully_covered = False
         kwargs = self.connection_kwargs
+        exception = None
         for startup_node in self.startup_nodes.values():
             try:
                 if startup_node.redis_connection:
                     r = startup_node.redis_connection
                 else:
-                    # Create a new Redis connection and let Redis decode the
-                    # responses so we won't need to handle that
-                    copy_kwargs = copy.deepcopy(kwargs)
-                    copy_kwargs.update({"decode_responses": True, "encoding": "utf-8"})
+                    # Create a new Redis connection
                     r = self.create_redis_node(
-                        startup_node.host, startup_node.port, **copy_kwargs
+                        startup_node.host, startup_node.port, **kwargs
                     )
                     self.startup_nodes[startup_node.name].redis_connection = r
                 # Make sure cluster mode is enabled on this node
@@ -1425,25 +1436,11 @@ class NodesManager:
                     )
                 cluster_slots = str_if_bytes(r.execute_command("CLUSTER SLOTS"))
                 startup_nodes_reachable = True
-            except (ConnectionError, TimeoutError):
-                continue
-            except ResponseError as e:
-                # Isn't a cluster connection, so it won't parse these
-                # exceptions automatically
-                message = e.__str__()
-                if "CLUSTERDOWN" in message or "MASTERDOWN" in message:
-                    continue
-                else:
-                    raise RedisClusterException(
-                        'ERROR sending "cluster slots" command to redis '
-                        f"server: {startup_node}. error: {message}"
-                    )
             except Exception as e:
-                message = e.__str__()
-                raise RedisClusterException(
-                    'ERROR sending "cluster slots" command to redis '
-                    f"server {startup_node.name}. error: {message}"
-                )
+                # Try the next startup node.
+                # The exception is saved and raised only if we have no more nodes.
+                exception = e
+                continue
 
             # CLUSTER SLOTS command results in the following output:
             # [[slot_section[from_slot,to_slot,master,replica1,...,replicaN]]]
@@ -1513,9 +1510,9 @@ class NodesManager:
 
         if not startup_nodes_reachable:
             raise RedisClusterException(
-                "Redis Cluster cannot be connected. Please provide at least "
-                "one reachable node. "
-            )
+                f"Redis Cluster cannot be connected. Please provide at least "
+                f"one reachable node"
+            ) from exception
 
         # Create Redis connections to all nodes
         self.create_redis_connections(list(tmp_nodes_cache.values()))
@@ -1698,14 +1695,14 @@ class ClusterPipeline(RedisCluster):
 
     def __init__(
         self,
-        nodes_manager,
-        commands_parser,
-        result_callbacks=None,
-        cluster_response_callbacks=None,
-        startup_nodes=None,
-        read_from_replicas=False,
-        cluster_error_retry_attempts=5,
-        reinitialize_steps=10,
+        nodes_manager: "NodesManager",
+        commands_parser: "CommandsParser",
+        result_callbacks: Optional[dict[str, Callable]] = None,
+        cluster_response_callbacks: Optional[dict[str, Callable]] = None,
+        startup_nodes: Optional[list["ClusterNode"]] = None,
+        read_from_replicas: bool = False,
+        cluster_error_retry_attempts: int = 3,
+        reinitialize_steps: int = 10,
         lock=None,
         **kwargs,
     ):
@@ -1857,22 +1854,22 @@ class ClusterPipeline(RedisCluster):
         """
         if not stack:
             return []
-
-        for _ in range(0, self.cluster_error_retry_attempts):
+        retry_attempts = self.cluster_error_retry_attempts
+        while True:
             try:
                 return self._send_cluster_commands(
                     stack,
                     raise_on_error=raise_on_error,
                     allow_redirections=allow_redirections,
                 )
-            except ClusterDownError:
-                # Try again with the new cluster setup. All other errors
-                # should be raised.
-                pass
-
-        # If it fails the configured number of times then raise
-        # exception back to caller of this method
-        raise ClusterDownError("CLUSTERDOWN error. Unable to rebuild the cluster")
+            except (ClusterDownError, ConnectionError) as e:
+                if retry_attempts > 0:
+                    # Try again with the new cluster setup. All other errors
+                    # should be raised.
+                    retry_attempts -= 1
+                    pass
+                else:
+                    raise e
 
     def _send_cluster_commands(
         self, stack, raise_on_error=True, allow_redirections=True
@@ -1897,7 +1894,6 @@ class ClusterPipeline(RedisCluster):
         # we figure out the slot number that command maps to, then from
         # the slot determine the node.
         for c in attempt:
-            connection_error_retry_counter = 0
             while True:
                 # refer to our internal node -> slot table that
                 # tells us where a given command should route to.
@@ -1930,13 +1926,10 @@ class ClusterPipeline(RedisCluster):
                     try:
                         connection = get_connection(redis_node, c.args)
                     except ConnectionError:
-                        connection_error_retry_counter += 1
-                        if connection_error_retry_counter < 5:
-                            # reinitialize the node -> slot table
-                            self.nodes_manager.initialize()
-                            continue
-                        else:
-                            raise
+                        # Connection retries are being handled in the node's
+                        # Retry object. Reinitialize the node -> slot table.
+                        self.nodes_manager.initialize()
+                        raise
                     nodes[node_name] = NodeCommands(
                         redis_node.parse_response,
                         redis_node.connection_pool,

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -529,7 +529,7 @@ class Connection:
             # Add TimeoutError to the errors list to retry on
             retry_on_error.append(TimeoutError)
         self.retry_on_error = retry_on_error
-        if retry_on_error:
+        if retry or retry_on_error:
             if retry is None:
                 self.retry = Retry(NoBackoff(), 1)
             else:
@@ -1445,6 +1445,13 @@ class ConnectionPool:
 
             for connection in connections:
                 connection.disconnect()
+
+    def set_retry(self, retry: "Retry") -> None:
+        self.connection_kwargs.update({"retry": retry})
+        for conn in self._available_connections:
+            conn.retry = retry
+        for conn in self._in_use_connections:
+            conn.retry = retry
 
 
 class BlockingConnectionPool(ConnectionPool):

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -249,63 +249,70 @@ class TestRedisClusterObj:
                 ]
             )
 
-    async def test_cluster_get_set_retry_object(self, request):
+    async def test_cluster_set_get_retry_object(self, request: FixtureRequest):
         retry = Retry(NoBackoff(), 2)
         url = request.config.getoption("--redis-url")
-        r = await RedisCluster.from_url(url, retry=retry)
-        assert r.get_retry()._retries == retry._retries
-        assert isinstance(r.get_retry()._backoff, NoBackoff)
-        for node in r.get_nodes():
-            n_retry = node.connection_kwargs.get("retry")
-            assert n_retry is not None
-            assert n_retry._retries == retry._retries
-            assert isinstance(n_retry._backoff, NoBackoff)
-        # Change retry policy
-        new_retry = Retry(ExponentialBackoff(), 3)
-        r.set_retry(new_retry)
-        assert r.get_retry()._retries == new_retry._retries
-        assert isinstance(r.get_retry()._backoff, ExponentialBackoff)
-        for node in r.get_nodes():
-            n_retry = node.connection_kwargs.get("retry")
-            assert n_retry is not None
-            assert n_retry._retries == new_retry._retries
-            assert isinstance(n_retry._backoff, ExponentialBackoff)
+        async with RedisCluster.from_url(url, retry=retry) as r:
+            assert r.get_retry()._retries == retry._retries
+            assert isinstance(r.get_retry()._backoff, NoBackoff)
+            for node in r.get_nodes():
+                n_retry = node.connection_kwargs.get("retry")
+                assert n_retry is not None
+                assert n_retry._retries == retry._retries
+                assert isinstance(n_retry._backoff, NoBackoff)
+            # Change retry policy
+            new_retry = Retry(ExponentialBackoff(), 3)
+            r.set_retry(new_retry)
+            assert r.get_retry()._retries == new_retry._retries
+            assert isinstance(r.get_retry()._backoff, ExponentialBackoff)
+            for node in r.get_nodes():
+                n_retry = node.connection_kwargs.get("retry")
+                assert n_retry is not None
+                assert n_retry._retries == new_retry._retries
+                assert isinstance(n_retry._backoff, ExponentialBackoff)
 
-    async def test_cluster_retry_object(self, request) -> None:
+    async def test_cluster_retry_object(self, request: FixtureRequest) -> None:
         url = request.config.getoption("--redis-url")
-        rc_default = await RedisCluster.from_url(url)
-        # Test default retry
-        retry = rc_default.connection_kwargs.get("retry")
-        assert isinstance(retry, Retry)
-        assert retry._retries == 3
-        assert isinstance(retry._backoff, type(get_default_backoff()))
-        assert rc_default.get_node("127.0.0.1", 16379).connection_kwargs.get(
-            "retry"
-        ) == rc_default.get_node("127.0.0.1", 16380).connection_kwargs.get("retry")
+        async with RedisCluster.from_url(url) as rc_default:
+            # Test default retry
+            retry = rc_default.connection_kwargs.get("retry")
+            assert isinstance(retry, Retry)
+            assert retry._retries == 3
+            assert isinstance(retry._backoff, type(get_default_backoff()))
+            assert rc_default.get_node("127.0.0.1", 16379).connection_kwargs.get(
+                "retry"
+            ) == rc_default.get_node("127.0.0.1", 16380).connection_kwargs.get("retry")
 
-        # Test custom retry
         retry = Retry(ExponentialBackoff(10, 5), 5)
-        rc_custom_retry = await RedisCluster.from_url(url, retry=retry)
-        assert (
-            rc_custom_retry.get_node("127.0.0.1", 16379).connection_kwargs.get("retry")
-            == retry
-        )
+        async with RedisCluster.from_url(url, retry=retry) as rc_custom_retry:
+            # Test custom retry
+            assert (
+                rc_custom_retry.get_node("127.0.0.1", 16379).connection_kwargs.get(
+                    "retry"
+                )
+                == retry
+            )
 
-        # Test no connection retries
-        rc_no_retries = await RedisCluster.from_url(
+        async with RedisCluster.from_url(
             url, connection_error_retry_attempts=0
-        )
-        assert (
-            rc_no_retries.get_node("127.0.0.1", 16379).connection_kwargs.get("retry")
-            is None
-        )
-        rc_no_retries = await RedisCluster.from_url(url, retry=Retry(NoBackoff(), 0))
-        assert (
-            rc_no_retries.get_node("127.0.0.1", 16379)
-            .connection_kwargs.get("retry")
-            ._retries
-            == 0
-        )
+        ) as rc_no_retries:
+            # Test no connection retries
+            assert (
+                rc_no_retries.get_node("127.0.0.1", 16379).connection_kwargs.get(
+                    "retry"
+                )
+                is None
+            )
+
+        async with RedisCluster.from_url(
+            url, retry=Retry(NoBackoff(), 0)
+        ) as rc_no_retries:
+            assert (
+                rc_no_retries.get_node("127.0.0.1", 16379)
+                .connection_kwargs.get("retry")
+                ._retries
+                == 0
+            )
 
     async def test_empty_startup_nodes(self) -> None:
         """

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -14,7 +14,7 @@ from redis.asyncio.cluster import ClusterNode, NodesManager, RedisCluster
 from redis.asyncio.connection import Connection, SSLConnection
 from redis.asyncio.parser import CommandsParser
 from redis.asyncio.retry import Retry
-from redis.backoff import get_default_backoff, ExponentialBackoff, NoBackoff
+from redis.backoff import ExponentialBackoff, NoBackoff, get_default_backoff
 from redis.cluster import PIPELINE_BLOCKED_COMMANDS, PRIMARY, REPLICA, get_node_name
 from redis.crc import REDIS_CLUSTER_HASH_SLOTS, key_slot
 from redis.exceptions import (

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -1356,8 +1356,11 @@ class TestClusterRedisCommands:
         assert "addr" in info
 
     @skip_if_server_version_lt("2.6.9")
-    async def test_client_kill(self, r: RedisCluster, r2: RedisCluster) -> None:
+    async def test_client_kill(
+        self, r: RedisCluster, create_redis: Callable[..., RedisCluster]
+    ) -> None:
         node = r.get_primaries()[0]
+        r2 = await create_redis(cls=RedisCluster, flushdb=False)
         await r.client_setname("redis-py-c1", target_nodes="all")
         await r2.client_setname("redis-py-c2", target_nodes="all")
         clients = [
@@ -1378,6 +1381,7 @@ class TestClusterRedisCommands:
         ]
         assert len(clients) == 1
         assert clients[0].get("name") == "redis-py-c1"
+        await r2.close()
 
     @skip_if_server_version_lt("2.6.0")
     async def test_cluster_bitop_not_empty_string(self, r: RedisCluster) -> None:

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -14,7 +14,7 @@ from redis.asyncio.cluster import ClusterNode, NodesManager, RedisCluster
 from redis.asyncio.connection import Connection, SSLConnection
 from redis.asyncio.parser import CommandsParser
 from redis.asyncio.retry import Retry
-from redis.backoff import ExponentialBackoff, NoBackoff, get_default_backoff
+from redis.backoff import ExponentialBackoff, NoBackoff, default_backoff
 from redis.cluster import PIPELINE_BLOCKED_COMMANDS, PRIMARY, REPLICA, get_node_name
 from redis.crc import REDIS_CLUSTER_HASH_SLOTS, key_slot
 from redis.exceptions import (
@@ -278,7 +278,7 @@ class TestRedisClusterObj:
             retry = rc_default.connection_kwargs.get("retry")
             assert isinstance(retry, Retry)
             assert retry._retries == 3
-            assert isinstance(retry._backoff, type(get_default_backoff()))
+            assert isinstance(retry._backoff, type(default_backoff()))
             assert rc_default.get_node("127.0.0.1", 16379).connection_kwargs.get(
                 "retry"
             ) == rc_default.get_node("127.0.0.1", 16380).connection_kwargs.get("retry")

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -260,6 +260,8 @@ class TestRedisClusterObj:
                 assert n_retry is not None
                 assert n_retry._retries == retry._retries
                 assert isinstance(n_retry._backoff, NoBackoff)
+            rand_cluster_node = r.get_random_node()
+            existing_conn = rand_cluster_node.acquire_connection()
             # Change retry policy
             new_retry = Retry(ExponentialBackoff(), 3)
             r.set_retry(new_retry)
@@ -270,6 +272,9 @@ class TestRedisClusterObj:
                 assert n_retry is not None
                 assert n_retry._retries == new_retry._retries
                 assert isinstance(n_retry._backoff, ExponentialBackoff)
+            assert existing_conn.retry._retries == new_retry._retries
+            new_conn = rand_cluster_node.acquire_connection()
+            assert new_conn.retry._retries == new_retry._retries
 
     async def test_cluster_retry_object(self, request: FixtureRequest) -> None:
         url = request.config.getoption("--redis-url")

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -1,8 +1,9 @@
 import pytest
 
+from redis.asyncio import Redis
 from redis.asyncio.connection import Connection, UnixDomainSocketConnection
 from redis.asyncio.retry import Retry
-from redis.backoff import AbstractBackoff, NoBackoff
+from redis.backoff import AbstractBackoff, ExponentialBackoff, NoBackoff
 from redis.exceptions import ConnectionError, TimeoutError
 
 
@@ -114,3 +115,18 @@ class TestRetry:
 
         assert self.actual_attempts == 5
         assert self.actual_failures == 5
+
+
+class TestRedisClientRetry:
+    "Test the Redis client behavior with retries"
+
+    async def test_get_set_retry_object(self, request):
+        retry = Retry(NoBackoff(), 2)
+        url = request.config.getoption("--redis-url")
+        r = await Redis.from_url(url, retry_on_timeout=True, retry=retry)
+        assert r.get_retry()._retries == retry._retries
+        assert isinstance(r.get_retry()._backoff, NoBackoff)
+        new_retry_policy = Retry(ExponentialBackoff(), 3)
+        r.set_retry(new_retry_policy)
+        assert r.get_retry()._retries == new_retry_policy._retries
+        assert isinstance(r.get_retry()._backoff, ExponentialBackoff)

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -127,6 +127,10 @@ class TestRedisClientRetry:
         assert r.get_retry()._retries == retry._retries
         assert isinstance(r.get_retry()._backoff, NoBackoff)
         new_retry_policy = Retry(ExponentialBackoff(), 3)
+        exiting_conn = await r.connection_pool.get_connection("_")
         r.set_retry(new_retry_policy)
         assert r.get_retry()._retries == new_retry_policy._retries
         assert isinstance(r.get_retry()._backoff, ExponentialBackoff)
+        assert exiting_conn.retry._retries == new_retry_policy._retries
+        new_conn = await r.connection_pool.get_connection("_")
+        assert new_conn.retry._retries == new_retry_policy._retries

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -365,7 +365,7 @@ class TestRedisClusterObj:
         key = "key"
         r.set("key", "value")
         primary = r.get_node_from_key(key, replica=False)
-        assert r.get("key") == "value"
+        assert str_if_bytes(r.get("key")) == "value"
         # Get the current output of cluster slots
         cluster_slots = primary.redis_connection.execute_command("CLUSTER SLOTS")
         replica_host = ""

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from redis.backoff import NoBackoff
+from redis.backoff import ExponentialBackoff, NoBackoff
 from redis.client import Redis
 from redis.connection import Connection, UnixDomainSocketConnection
 from redis.exceptions import (
@@ -203,3 +203,13 @@ class TestRedisClientRetry:
                     r.get("foo")
                 finally:
                     assert parse_response.call_count == retries + 1
+
+    def test_get_set_retry_object(self, request):
+        retry = Retry(NoBackoff(), 2)
+        r = _get_client(Redis, request, retry_on_timeout=True, retry=retry)
+        assert r.get_retry()._retries == retry._retries
+        assert isinstance(r.get_retry()._backoff, NoBackoff)
+        new_retry_policy = Retry(ExponentialBackoff(), 3)
+        r.set_retry(new_retry_policy)
+        assert r.get_retry()._retries == new_retry_policy._retries
+        assert isinstance(r.get_retry()._backoff, ExponentialBackoff)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -207,9 +207,13 @@ class TestRedisClientRetry:
     def test_get_set_retry_object(self, request):
         retry = Retry(NoBackoff(), 2)
         r = _get_client(Redis, request, retry_on_timeout=True, retry=retry)
+        exist_conn = r.connection_pool.get_connection("_")
         assert r.get_retry()._retries == retry._retries
         assert isinstance(r.get_retry()._backoff, NoBackoff)
         new_retry_policy = Retry(ExponentialBackoff(), 3)
         r.set_retry(new_retry_policy)
         assert r.get_retry()._retries == new_retry_policy._retries
         assert isinstance(r.get_retry()._backoff, ExponentialBackoff)
+        assert exist_conn.retry._retries == new_retry_policy._retries
+        new_conn = r.connection_pool.get_connection("_")
+        assert new_conn.retry._retries == new_retry_policy._retries


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change


### Failover handling improvements for RedisCluster and Async RedisCluster
1. **Handle cluster connection errors in the retry object** -Removed handling of timeouts/connection errors within the cluster loop to reduce retries duplication with Retry objects and enable backoff strategies. Each cluster node will share the cluster's Retry object for retry and backoff policy. 
2. **Fixed "cannot pickle '_thread.lock' object" bug**- When we use NodesManager's initialize function to refresh the cluster topology after a failover, if the chosen startup node was the failed node, we received the above exception when trying to copy the connection kwargs (traceback at the end), and this error was raised to the user since it was not expected. It caused the initialize loop to get stuck on the failed node and not continue. Removed the copy of kwargs as it no longer needed since we call str_if_bytes on the conncetion's responses. We now throw exceptions in the initialize() loop only if there are no more startup nodes available. Closing #2354 #2297 
3. **Removing the failed target node from the seed nodes when connection/timeout errors occur:** the failed target node will return to the startup nodes if discovered on the cluster slots, but we'll skip it in this initialize iteration.
4.  **Backwards comparability for connection_error_retry_attempts** - connection_error_retry_attempts can still be used to pass the number of retries to execute on connection/timeout error. If connection_error_retry_attempts = 0 and retry object isn't being passed, no retries will be done on connecton/timeout errors for the cluster.

```
Traceback (most recent call last):   File "/home/ubuntu/redis-py/redis/cluster.py", line 1424, in initialize

    copy_kwargs = copy.deepcopy(kwargs)

  File "/usr/lib/python3.10/copy.py", line 146, in deepcopy

    y = copier(x, memo)

...
  File "/usr/lib/python3.10/copy.py", line 146, in deepcopy

    y = copier(x, memo)

  File "/usr/lib/python3.10/copy.py", line 231, in _deepcopy_dict

    y[deepcopy(key, memo)] = deepcopy(value, memo)

  File "/usr/lib/python3.10/copy.py", line 161, in deepcopy

    rv = reductor(4)

TypeError: cannot pickle '_thread.lock' object
```