### PR TITLE
workflows/integration: trailofbits/gh-action-pip-audit is now pypa/gh-action-pip-audit

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -23,7 +23,7 @@ jobs:
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v3
-       - uses: trailofbits/gh-action-pip-audit@v1.0.0
+       - uses: pypa/gh-action-pip-audit@v1.0.0
          with:
            inputs: requirements.txt dev_requirements.txt
 


### PR DESCRIPTION
No functional changes, so I didn't fill out the checklist. But let me know if you'd like me to!

Closes #2379.

Signed-off-by: William Woodruff <william@trailofbits.com>
