### PR TITLE
Supply chain risk reduction: remove dependency on library named `deprecated`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@
     * Fix RedisCluster to immediately raise AuthenticationError without a retry
     * ClusterPipeline Doesn't Handle ConnectionError for Dead Hosts (#2225)
     * Remove compatibility code for old versions of Hiredis, drop Packaging dependency
+    * The `deprecated` library is no longer a dependency
 
 * 4.1.3 (Feb 8, 2022)
     * Fix flushdb and flushall (#1926)

--- a/redis/commands/bf/commands.py
+++ b/redis/commands/bf/commands.py
@@ -1,8 +1,6 @@
-from deprecated import deprecated
-
 from redis.client import NEVER_DECODE
 from redis.exceptions import ModuleError
-from redis.utils import HIREDIS_AVAILABLE
+from redis.utils import HIREDIS_AVAILABLE, deprecated_function
 
 BF_RESERVE = "BF.RESERVE"
 BF_ADD = "BF.ADD"
@@ -327,7 +325,7 @@ class TOPKCommands:
         """  # noqa
         return self.execute_command(TOPK_QUERY, key, *items)
 
-    @deprecated(version="4.4.0", reason="deprecated since redisbloom 2.4.0")
+    @deprecated_function(version="4.4.0", reason="deprecated since redisbloom 2.4.0")
     def count(self, key, *items):
         """
         Return count for one `item` or more from `key`.

--- a/redis/commands/json/commands.py
+++ b/redis/commands/json/commands.py
@@ -2,9 +2,8 @@ import os
 from json import JSONDecodeError, loads
 from typing import Dict, List, Optional, Union
 
-from deprecated import deprecated
-
 from redis.exceptions import DataError
+from redis.utils import deprecated_function
 
 from ._util import JsonType
 from .decoders import decode_dict_keys
@@ -137,7 +136,7 @@ class JSONCommands:
             "JSON.NUMINCRBY", name, str(path), self._encode(number)
         )
 
-    @deprecated(version="4.0.0", reason="deprecated since redisjson 1.0.0")
+    @deprecated_function(version="4.0.0", reason="deprecated since redisjson 1.0.0")
     def nummultby(self, name: str, path: str, number: int) -> str:
         """Multiply the numeric (integer or floating point) JSON value under
         ``path`` at key ``name`` with the provided ``number``.
@@ -368,19 +367,19 @@ class JSONCommands:
             pieces.append(str(path))
         return self.execute_command("JSON.DEBUG", *pieces)
 
-    @deprecated(
+    @deprecated_function(
         version="4.0.0", reason="redisjson-py supported this, call get directly."
     )
     def jsonget(self, *args, **kwargs):
         return self.get(*args, **kwargs)
 
-    @deprecated(
+    @deprecated_function(
         version="4.0.0", reason="redisjson-py supported this, call get directly."
     )
     def jsonmget(self, *args, **kwargs):
         return self.mget(*args, **kwargs)
 
-    @deprecated(
+    @deprecated_function(
         version="4.0.0", reason="redisjson-py supported this, call get directly."
     )
     def jsonset(self, *args, **kwargs):

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -2,9 +2,8 @@ import itertools
 import time
 from typing import Dict, Optional, Union
 
-from deprecated import deprecated
-
 from redis.client import Pipeline
+from redis.utils import deprecated_function
 
 from ..helpers import parse_to_dict
 from ._util import to_string
@@ -238,7 +237,7 @@ class SearchCommands:
 
         return self.execute_command(*args)
 
-    @deprecated(
+    @deprecated_function(
         version="2.0.0", reason="deprecated since redisearch 2.0, call hset instead"
     )
     def add_document(
@@ -294,7 +293,7 @@ class SearchCommands:
             **fields,
         )
 
-    @deprecated(
+    @deprecated_function(
         version="2.0.0", reason="deprecated since redisearch 2.0, call hset instead"
     )
     def add_document_hash(self, doc_id, score=1.0, language=None, replace=False):

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from functools import wraps
 from typing import Any, Dict, Mapping, Union
 
 try:
@@ -80,3 +81,30 @@ def merge_result(command, res):
             result.add(value)
 
     return list(result)
+
+
+def warn_deprecated(name, reason="", version="", stacklevel=2):
+    import warnings
+
+    msg = f"Call to deprecated {name}."
+    if reason:
+        msg += f" ({reason})"
+    if version:
+        msg += f" -- Deprecated since version {version}."
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=stacklevel)
+
+
+def deprecated_function(reason="", version="", name=None):
+    """
+    Decorator to mark a function as deprecated.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            warn_deprecated(name or func.__name__, reason, version, stacklevel=3)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 async-timeout>=4.0.2
-deprecated>=1.2.3
 typing-extensions; python_version<"3.8"

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     author_email="oss@redis.com",
     python_requires=">=3.7",
     install_requires=[
-        "deprecated>=1.2.3",
         'importlib-metadata >= 1.0; python_version < "3.8"',
         'typing-extensions; python_version<"3.8"',
         "async-timeout>=4.0.2",


### PR DESCRIPTION
No need for an external library just for 5 annotations.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

### Description of change

This PR removes the dependency on the `@deprecated` library in favor of a simple 8-line function.
