### PR TITLE
tox.ini: fix healtcheck -> healthcheck

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ name = master
 image = redisfab/redis-py:6.2.6-buster
 ports =
     6379:6379/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6379)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6379)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis6.2/master/redis.conf:/redis.conf
 
@@ -32,7 +32,7 @@ links =
     master:master
 ports =
     6380:6380/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6380)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6380)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis6.2/replica/redis.conf:/redis.conf
 
@@ -41,7 +41,7 @@ name = unstable
 image = redisfab/redis-py:unstable-bionic
 ports =
     6378:6378/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6378)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6378)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/unstable/redis.conf:/redis.conf
 
@@ -55,7 +55,7 @@ ports =
     6375:6375/tcp
     6376:6376/tcp
     6377:6377/tcp
-healtcheck_cmd = python -c "import socket;print(True) if all([0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',port)) for port in range(6372,6377)]) else False"
+healthcheck_cmd = python -c "import socket;print(True) if all([0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',port)) for port in range(6372,6377)]) else False"
 volumes =
     bind:rw:{toxinidir}/docker/unstable_cluster/redis.conf:/redis.conf
 
@@ -66,7 +66,7 @@ links =
     master:master
 ports =
     26379:26379/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26379)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26379)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis6.2/sentinel/sentinel_1.conf:/sentinel.conf
 
@@ -77,7 +77,7 @@ links =
     master:master
 ports =
     26380:26380/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26380)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26380)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis6.2/sentinel/sentinel_2.conf:/sentinel.conf
 
@@ -88,7 +88,7 @@ links =
     master:master
 ports =
     26381:26381/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26381)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26381)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis6.2/sentinel/sentinel_3.conf:/sentinel.conf
 
@@ -97,7 +97,7 @@ name = redismod
 image = redislabs/redismod:edge
 ports =
     36379:6379/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',36379)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',36379)) else False"
 
 [docker:redis_cluster]
 name = redis_cluster
@@ -109,7 +109,7 @@ ports =
     16382:16382/tcp
     16383:16383/tcp
     16384:16384/tcp
-healtcheck_cmd = python -c "import socket;print(True) if all([0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',port)) for port in range(16379,16384)]) else False"
+healthcheck_cmd = python -c "import socket;print(True) if all([0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',port)) for port in range(16379,16384)]) else False"
 volumes =
     bind:rw:{toxinidir}/docker/cluster/redis.conf:/redis.conf
 
@@ -123,14 +123,14 @@ ports =
     46382:46382/tcp
     46383:46383/tcp
     46384:46384/tcp
-healtcheck_cmd = python -c "import socket;print(True) if all([0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',port)) for port in range(46379,46384)]) else False"
+healthcheck_cmd = python -c "import socket;print(True) if all([0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',port)) for port in range(46379,46384)]) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redismod_cluster/redis.conf:/redis.conf
 
 [docker:stunnel]
 name = stunnel
 image = redisfab/stunnel:latest
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6666)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6666)) else False"
 links =
     master:master
 ports =
@@ -144,7 +144,7 @@ name = redis5_master
 image = redisfab/redis-py:5.0-buster
 ports =
     6382:6382/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6382)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6382)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis5/master/redis.conf:/redis.conf
 
@@ -155,7 +155,7 @@ links =
     redis5_master:redis5_master
 ports =
     6383:6383/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6383)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6383)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis5/replica/redis.conf:/redis.conf
 
@@ -166,7 +166,7 @@ links =
     redis5_master:redis5_master
 ports =
     26382:26382/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26382)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26382)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis5/sentinel/sentinel_1.conf:/sentinel.conf
 
@@ -177,7 +177,7 @@ links =
     redis5_master:redis5_master
 ports =
     26383:26383/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26383)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26383)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis5/sentinel/sentinel_2.conf:/sentinel.conf
 
@@ -188,7 +188,7 @@ links =
     redis5_master:redis5_master
 ports =
     26384:26384/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26384)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26384)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis5/sentinel/sentinel_3.conf:/sentinel.conf
 
@@ -202,7 +202,7 @@ ports =
     16388:16388/tcp
     16389:16389/tcp
     16390:16390/tcp
-healtcheck_cmd = python -c "import socket;print(True) if all([0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',port)) for port in range(16385,16390)]) else False"
+healthcheck_cmd = python -c "import socket;print(True) if all([0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',port)) for port in range(16385,16390)]) else False"
 volumes =
     bind:rw:{toxinidir}/docker/cluster/redis.conf:/redis.conf
 
@@ -211,7 +211,7 @@ name = redis4_master
 image = redisfab/redis-py:4.0-buster
 ports =
     6381:6381/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6381)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',6381)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis4/master/redis.conf:/redis.conf
 
@@ -222,7 +222,7 @@ links =
     redis4_master:redis4_master
 ports =
     26385:26385/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26385)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26385)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis4/sentinel/sentinel_1.conf:/sentinel.conf
 
@@ -233,7 +233,7 @@ links =
     redis4_master:redis4_master
 ports =
     26386:26386/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26386)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26386)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis4/sentinel/sentinel_2.conf:/sentinel.conf
 
@@ -244,7 +244,7 @@ links =
     redis4_master:redis4_master
 ports =
     26387:26387/tcp
-healtcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26387)) else False"
+healthcheck_cmd = python -c "import socket;print(True) if 0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',26387)) else False"
 volumes =
     bind:rw:{toxinidir}/docker/redis4/sentinel/sentinel_3.conf:/sentinel.conf
 
@@ -258,7 +258,7 @@ ports =
     16394:16394/tcp
     16395:16395/tcp
     16396:16396/tcp
-healtcheck_cmd = python -c "import socket;print(True) if all([0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',port)) for port in range(16391,16396)]) else False"
+healthcheck_cmd = python -c "import socket;print(True) if all([0 == socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex(('127.0.0.1',port)) for port in range(16391,16396)]) else False"
 volumes =
     bind:rw:{toxinidir}/docker/cluster/redis.conf:/redis.conf
 


### PR DESCRIPTION
This could maybe fix the flakiness of some of the cluster tests.

Alternate take on #2387.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

`healtcheck_cmd` has been typoed in tox.ini since its inception, making it a no-op.

Some CI is failing right now due to what seems to be failure connecting to cluster nodes, so perhaps waiting for them to be up fixes things.