### PR TITLE
Test `test_get_moveable_keys` was broken

### DIFF
--- a/tests/test_command_parser.py
+++ b/tests/test_command_parser.py
@@ -53,7 +53,8 @@ class TestCommandsParser:
 
         assert sorted(commands_parser.get_keys(r, *args1)) == sorted(["key1", "key2"])
         assert (
-            sorted(commands_parser.get_keys(r, *args2)) == sorted(["mystream", "writers"])
+            sorted(commands_parser.get_keys(r, *args2))
+            == sorted(["mystream", "writers"])
         )
         assert (
             sorted(commands_parser.get_keys(r, *args3))

--- a/tests/test_command_parser.py
+++ b/tests/test_command_parser.py
@@ -51,21 +51,12 @@ class TestCommandsParser:
         ]
         args7 = ["MIGRATE", "192.168.1.34", 6379, "key1", 0, 5000]
 
-        assert sorted(commands_parser.get_keys(r, *args1)) == sorted(["key1", "key2"])
-        assert (
-            sorted(commands_parser.get_keys(r, *args2))
-            == sorted(["mystream", "writers"])
-        )
-        assert (
-            sorted(commands_parser.get_keys(r, *args3))
-            == sorted(["out", "zset1", "zset2"])
-        )
-        assert sorted(commands_parser.get_keys(r, *args4)) == sorted(["Sicily", "out"])
+        assert sorted(commands_parser.get_keys(r, *args1)) == ["key1", "key2"]
+        assert sorted(commands_parser.get_keys(r, *args2)) == ["mystream", "writers"]
+        assert sorted(commands_parser.get_keys(r, *args3)) == ["out", "zset1", "zset2"]
+        assert sorted(commands_parser.get_keys(r, *args4)) == ["Sicily", "out"]
         assert sorted(commands_parser.get_keys(r, *args5)) == ["foo"]
-        assert (
-            sorted(commands_parser.get_keys(r, *args6))
-            == sorted(["key1", "key2", "key3"])
-        )
+        assert sorted(commands_parser.get_keys(r, *args6)) == ["key1", "key2", "key3"]
         assert sorted(commands_parser.get_keys(r, *args7)) == ["key1"]
 
     # A bug in redis<7.0 causes this to fail: https://github.com/redis/redis/issues/9493

--- a/tests/test_command_parser.py
+++ b/tests/test_command_parser.py
@@ -51,21 +51,21 @@ class TestCommandsParser:
         ]
         args7 = ["MIGRATE", "192.168.1.34", 6379, "key1", 0, 5000]
 
-        assert commands_parser.get_keys(r, *args1).sort() == ["key1", "key2"].sort()
+        assert sorted(commands_parser.get_keys(r, *args1)) == sorted(["key1", "key2"])
         assert (
-            commands_parser.get_keys(r, *args2).sort() == ["mystream", "writers"].sort()
+            sorted(commands_parser.get_keys(r, *args2)) == sorted(["mystream", "writers"])
         )
         assert (
-            commands_parser.get_keys(r, *args3).sort()
-            == ["out", "zset1", "zset2"].sort()
+            sorted(commands_parser.get_keys(r, *args3))
+            == sorted(["out", "zset1", "zset2"])
         )
-        assert commands_parser.get_keys(r, *args4).sort() == ["Sicily", "out"].sort()
-        assert commands_parser.get_keys(r, *args5).sort() == ["foo"].sort()
+        assert sorted(commands_parser.get_keys(r, *args4)) == sorted(["Sicily", "out"])
+        assert sorted(commands_parser.get_keys(r, *args5)) == ["foo"]
         assert (
-            commands_parser.get_keys(r, *args6).sort()
-            == ["key1", "key2", "key3"].sort()
+            sorted(commands_parser.get_keys(r, *args6))
+            == sorted(["key1", "key2", "key3"])
         )
-        assert commands_parser.get_keys(r, *args7).sort() == ["key1"].sort()
+        assert sorted(commands_parser.get_keys(r, *args7)) == ["key1"]
 
     # A bug in redis<7.0 causes this to fail: https://github.com/redis/redis/issues/9493
     @skip_if_server_version_lt("7.0.0")


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

This test was not checking anything, because `.sort()` always returns `None`. It was checking that `None == None`.

See:

```python
>>> assert [3, 1, 2].sort() is None
>>> sorted([3, 1, 2])
[1, 2, 3]
```
