### PR TITLE
fix: catch OSError on asyncio

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1445,7 +1445,7 @@ class ConnectionPool:
             try:
                 if await connection.can_read_destructive():
                     raise ConnectionError("Connection has data") from None
-            except ConnectionError:
+            except (ConnectionError, OSError):
                 await connection.disconnect()
                 await connection.connect()
                 if await connection.can_read_destructive():
@@ -1646,7 +1646,7 @@ class BlockingConnectionPool(ConnectionPool):
             try:
                 if await connection.can_read_destructive():
                     raise ConnectionError("Connection has data") from None
-            except ConnectionError:
+            except (ConnectionError, OSError):
                 await connection.disconnect()
                 await connection.connect()
                 if await connection.can_read_destructive():


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change
Before redis-py support asyncio, https://github.com/redis/redis-py/pull/1832 merged to master
https://github.com/redis/redis-py/pull/1832#issuecomment-1271556337
So, asyncio to catch OSError too