### PR TITLE
Fix issue with `pack_commands` returning an empty byte sequence

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -922,7 +922,8 @@ class Connection:
                     or chunklen > buffer_cutoff
                     or isinstance(chunk, memoryview)
                 ):
-                    output.append(SYM_EMPTY.join(pieces))
+                    if pieces:
+                        output.append(SYM_EMPTY.join(pieces))
                     buffer_length = 0
                     pieces = []
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -930,7 +930,8 @@ class Connection:
                     or chunklen > buffer_cutoff
                     or isinstance(chunk, memoryview)
                 ):
-                    output.append(SYM_EMPTY.join(pieces))
+                    if pieces:
+                        output.append(SYM_EMPTY.join(pieces))
                     buffer_length = 0
                     pieces = []
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Under certain circumstances `pack_commands()` adds an empty byte sequence (`b""`) to the returned list, which when connecting to a Redis server over SSL could cause an EOF error:

```
redis.exceptions.ConnectionError: Error while reading from socket: (8, 'EOF occurred in violation of protocol (_ssl.c:2483)')
```
In our case we are running an async Falcon application using the `uvicorn` worker type; we ran into the problem when using a Redis pipeline to perform an `MSET` followed by one or more `EXPIRE` commands. The values in the `MSET` are images, generally around 5 to 6kb in size. From what I can see it was certain images within a very specific size range, where the length 
 of the value was just under 6000, that caused the problem (6000 being the `buffer_cutoff` value used in `pack_commands`).

(Note that in some/many cases the `b""` doesn't seem to cause a problem; I wrote a simple script to reproduce the error, executing the code in the standard `asyncio` event loop, but couldn't reproduce it that way. It was only by creating a simple Falcon/uvicorn app and executing it within that that I could reproduce it; I guess it's to do with the fact that uvicorn uses `uvloop` instead of the asyncio event loop, and there must be some difference in the underlying SSL transport.)