### PR TITLE
Fix Sentinel.execute_command to execute across the entire sentinel cluster 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@
     * Fixed "cannot pickle '_thread.lock' object" bug (#2354, #2297)
     * Added CredentialsProvider class to support password rotation
     * Enable Lock for asyncio cluster mode
+    * Fix Sentinel.execute_command doesn't execute across the entire sentinel cluster bug (#2458)
 
 * 4.1.3 (Feb 8, 2022)
     * Fix flushdb and flushall (#1926)

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -200,10 +200,10 @@ class Sentinel(SentinelCommands):
             kwargs.pop("once")
 
         if once:
+            random.choice(self.sentinels).execute_command(*args, **kwargs)
+        else:
             for sentinel in self.sentinels:
                 sentinel.execute_command(*args, **kwargs)
-        else:
-            random.choice(self.sentinels).execute_command(*args, **kwargs)
         return True
 
     def __repr__(self):


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

closes: #2458 

Sentinel.execute_command fixed to execute across sentinel cluster when once argument is not given or set to false, or execute on one random sentinel from the cluster if the once argument is true (like the documentation suggests).
