### PR TITLE
Added a replacement for the default cluster node in the event of failure.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@
     * Fixed "cannot pickle '_thread.lock' object" bug (#2354, #2297)
     * Added CredentialsProvider class to support password rotation
     * Enable Lock for asyncio cluster mode
+    * Added a replacement for the default cluster node in the event of failure (#2463)
 
 * 4.1.3 (Feb 8, 2022)
     * Fix flushdb and flushall (#1926)

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1501,7 +1501,7 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
                         raise result
 
             if is_default_node:
-                self.replace_default_node()
+                client.replace_default_node()
 
         return [cmd.result for cmd in stack]
 

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -11,6 +11,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -516,7 +517,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
 
     async def _determine_nodes(
         self, command: str, *args: Any, node_flag: Optional[str] = None
-    ) -> tuple[list["ClusterNode"], bool]:
+    ) -> Tuple[List["ClusterNode"], bool]:
         """Determine which nodes should be executed the command on
 
         Returns:

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -4,7 +4,7 @@ import sys
 import threading
 import time
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from redis.backoff import default_backoff
 from redis.client import CaseInsensitiveDict, PubSub, Redis, parse_scan
@@ -36,10 +36,6 @@ from redis.utils import (
     merge_result,
     safe_str,
     str_if_bytes,
-)
-
-TargetNodesT = TypeVar(
-    "TargetNodesT", str, "ClusterNode", List["ClusterNode"], Dict[Any, "ClusterNode"]
 )
 
 
@@ -839,7 +835,7 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         """Set a custom Response Callback"""
         self.cluster_response_callbacks[command] = callback
 
-    def _determine_nodes(self, *args, **kwargs) -> tuple[list["ClusterNode"], bool]:
+    def _determine_nodes(self, *args, **kwargs) -> Tuple[List["ClusterNode"], bool]:
         """Determine which nodes should be executed the command on
 
         Returns:

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1057,10 +1057,10 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
                 # Return the processed result
                 return self._process_result(args[0], res, **kwargs)
             except Exception as e:
-                if is_default_node:
-                    # Replace the default cluster node
-                    self.replace_default_node()
                 if retry_attempts > 0 and type(e) in self.__class__.ERRORS_ALLOW_RETRY:
+                    if is_default_node:
+                        # Replace the default cluster node
+                        self.replace_default_node()
                     # The nodes and slots cache were reinitialized.
                     # Try again with the new cluster setup.
                     retry_attempts -= 1

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -4,7 +4,7 @@ import sys
 import threading
 import time
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 from redis.backoff import default_backoff
 from redis.client import CaseInsensitiveDict, PubSub, Redis, parse_scan
@@ -36,6 +36,10 @@ from redis.utils import (
     merge_result,
     safe_str,
     str_if_bytes,
+)
+
+TargetNodesT = TypeVar(
+    "TargetNodesT", str, "ClusterNode", List["ClusterNode"], Dict[Any, "ClusterNode"]
 )
 
 

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -800,7 +800,6 @@ class TestRedisClusterObj:
         # CLUSTER NODES command is being executed on the default node
         nodes = await r.cluster_nodes()
         assert "myself" in nodes.get(curr_default_node.name).get("flags")
-
         # Mock connection error for the default node
         mock_node_resp_exc(curr_default_node, ConnectionError("error"))
         # Test that the command succeed from a different node

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -807,6 +807,8 @@ class TestRedisClusterObj:
         nodes = await r.cluster_nodes()
         assert "myself" not in nodes.get(curr_default_node.name).get("flags")
         assert r.get_default_node() != curr_default_node
+        # Rollback to the old default node
+        r.replace_default_node(curr_default_node)
 
 
 class TestClusterRedisCommands:

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -788,6 +788,26 @@ class TestRedisClusterObj:
         )
         await rc.close()
 
+    def test_replace_cluster_node(self, r: RedisCluster) -> None:
+        prev_default_node = r.get_default_node()
+        r.replace_default_node()
+        assert r.get_default_node() != prev_default_node
+        r.replace_default_node(prev_default_node)
+        assert r.get_default_node() == prev_default_node
+
+    async def test_default_node_is_replaced_after_exception(self, r):
+        curr_default_node = r.get_default_node()
+        # CLUSTER NODES command is being executed on the default node
+        nodes = await r.cluster_nodes()
+        assert "myself" in nodes.get(curr_default_node.name).get("flags")
+
+        # Mock connection error for the default node
+        mock_node_resp_exc(curr_default_node, ConnectionError("error"))
+        # Test that the command succeed from a different node
+        nodes = await r.cluster_nodes()
+        assert "myself" not in nodes.get(curr_default_node.name).get("flags")
+        assert r.get_default_node() != curr_default_node
+
 
 class TestClusterRedisCommands:
     """

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -813,6 +813,8 @@ class TestRedisClusterObj:
         nodes = r.cluster_nodes()
         assert "myself" not in nodes.get(curr_default_node.name).get("flags")
         assert r.get_default_node() != curr_default_node
+        # Rollback to the old default node
+        r.replace_default_node(curr_default_node)
 
 
 @pytest.mark.onlycluster

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -813,8 +813,6 @@ class TestRedisClusterObj:
         nodes = r.cluster_nodes()
         assert "myself" not in nodes.get(curr_default_node.name).get("flags")
         assert r.get_default_node() != curr_default_node
-        # Rollback to the old default node
-        r.replace_default_node(curr_default_node)
 
 
 @pytest.mark.onlycluster


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

For non-key based commands, we choose the default cluster node to execute the command on (for example, PING, CLUSTER NODES, CONFIG, etc..).

When the default node fails, we'll replace it with a new node before retrying the command.
Improves failover handling. 

- Separated AUTH cluster/non-cluster tests