### PR TITLE
Wrong number of arguments for `geosearch` command

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -5581,7 +5581,7 @@ class GeoCommands(CommandsProtocol):
                     "GEOSEARCH member and longitude or latitude" " cant be set together"
                 )
             pieces.extend([b"FROMMEMBER", kwargs["member"]])
-        if kwargs["longitude"] and kwargs["latitude"]:
+        if kwargs["longitude"] is not None and kwargs["latitude"] is not None:
             pieces.extend([b"FROMLONLAT", kwargs["longitude"], kwargs["latitude"]])
 
         # BYRADIUS or BYBOX


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
In the current implementation - if longitude or latitude are 0 `b"FROMLONLAT", kwargs["longitude"], kwargs["latitude"]]` will not be added and that will cause an error

Fixes #2462 