### PR TITLE
Async clusters: Support creating locks inside async functions

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -356,11 +356,13 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         )
 
         self._initialize = True
-        self._lock = asyncio.Lock()
+        self._lock: Optional[asyncio.Lock] = None
 
     async def initialize(self) -> "RedisCluster":
         """Get all nodes from startup nodes & creates connections if not initialized."""
         if self._initialize:
+            if not self._lock:
+                self._lock = asyncio.Lock()
             async with self._lock:
                 if self._initialize:
                     try:
@@ -378,6 +380,8 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
     async def close(self) -> None:
         """Close all connections & client if initialized."""
         if not self._initialize:
+            if not self._lock:
+                self._lock = asyncio.Lock()
             async with self._lock:
                 if not self._initialize:
                     self._initialize = True


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

This allows creating the client at the module level or before the event loop has been initialized.
Ref: https://github.com/encode/starlette/issues/1315#issuecomment-1096256231