### PR TITLE
Fix redis version check in ACL tests

### DIFF
--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -19,6 +19,7 @@ from tests.conftest import (
 )
 
 REDIS_6_VERSION = "5.9.0"
+REDIS_6_2_VERSION = "6.2.0"
 
 
 @pytest_asyncio.fixture()
@@ -114,7 +115,7 @@ class TestRedisCommands:
         password = await r.acl_genpass()
         assert isinstance(password, str)
 
-    @skip_if_server_version_lt(REDIS_6_VERSION)
+    @skip_if_server_version_lt(REDIS_6_2_VERSION)
     @skip_if_server_version_gte("7.0.0")
     async def test_acl_getuser_setuser(self, r_teardown):
         username = "redis-py-user"
@@ -221,7 +222,7 @@ class TestRedisCommands:
         )
         assert len((await r.acl_getuser(username))["passwords"]) == 1
 
-    @skip_if_server_version_lt(REDIS_6_VERSION)
+    @skip_if_server_version_lt(REDIS_6_2_VERSION)
     @skip_if_server_version_gte("7.0.0")
     async def test_acl_list(self, r_teardown):
         username = "redis-py-user"


### PR DESCRIPTION
Tests with sanitize-payload assertions require Redis 6.2 and fail on Redis 6.0.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
