### PR TITLE
feat(redis/client.py):set default value for socket_timeout

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -908,7 +908,7 @@ class Redis(AbstractRedis, RedisModuleCommands, CoreCommands, SentinelCommands):
         port=6379,
         db=0,
         password=None,
-        socket_timeout=100,
+        socket_timeout=1000,
         socket_connect_timeout=None,
         socket_keepalive=None,
         socket_keepalive_options=None,

--- a/redis/client.py
+++ b/redis/client.py
@@ -905,7 +905,7 @@ class Redis(AbstractRedis, RedisModuleCommands, CoreCommands, SentinelCommands):
         port=6379,
         db=0,
         password=None,
-        socket_timeout=None,
+        socket_timeout=100,
         socket_connect_timeout=None,
         socket_keepalive=None,
         socket_keepalive_options=None,


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

By default, socket_timeout is None. Sometimes(mostly related to network issues) it will never throw exception for a few days! It makes it very difficult to find out what the problem was.
So I recommend setting socket_timeout to a specific value.
