### PR TITLE
Raising NotImplementedError for certain CLUSTER commands

### DIFF
--- a/redis/commands/cluster.py
+++ b/redis/commands/cluster.py
@@ -644,6 +644,16 @@ class ClusterManagementCommands(ManagementCommands):
         """
         return self.execute_command("CLUSTER LINKS", target_nodes=target_node)
 
+    def cluster_flushslots(self, target_nodes: Optional["TargetNodesT"] = None) -> None:
+        raise NotImplementedError(
+            "CLUSTER FLUSHSLOTS is intentionally not implemented in the client."
+        )
+
+    def cluster_bumpepoch(self, target_nodes: Optional["TargetNodesT"] = None) -> None:
+        raise NotImplementedError(
+            "CLUSTER BUMPEPOCH is intentionally not implemented in the client."
+        )
+
     def readonly(self, target_nodes: Optional["TargetNodesT"] = None) -> ResponseT:
         """
         Enables read queries.

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1289,6 +1289,14 @@ class TestClusterRedisCommands:
         for i in range(0, len(res) - 1, 2):
             assert res[i][3] == res[i + 1][3]
 
+    def test_cluster_flshslots_not_implemented(self, r):
+        with pytest.raises(NotImplementedError):
+            r.cluster_flushslots()
+
+    def test_cluster_bumpepoch_not_implemented(self, r):
+        with pytest.raises(NotImplementedError):
+            r.cluster_bumpepoch()
+
     @skip_if_redis_enterprise()
     def test_readonly(self):
         r = get_mocked_redis_client(host=default_host, port=default_port)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

closes #1968 
closes #1969 