### PR TITLE
Make PythonParser resumable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Make PythonParser resumable in case of error (#2510)
     * Add `timeout=None` in `SentinelConnectionManager.read_response`
     * Documentation fix: password protected socket connection (#2374)
     * Allow `timeout=None` in `PubSub.get_message()` to wait forever

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -264,8 +264,6 @@ class PythonParser(BaseParser):
         if not self._stream or not self.encoder:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         raw = await self._readline()
-        if not raw:
-            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         response: Any
         byte, response = raw[:1], raw[1:]
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -247,6 +247,8 @@ class PythonParser(BaseParser):
             return False
 
     async def read_response(self, disable_decoding: bool = False):
+        if self._stream is None:
+            raise RedisError("Buffer is closed.")   
         if self._chunks:
             # augment parsing buffer with previously read data
             self._buffer += b"".join(self._chunks)
@@ -325,8 +327,6 @@ class PythonParser(BaseParser):
         if len(self._buffer) >= end:
             result = self._buffer[self._pos : end - 2]
         else:
-            if self._stream is None:
-                raise RedisError("Buffer is closed.")
             tail = self._buffer[self._pos :]
             try:
                 data = await self._stream.readexactly(want - len(tail))
@@ -346,8 +346,6 @@ class PythonParser(BaseParser):
         if found >= 0:
             result = self._buffer[self._pos : found]
         else:
-            if self._stream is None:
-                raise RedisError("Buffer is closed.")
             tail = self._buffer[self._pos :]
             data = await self._stream.readline()
             if not data.endswith(b"\r\n"):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,41 @@
+# Various mocks for testing
+
+
+class MockSocket:
+    """
+    A class simulating an readable socket, optionally raising a
+    special exception every other read.
+    """
+
+    class TestError(BaseException):
+        pass
+
+    def __init__(self, data, interrupt_every=0):
+        self.data = data
+        self.counter = 0
+        self.pos = 0
+        self.interrupt_every = interrupt_every
+
+    def tick(self):
+        self.counter += 1
+        if not self.interrupt_every:
+            return
+        if (self.counter % self.interrupt_every) == 0:
+            raise self.TestError()
+
+    def recv(self, bufsize):
+        self.tick()
+        bufsize = min(5, bufsize)  # truncate the read size
+        result = self.data[self.pos : self.pos + bufsize]
+        self.pos += len(result)
+        return result
+
+    def recv_into(self, buffer, nbytes=0, flags=0):
+        self.tick()
+        if nbytes == 0:
+            nbytes = len(buffer)
+        nbytes = min(5, nbytes)  # truncate the read size
+        result = self.data[self.pos : self.pos + nbytes]
+        self.pos += len(result)
+        buffer[: len(result)] = result
+        return len(result)

--- a/tests/test_asyncio/mocks.py
+++ b/tests/test_asyncio/mocks.py
@@ -1,0 +1,51 @@
+import asyncio
+
+# Helper Mocking classes for the tests.
+
+
+class MockStream:
+    """
+    A class simulating an asyncio input buffer, optionally raising a
+    special exception every other read.
+    """
+
+    class TestError(BaseException):
+        pass
+
+    def __init__(self, data, interrupt_every=0):
+        self.data = data
+        self.counter = 0
+        self.pos = 0
+        self.interrupt_every = interrupt_every
+
+    def tick(self):
+        self.counter += 1
+        if not self.interrupt_every:
+            return
+        if (self.counter % self.interrupt_every) == 0:
+            raise self.TestError()
+
+    async def read(self, want):
+        self.tick()
+        want = 5
+        result = self.data[self.pos : self.pos + want]
+        self.pos += len(result)
+        return result
+
+    async def readline(self):
+        self.tick()
+        find = self.data.find(b"\n", self.pos)
+        if find >= 0:
+            result = self.data[self.pos : find + 1]
+        else:
+            result = self.data[self.pos :]
+        self.pos += len(result)
+        return result
+
+    async def readexactly(self, length):
+        self.tick()
+        result = self.data[self.pos : self.pos + length]
+        if len(result) < length:
+            raise asyncio.IncompleteReadError(result, None)
+        self.pos += len(result)
+        return result

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -162,6 +162,7 @@ class InterruptingReader:
         return result
 
 
+@pytest.mark.onlynoncluster
 async def test_connection_parse_response_resume(r: redis.Redis):
     """
     This test verifies that the Connection parser,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,7 +7,7 @@ import pytest
 
 import redis
 from redis.backoff import NoBackoff
-from redis.connection import Connection, PythonParser, HiredisParser
+from redis.connection import Connection, HiredisParser, PythonParser
 from redis.exceptions import ConnectionError, InvalidResponse, TimeoutError
 from redis.retry import Retry
 from redis.utils import HIREDIS_AVAILABLE


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

See issue #2513

Recent changes in redis.asyncio changed the way timeouts are handled, by catching timeouts on a higher level and not leave a `Connection` object in a failed state.  Timeouts are now received directly when doing IO, instead of running a preliminary `can_read()` test with timeout.  This resulted in significant simplification of the logic and consolidated different timeout handling.

Unfortunately, the `PythonParser`, unlike the `HiredisParser` was not able to deal with IO being interrupted as it didn't maintain internal state.  A TimeoutException caught while parsing a response would cause data to be lost.  The `HiredisParser`, however, cleanly separates parsing and IO, and maintains its own internal parse buffer which is fed by IO separately.

This PR fixes `PythonParser` to keep a buffer of incomplete responses, so that if IO is interrupted, the parser's `read_response()` method can be called again, if it is interrupted during IO.

See also PR #2512 which suggests a slightly different (and probably simpler and better) approach, more in line with how `HiredisParser` works.

See issue #2499 where this problem was pointed out.
