### PR TITLE
Support for resetchannels since Redis 6.2.0

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -193,6 +193,7 @@ class ACLCommands(CommandsProtocol):
         selectors: Optional[Iterable[Tuple[str, KeyT]]] = None,
         reset: bool = False,
         reset_keys: bool = False,
+        reset_channels: bool = False,
         reset_passwords: bool = False,
         **kwargs,
     ) -> ResponseT:
@@ -248,6 +249,12 @@ class ACLCommands(CommandsProtocol):
         key permissions will be kept and any new specified key permissions
         will be applied on top.
 
+        ``reset_channels`` is a boolean indicating whether the user's channel
+        permissions should be reset prior to applying any new channel permissions
+        specified in ``channels``.If this is False, the user's existing
+        channel permissions will be kept and any new specified channel permissions
+        will be applied on top.
+
         ``reset_passwords`` is a boolean indicating whether to remove all
         existing passwords and the 'nopass' flag from the user prior to
         applying any new passwords specified in 'passwords' or
@@ -265,6 +272,9 @@ class ACLCommands(CommandsProtocol):
 
         if reset_keys:
             pieces.append(b"resetkeys")
+
+        if reset_channels:
+            pieces.append(b"resetchannels")
 
         if reset_passwords:
             pieces.append(b"resetpass")


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Add resetchannels for acl command.This parameter refreshes the list of allowed channel modes. It has been supported since version 6.2. It is supported to adapt to the functions of Redis. 
