### PR TITLE
Close a Connection whenever an exception is raised for send_command()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Close Connection on all send_command() errors (#2516)
     * Documentation fix: password protected socket connection (#2374)
     * Allow `timeout=None` in `PubSub.get_message()` to wait forever
     * add `nowait` flag to `asyncio.Connection.disconnect()`

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -763,7 +763,11 @@ class Connection:
             raise ConnectionError(
                 f"Error {err_no} while writing to socket. {errmsg}."
             ) from e
-        except Exception:
+        except BaseException:
+            # The send_packed_command api does not support re-trying a partially
+            # sent message, so there is no point in keeping the connection open.
+            # An unknown number of bytes has been sent and the connection is therefore
+            # unusable.
             await self.disconnect(nowait=True)
             raise
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -778,7 +778,11 @@ class Connection:
                 errno = e.args[0]
                 errmsg = e.args[1]
             raise ConnectionError(f"Error {errno} while writing to socket. {errmsg}.")
-        except Exception:
+        except BaseException:
+            # The send_packed_command api does not support re-trying a partially
+            # sent message, so there is no point in keeping the connection open.
+            # An unknown number of bytes has been sent and the connection is therefore
+            # unusable.
             self.disconnect()
             raise
 


### PR DESCRIPTION
The api does not allow for a "resume", e.g. on a timeout, because an unknown number of bytes has been sent and an internal send state is not maintained.  Therefore, there is no point in keeping the connection open.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

The discussion at #2560 pointed out that there is no way an open Connecition after a failed `send_command()` call can be useful.  This PR therefore closes the `Connection` on _every_ exception in that case, thus partially reverts a change made in #2104
