### PR TITLE
BlockingConnectionPool simplification: use counter instead of connection list

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,7 @@
     * Fix Sentinel.execute_command doesn't execute across the entire sentinel cluster bug (#2458)
     * Added a replacement for the default cluster node in the event of failure (#2463)
     * Fix for Unhandled exception related to self.host with unix socket (#2496)
+    * Simplified connection allocation code for asyncio.connection.BlockingConnectionPool
 
 * 4.1.3 (Feb 8, 2022)
     * Fix flushdb and flushall (#1926)

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -70,7 +70,7 @@ async def test_single_connection():
     mock_conn = mock.MagicMock()
     mock_conn.retry = Retry_()
 
-    async def get_conn(_):
+    async def get_conn(*_):
         # Validate only one client is created in single-client mode when
         # concurrent requests are made
         nonlocal init_call_count
@@ -78,8 +78,8 @@ async def test_single_connection():
         init_call_count += 1
         return mock_conn
 
-    with mock.patch.object(r.connection_pool, "get_connection", get_conn):
-        with mock.patch.object(r.connection_pool, "release"):
+    with mock.patch.object(type(r.connection_pool), "get_connection", get_conn):
+        with mock.patch.object(type(r.connection_pool), "release"):
             await asyncio.gather(r.set("a", "b"), r.set("c", "d"))
 
     assert init_call_count == 1


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
I do not have docker on my machine and i couldn't find a way to make it work with podman. I hope repo CI can run test and catch bugs.
There are a lot of linting errors/warnings about docstring formatting in cluster.py file which I haven't touched.
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
Action doesn't start for my branch. I assume it only works for PRs
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Existing code juggling full queue of `None`s and using extra list to store connections looked weird so I simplified it to use a simple counter to track how many connections were allocated.
Also added slots to pools.

I tested my change with the following code using different `max_connections` values:
```py
import asyncio

from redis import asyncio as redis


async def main() -> None:
    pool = redis.BlockingConnectionPool(max_connections=50)
    async with redis.Redis(connection_pool=pool) as rd:
        await asyncio.gather(*[rd.set(str(i), i) for i in range(200_000)])


asyncio.run(main())
```
It also performs a few % better than existing solution, probably because of slots.