### PR TITLE
Fix AttributeError when trying to split library version

### DIFF
--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -53,7 +53,10 @@ except metadata.PackageNotFoundError:
     __version__ = "99.99.99"
 
 
-VERSION = tuple(map(int_or_str, __version__.split(".")))
+try:
+    VERSION = tuple(map(int_or_str, __version__.split(".")))
+except ValueError:
+    VERSION = tuple(99, 99, 99)
 
 __all__ = [
     "AuthenticationError",


### PR DESCRIPTION
Fallback for issue https://github.com/redis/redis-py/issues/2215

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._

Fallback for splitting __version__ NoneType
