### PR TITLE
Allow replica to master promotion in nodes_cache

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1437,6 +1437,8 @@ class NodesManager:
             if target_node is None or target_node.redis_connection is None:
                 # create new cluster node for this cluster
                 target_node = ClusterNode(host, port, role)
+            if target_node.server_type != role:
+                target_node.server_type = role
 
         return target_node
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
_Please provide a description of the change here._
fixes https://github.com/redis/redis-py/issues/2433

When replica is promoted to master, ClusterNode's server_type must change accordingly, but the current implementation reuses the server_type, so no master is found in nodes_cache after initialization

This PR changes the server_type to a correct value, even if we reuse ClusterNode from nodes_cache

I've personally experienced this scenario, when i changed instance type in AWS Elasticache
  - changing instance type resulted in the addition of a new replica node and that node getting promoted to master

