### PR TITLE
Fix issue 2349: Let async HiredisParser finish parsing after a Connection.disconnect()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Add test and fix async HiredisParser when reading during a disconnect() (#2349)
     * Simplify synchronous SocketBuffer state management
     * Fix string cleanse in Redis Graph
     * Make PythonParser resumable in case of error (#2510)

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -350,13 +350,14 @@ class PythonParser(BaseParser):
 class HiredisParser(BaseParser):
     """Parser class for connections using Hiredis"""
 
-    __slots__ = BaseParser.__slots__ + ("_reader",)
+    __slots__ = BaseParser.__slots__ + ("_reader", "_connected")
 
     def __init__(self, socket_read_size: int):
         if not HIREDIS_AVAILABLE:
             raise RedisError("Hiredis is not available.")
         super().__init__(socket_read_size=socket_read_size)
         self._reader: Optional[hiredis.Reader] = None
+        self._connected: bool = False
 
     def on_connect(self, connection: "Connection"):
         self._stream = connection._reader
@@ -369,13 +370,13 @@ class HiredisParser(BaseParser):
             kwargs["errors"] = connection.encoder.encoding_errors
 
         self._reader = hiredis.Reader(**kwargs)
+        self._connected = True
 
     def on_disconnect(self):
-        self._stream = None
-        self._reader = None
+        self._connected = False
 
     async def can_read_destructive(self):
-        if not self._stream or not self._reader:
+        if not self._connected:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         if self._reader.gets():
             return True
@@ -397,8 +398,10 @@ class HiredisParser(BaseParser):
     async def read_response(
         self, disable_decoding: bool = False
     ) -> Union[EncodableT, List[EncodableT]]:
-        if not self._stream or not self._reader:
-            self.on_disconnect()
+        # If `on_disconnect()` has been called, prohibit any more reads
+        # even if they could happen because data might be present.
+        # We still allow reads in progress to finish
+        if not self._connected:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from None
 
         response = self._reader.gets()

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -158,9 +158,9 @@ async def test_connection_disconect_race(parser_class):
     """
     This test reproduces the case in issue #2349
     where a connection is closed while the parser is reading to feed the
-    internal buffer.The stremam read() will succeed, but when it returns,
-    another task hasalready called `disconnect()` and is waiting for
-    close to finish.  When it attempts to feed the buffer, it will fail
+    internal buffer.The stream `read()` will succeed, but when it returns,
+    another task has already called `disconnect()` and is waiting for
+    close to finish.  When we attempts to feed the buffer, we will fail
     since the buffer is no longer there.
 
     This test verifies that a read in progress can finish even


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This change addresses an issue raised in issue #2349.

It ensures that an async `Connection.read_response()` call can succeed even if a simultaneous `Connection.disconnect()`
call is issued.  Socket disconnects are _graceful_ in that one closes the send direction and can then wait for any data
in transit to arrive, until an EOF is delivered from the remote side.  In `asyncio` parlance this means that to gracefully close a socket, you close the `send` _stream_ and can then read from the `receive` stream until you reach an End Of File.

This change makes sure that the internal `BaseParser` state is maintained so that it can continue to request and parse chunks for as long as it can.   Previously, the HiredisParser would get its internal state cleared immediately, and this would cause the read, in progress, to fail with an unexpected error.  Now an ongoing `read_response()` will continue until it succeeds or encounters an error such as EOF.

A new `read_response()` issued **after** a `disconnect()` call has been issued (but before it completes) will immediately fail, howerver.  This is to maintain previous semantics, even though we **could** simply allow it to go through and fail later when it attemts to read from a closed connection.
