### PR TITLE
Fix issue 2567: NoneType check before raising exception

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -334,11 +334,12 @@ class PythonParser(BaseParser):
         return self._buffer and self._buffer.can_read(timeout)
 
     def read_response(self, disable_decoding=False):
-        pos = self._buffer.get_pos()
+        pos = self._buffer.get_pos() if self._buffer else None
         try:
             result = self._read_response(disable_decoding=disable_decoding)
         except BaseException:
-            self._buffer.rewind(pos)
+            if self._buffer:
+                self._buffer.rewind(pos)
             raise
         else:
             self._buffer.purge()


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

The change made to the read_response function adds a check to ensure that self._buffer is not None before trying to call rewind on it. If self._buffer is None, the call to rewind is skipped and the exception is re-raised as normal.

This change is necessary to prevent the "AttributeError: 'NoneType' object has no attribute 'rewind'" error from being raised if an exception occurs during the call to self._read_response() and the connection to Redis has been closed. Without this check, the rewind call would raise an error because self._buffer would be None, and None does not have a rewind attribute.
