### PR TITLE
if an index error occurs while fetching a node, return master node

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1379,7 +1379,10 @@ class NodesManager:
             # randomly choose one of the replicas
             node_idx = random.randint(1, len(self.slots_cache[slot]) - 1)
 
-        return self.slots_cache[slot][node_idx]
+        try:
+            return self.slots_cache[slot][node_idx]
+        except IndexError:
+            return self.slots_cache[slot][0]
 
     def get_nodes_by_server_type(self, server_type):
         """


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
_Please provide a description of the change here._

When an AWS Elasticache shard is added to an existing cluster, below exception occurs in redis-py.
```
Traceback (most recent call last):
  ...
  File "/usr/lib/python3.8-pyston2.3/site-packages/redis/cluster.py", line 876, in _determine_nodes
    node = self.nodes_manager.get_node_from_slot(
  File "/usr/lib/python3.8-pyston2.3/site-packages/redis/cluster.py", line 1382, in get_node_from_slot
    return self.slots_cache[slot][node_idx]
IndexError: list index out of range
```

The above exception seems to occur, when slots_cache changes dynamically, while get_node_from_slot is being executed.
In order to avoid the above exception, return the primary node, when an IndexError occurs