### PR TITLE
when TimeoutError occurs in get_connection, retry command after node initialization

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1902,7 +1902,7 @@ class ClusterPipeline(RedisCluster):
                     raise_on_error=raise_on_error,
                     allow_redirections=allow_redirections,
                 )
-            except (ClusterDownError, ConnectionError) as e:
+            except (ClusterDownError, ConnectionError, TimeoutError) as e:
                 if retry_attempts > 0:
                     # Try again with the new cluster setup. All other errors
                     # should be raised.
@@ -1967,7 +1967,7 @@ class ClusterPipeline(RedisCluster):
                     redis_node = self.get_redis_connection(node)
                     try:
                         connection = get_connection(redis_node, c.args)
-                    except ConnectionError:
+                    except (ConnectionError, TimeoutError):
                         # Connection retries are being handled in the node's
                         # Retry object. Reinitialize the node -> slot table.
                         self.nodes_manager.initialize()


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
_Please provide a description of the change here._

below exception occurs, when AWS Elasticache instance type is changed
```
Traceback (most recent call last):
  ...
  File "/usr/lib/python3.8-pyston2.3/site-packages/redis/cluster.py", line 1841, in execute
    return self.send_cluster_commands(stack, raise_on_error)
  File "/usr/lib/python3.8-pyston2.3/site-packages/redis/cluster.py", line 1900, in send_cluster_commands
    return self._send_cluster_commands(
  File "/usr/lib/python3.8-pyston2.3/site-packages/redis/cluster.py", line 1969, in _send_cluster_commands
    connection = get_connection(redis_node, c.args)
  File "/usr/lib/python3.8-pyston2.3/site-packages/redis/cluster.py", line 47, in get_connection
    return redis_node.connection or redis_node.connection_pool.get_connection(
  File "/usr/lib/python3.8-pyston2.3/site-packages/redis/connection.py", line 1629, in get_connection
    connection.connect()
  File "/usr/lib/python3.8-pyston2.3/site-packages/redis/connection.py", line 628, in connect
    raise TimeoutError("Timeout connecting to server")
redis.exceptions.TimeoutError: Timeout connecting to server
```

This exception doesn't occur in RedisCluster, but only occurs in ClusterPipeline.

This PR fixes the issue by initializing NodesManager after TimeoutError in get_connection. It also adds TimeoutError to the retry exceptions