### PR TITLE
Speeding up the protocol parsing

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -286,24 +286,24 @@ class PythonParser(BaseParser):
             pass
         # int value
         elif byte == b":":
-            response = int(response)
+            return int(response)
         # bulk response
         elif byte == b"$" and response == b"-1":
             return None
-        elif byte == b"$" and response != b"-1":
+        elif byte == b"$":
             response = await self._read(int(response))
         # multi-bulk response
         elif byte == b"*" and response == b"-1":
             return None
-        elif byte == b"*" and response != b"-1":
+        elif byte == b"*":
             response = [
                 (await self._read_response(disable_decoding))
                 for _ in range(int(response))  # noqa
             ]
-        elif byte not in (b"-", b"+", b":", b"$", b"*"):
+        else:
             raise InvalidResponse(f"Protocol Error: {raw!r}")
 
-        if isinstance(response, bytes) and disable_decoding is False:
+        if disable_decoding is False:
             response = self.encoder.decode(response)
         return response
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -288,16 +288,17 @@ class PythonParser(BaseParser):
         elif byte == b":":
             response = int(response)
         # bulk response
-        elif byte == b"$" and response == b'-1':
-                return None
-        elif byte == b"$" and response != b'-1':
+        elif byte == b"$" and response == b"-1":
+            return None
+        elif byte == b"$" and response != b"-1":
             response = await self._read(int(response))
         # multi-bulk response
-        elif byte == b"*" and response == b'-1':
+        elif byte == b"*" and response == b"-1":
             return None
-        elif byte == b"*" and response != b'-1':
+        elif byte == b"*" and response != b"-1":
             response = [
-                (await self._read_response(disable_decoding)) for _ in range(int(response))
+                (await self._read_response(disable_decoding))
+                for _ in range(int(response))  # noqa
             ]
         elif byte not in (b"-", b"+", b":", b"$", b"*"):
             raise InvalidResponse(f"Protocol Error: {raw!r}")

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -358,9 +358,6 @@ class PythonParser(BaseParser):
 
         byte, response = raw[:1], raw[1:]
 
-        if byte not in (b"-", b"+", b":", b"$", b"*"):
-            raise InvalidResponse(f"Protocol Error: {raw!r}")
-
         # server returned an error
         if byte == b"-":
             response = response.decode("utf-8", errors="replace")
@@ -381,20 +378,21 @@ class PythonParser(BaseParser):
         elif byte == b":":
             response = int(response)
         # bulk response
-        elif byte == b"$":
-            length = int(response)
-            if length == -1:
-                return None
-            response = self._buffer.read(length)
+        elif byte == b"$" and response == b'-1':
+            return None
+        elif byte == b"$" and response != b'-1':
+            response = self._buffer.read(int(response))
         # multi-bulk response
-        elif byte == b"*":
-            length = int(response)
-            if length == -1:
-                return None
+        elif byte == b"*" and response == b'-1':
+            return None
+        elif byte == b"*" and response != b'-1':
             response = [
                 self._read_response(disable_decoding=disable_decoding)
-                for i in range(length)
+                for i in range(int(response))
             ]
+        elif byte not in (b"-", b"+", b":", b"$", b"*"):
+            raise InvalidResponse(f"Protocol Error: {raw!r}")
+
         if isinstance(response, bytes) and disable_decoding is False:
             response = self.encoder.decode(response)
         return response

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -376,24 +376,24 @@ class PythonParser(BaseParser):
             pass
         # int value
         elif byte == b":":
-            response = int(response)
+            return int(response)
         # bulk response
         elif byte == b"$" and response == b"-1":
             return None
-        elif byte == b"$" and response != b"-1":
+        elif byte == b"$":
             response = self._buffer.read(int(response))
         # multi-bulk response
         elif byte == b"*" and response == b"-1":
             return None
-        elif byte == b"*" and response != b"-1":
+        elif byte == b"*":
             response = [
                 self._read_response(disable_decoding=disable_decoding)
                 for i in range(int(response))
             ]
-        elif byte not in (b"-", b"+", b":", b"$", b"*"):
+        else:
             raise InvalidResponse(f"Protocol Error: {raw!r}")
 
-        if isinstance(response, bytes) and disable_decoding is False:
+        if disable_decoding is False:
             response = self.encoder.decode(response)
         return response
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -378,14 +378,14 @@ class PythonParser(BaseParser):
         elif byte == b":":
             response = int(response)
         # bulk response
-        elif byte == b"$" and response == b'-1':
+        elif byte == b"$" and response == b"-1":
             return None
-        elif byte == b"$" and response != b'-1':
+        elif byte == b"$" and response != b"-1":
             response = self._buffer.read(int(response))
         # multi-bulk response
-        elif byte == b"*" and response == b'-1':
+        elif byte == b"*" and response == b"-1":
             return None
-        elif byte == b"*" and response != b'-1':
+        elif byte == b"*" and response != b"-1":
             response = [
                 self._read_response(disable_decoding=disable_decoding)
                 for i in range(int(response))


### PR DESCRIPTION
This PR makes small changes to the protocol parsers. Specifically, this reduces the number of branches, and composite branches (if then if) that happen along the way. 

As part of this change, fewer cast operations now happen, and the response comparison is (when necessary) only on the first byte of the response. This in turn makes the comparison cost lower (memory), and faster, due to the lack of repeated casting.

This is true of both async and sync.

There are no user facing changes.