### PR TITLE
Add payload feature in RediSearch Query class

### DIFF
--- a/redis/commands/search/query.py
+++ b/redis/commands/search/query.py
@@ -37,6 +37,7 @@ class Query:
         self._language = None
         self._expander = None
         self._dialect = None
+        self._payload = None
 
     def query_string(self):
         """Return the query string of this query only."""
@@ -213,6 +214,8 @@ class Query:
             args += ["EXPANDER", self._expander]
         if self._dialect:
             args += ["DIALECT", self._dialect]
+        if self._payload:
+            args += ["PAYLOAD", self._payload]
 
         return args
 
@@ -306,6 +309,15 @@ class Query:
         - **dialect** - dialect version to execute the query under
         """
         self._dialect = dialect
+        return self
+
+    def payload(self, payload):
+        """
+        Add a payload field to the query.
+
+        - **payload** - payload
+        """
+        self._payload = payload
         return self
 
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Simple fix to use RediSearch hamming distance on redis-py
Hamming distance needs payload but redis-py Query class doesn't have that feature.
I know that there are some hacky solutions (e.g. [#2502](https://github.com/redis/redis-py/issues/2502)) and the payload feature is deprecated in RediSearch 2.0.
However, since hamming distance still requires payload, I open this PR.
