### PR TITLE
[docs] ConnectionPool SSL example

### DIFF
--- a/docs/examples/ssl_connection_examples.ipynb
+++ b/docs/examples/ssl_connection_examples.ipynb
@@ -57,6 +57,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "04e70233",
+   "metadata": {},
+   "source": [
+    "## Connecting to a Redis instance using ConnectionPool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2903de26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import redis\n",
+    "redis_pool = redis.ConnectionPool(host=\"localhost\", port=6666, connection_class=redis.SSLConnection)\n",
+    "ssl_connection = redis.StrictRedis(connection_pool=redis_pool) \n",
+    "ssl_connection.ping()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Connecting to a Redis instance via SSL, while specifying a self-signed SSL certificate."


### PR DESCRIPTION
There are several examples on the documentation on how to connect to redis with SSL but ConnectionPool example was missing. This was noted by user aiguofer on issue https://github.com/redis/redis-py/issues/780#issuecomment-767904631
This PR adds an example with ConnectionPool.