### PR TITLE
update json().arrindex() default values

### DIFF
--- a/redis/commands/json/commands.py
+++ b/redis/commands/json/commands.py
@@ -44,9 +44,9 @@ class JSONCommands:
         For more information see `JSON.ARRINDEX <https://redis.io/commands/json.arrindex>`_.
         """  # noqa
         pieces = [name, str(path), self._encode(scalar)]
-        if start:
+        if start is not None:
             pieces.append(start)
-            if stop:
+            if stop is not None:
                 pieces.append(stop)
 
         return self.execute_command("JSON.ARRINDEX", *pieces)

--- a/redis/commands/json/commands.py
+++ b/redis/commands/json/commands.py
@@ -31,8 +31,8 @@ class JSONCommands:
         name: str,
         path: str,
         scalar: int,
-        start: Optional[int] = 0,
-        stop: Optional[int] = -1,
+        start: Optional[int] = None,
+        stop: Optional[int] = None,
     ) -> List[Union[int, None]]:
         """
         Return the index of ``scalar`` in the JSON array under ``path`` at key
@@ -43,9 +43,13 @@ class JSONCommands:
 
         For more information see `JSON.ARRINDEX <https://redis.io/commands/json.arrindex>`_.
         """  # noqa
-        return self.execute_command(
-            "JSON.ARRINDEX", name, str(path), self._encode(scalar), start, stop
-        )
+        pieces = [name, str(path), self._encode(scalar)]
+        if start:
+            pieces.append(start)
+            if stop:
+                pieces.append(stop)
+
+        return self.execute_command("JSON.ARRINDEX", *pieces)
 
     def arrinsert(
         self, name: str, path: str, index: int, *args: List[JsonType]

--- a/tests/test_asyncio/test_json.py
+++ b/tests/test_asyncio/test_json.py
@@ -148,6 +148,11 @@ async def test_arrindex(modclient: redis.Redis):
     await modclient.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
     assert 1 == await modclient.json().arrindex("arr", Path.root_path(), 1)
     assert -1 == await modclient.json().arrindex("arr", Path.root_path(), 1, 2)
+    assert 4 == await modclient.json().arrindex("arr", Path.root_path(), 4)
+    assert 4 == await modclient.json().arrindex("arr", Path.root_path(), 4, start=0)
+    assert 4 == await modclient.json().arrindex("arr", Path.root_path(), 4, start=0, stop=5000)
+    assert -1 == await modclient.json().arrindex("arr", Path.root_path(), 4, start=0, stop=-1)
+    assert -1 == await modclient.json().arrindex("arr", Path.root_path(), 4, start=1, stop=3)
 
 
 @pytest.mark.redismod

--- a/tests/test_asyncio/test_json.py
+++ b/tests/test_asyncio/test_json.py
@@ -145,14 +145,15 @@ async def test_arrappend(modclient: redis.Redis):
 
 @pytest.mark.redismod
 async def test_arrindex(modclient: redis.Redis):
-    await modclient.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
-    assert 1 == await modclient.json().arrindex("arr", Path.root_path(), 1)
-    assert -1 == await modclient.json().arrindex("arr", Path.root_path(), 1, 2)
-    assert 4 == await modclient.json().arrindex("arr", Path.root_path(), 4)
-    assert 4 == await modclient.json().arrindex("arr", Path.root_path(), 4, start=0)
-    assert 4 == await modclient.json().arrindex("arr", Path.root_path(), 4, start=0, stop=5000)
-    assert -1 == await modclient.json().arrindex("arr", Path.root_path(), 4, start=0, stop=-1)
-    assert -1 == await modclient.json().arrindex("arr", Path.root_path(), 4, start=1, stop=3)
+    r_path = Path.root_path()
+    await modclient.json().set("arr", r_path, [0, 1, 2, 3, 4])
+    assert 1 == await modclient.json().arrindex("arr", r_path, 1)
+    assert -1 == await modclient.json().arrindex("arr", r_path, 1, 2)
+    assert 4 == await modclient.json().arrindex("arr", r_path, 4)
+    assert 4 == await modclient.json().arrindex("arr", r_path, 4, start=0)
+    assert 4 == await modclient.json().arrindex("arr", r_path, 4, start=0, stop=5000)
+    assert -1 == await modclient.json().arrindex("arr", r_path, 4, start=0, stop=-1)
+    assert -1 == await modclient.json().arrindex("arr", r_path, 4, start=1, stop=3)
 
 
 @pytest.mark.redismod

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -166,6 +166,8 @@ def test_arrindex(client):
     client.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
     assert 1 == client.json().arrindex("arr", Path.root_path(), 1)
     assert -1 == client.json().arrindex("arr", Path.root_path(), 1, 2)
+    assert 4 == client.json().arrindex("arr", Path.root_path(), 4)
+    # assert -1 == client.json().arrindex("arr", Path.root_path(), 4, start=0, stop=-1)
 
 
 @pytest.mark.redismod

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -167,7 +167,7 @@ def test_arrindex(client):
     assert 1 == client.json().arrindex("arr", Path.root_path(), 1)
     assert -1 == client.json().arrindex("arr", Path.root_path(), 1, 2)
     assert 4 == client.json().arrindex("arr", Path.root_path(), 4)
-    # assert -1 == client.json().arrindex("arr", Path.root_path(), 4, start=0, stop=-1)
+    assert -1 == client.json().arrindex("arr", Path.root_path(), 4, start=0, stop=-1)
 
 
 @pytest.mark.redismod

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -167,7 +167,10 @@ def test_arrindex(client):
     assert 1 == client.json().arrindex("arr", Path.root_path(), 1)
     assert -1 == client.json().arrindex("arr", Path.root_path(), 1, 2)
     assert 4 == client.json().arrindex("arr", Path.root_path(), 4)
+    assert 4 == client.json().arrindex("arr", Path.root_path(), 4, start=0)
+    assert 4 == client.json().arrindex("arr", Path.root_path(), 4, start=0, stop=5000)
     assert -1 == client.json().arrindex("arr", Path.root_path(), 4, start=0, stop=-1)
+    assert -1 == client.json().arrindex("arr", Path.root_path(), 4, start=1, stop=3)
 
 
 @pytest.mark.redismod


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Refactor default `start` / `stop` values in the `json().arrindex()` function. Previously, if `stop` was _unset_, the stop value would default to -1. If the value being searched was the last element in an array, and `stop` was set to -1, the server would reply with -1 instead of the element's index.

eg.: given a json object myarr: `{"l": ["a", "b", "c", "d"]}`:

```
localhost:36379> JSON.ARRINDEX myarr $.l '"d"'            # no start or stop set
1) (integer) 3
localhost:36379> JSON.ARRINDEX myarr $.l '"d"' 0 10000    # stop set to some huge value
1) (integer) 3
localhost:36379> JSON.ARRINDEX myarr $.l '"d"' 0 -1       # stop set to -1
1) (integer) -1
localhost:36379> JSON.ARRINDEX myarr $.l '"d"' 0          # start set to 0, but stop omitted
1) (integer) 3
```

By only appending `start` and `stop` values to the `JSON.ARRINDEX` command if they're set, the python client more closely mimics redis' behaviour. 

Fixes #2481 