### PR TITLE
[types] update return type of smismember to list[int]

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3357,7 +3357,10 @@ class SetCommands(CommandsProtocol):
 
     def smismember(
         self, name: str, values: List, *args: List
-    ) -> Union[Awaitable[List[int]], List[int]]:
+    ) -> Union[
+        Awaitable[List[Union[Literal[0], Literal[1]]]],
+        List[Union[Literal[0], Literal[1]]],
+    ]:
         """
         Return whether each value in ``values`` is a member of the set ``name``
         as a list of ``int`` in the order of ``values``:

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3357,10 +3357,12 @@ class SetCommands(CommandsProtocol):
 
     def smismember(
         self, name: str, values: List, *args: List
-    ) -> Union[Awaitable[List[bool]], List[bool]]:
+    ) -> Union[Awaitable[List[int]], List[int]]:
         """
         Return whether each value in ``values`` is a member of the set ``name``
-        as a list of ``bool`` in the order of ``values``
+        as a list of ``int`` in the order of ``values``:
+        - 1 if the value is a member of the set.
+        - 0 if the value is not a member of the set or if key does not exist.
 
         For more information see https://redis.io/commands/smismember
         """


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

[`smismember`](https://redis.io/commands/smismember/) returns a list of ints (0 or 1), not a list of bools:
<img width="775" alt="image" src="https://user-images.githubusercontent.com/10580207/225167654-7489a020-3ef1-4ee9-8dcc-603553ce9309.png">

- It seems `sismember` returns bool though, so didn't change that.

```
In [10]: redis_client.smismember('key', '1')
Out[10]: [0]

In [11]: redis_client.sismember('key', '1')
Out[11]: False

```

are there plans to make smismember return a `list[bool]` instead? if so I can just close this. thanks!