### PR TITLE
Remove redundant assignment to RedisCluster.nodes_manager.

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -588,7 +588,6 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         self.read_from_replicas = read_from_replicas
         self.reinitialize_counter = 0
         self.reinitialize_steps = reinitialize_steps
-        self.nodes_manager = None
         self.nodes_manager = NodesManager(
             startup_nodes=startup_nodes,
             from_url=from_url,


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Nothing grandiose, but can we just remove that line that keeps bugging me? I don't think assigning `None` to the attribute, only to immediately assign a `NodeManager` instance to the same one, has any meaningful effect, does it?

Of course I'm not adding this to my resume or anything.. just spotted the line while reading through and couldn't help but make a PR.