### PR TITLE
Fix UDS in v4.5.2: UnixDomainSocketConnection missing constructor argument

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1155,8 +1155,9 @@ class SSLConnection(Connection):
 class UnixDomainSocketConnection(AbstractConnection):
     "Manages UDS communication to and from a Redis server"
 
-    def __init__(self, path="", **kwargs):
+    def __init__(self, path="", socket_timeout=None, **kwargs):
         self.path = path
+        self.socket_timeout = socket_timeout
         super().__init__(**kwargs)
 
     def repr_pieces(self):


### PR DESCRIPTION
Closes #2629

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested? (https://github.com/redis/redis-py/pull/2630#issuecomment-1476680383 )
- [ ] ~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~
- [ ] ~Is there an example added to the examples folder (if applicable)?~
- [ ] ~Was the change added to CHANGES file?~

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

`UnixDomainSocketConnection` was missing the `socket_timeout` after the refactoring in https://github.com/redis/redis-py/pull/2588
