### PR TITLE
[CRITICAL][FIX] cancelled response doesn't drain connection

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -853,6 +853,7 @@ class Connection:
         except asyncio.CancelledError:
             # need this check for 3.7, where CancelledError
             # is subclass of Exception, not BaseException
+            await self.disconnect(nowait=True)
             raise
         except Exception:
             await self.disconnect(nowait=True)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Edge case in RedisCluster currently leads to mixed request-responses:
```
import asyncio

from redis.asyncio.cluster import RedisCluster as Redis


async def main():
    r = await Redis.from_url("redis://localhost:7000/0", max_connections=1)

    for i in range(100):
        await r.set(f"foo{i}", f"bar{i}")

    print("running DEBUG SLEEP 2 in a separate terminal")
    import pdb

    pdb.set_trace()
    task = asyncio.create_task(r.get("foo"))
    await asyncio.sleep(0.1)
    task.cancel()

    for i in range(100):
        assert (await r.get(f"foo{i}")).decode() == f"bar{i}"

    print("yay")
```
In this case, a r.get can return the value from a different redis key if the r.get is cancelled after request is sent but before response is received
