### PR TITLE
fix: do not use asyncio's timeout lib before 3.11.2

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -25,7 +25,9 @@ from typing import (
 )
 from urllib.parse import ParseResult, parse_qs, unquote, urlparse
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 11:
+# the functionality is available in 3.11.x but has a major issue before
+# 3.11.3. See https://github.com/redis/redis-py/issues/2633
+if sys.version_info >= (3, 11, 3):
     from asyncio import timeout as async_timeout
 else:
     from async_timeout import timeout as async_timeout

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'importlib-metadata >= 1.0; python_version < "3.8"',
         'typing-extensions; python_version<"3.8"',
-        'async-timeout>=4.0.2; python_version<"3.11"',
+        'async-timeout>=4.0.2; python_version<="3.11.2"',
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -5,7 +5,9 @@ import sys
 from typing import Optional
 from unittest.mock import patch
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 11:
+# the functionality is available in 3.11.x but has a major issue before
+# 3.11.3. See https://github.com/redis/redis-py/issues/2633
+if sys.version_info >= (3, 11, 3):
     from asyncio import timeout as async_timeout
 else:
     from async_timeout import timeout as async_timeout


### PR DESCRIPTION
There's an issue in asyncio's timeout lib before 3.11.3 that causes async calls to raise `CancelledError`.

This is a cpython issue that was fixed in this commit [1] and cherry-picked to previous versions, meaning 3.11.3 will work correctly.

Check [2] for more info.

[1] https://github.com/python/cpython/commit/04adf2df395ded81922c71360a5d66b597471e49
[2] https://github.com/redis/redis-py/issues/2633