### PR TITLE
Fix memory leak caused by hiredis in asyncio case

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * asyncio: Fix memory leak caused by hiredis (#2693)
     * Allow data to drain from async PythonParser when reading during a disconnect()
     * Use asyncio.timeout() instead of async_timeout.timeout() for python >= 3.11 (#2602)
     * Add test and fix async HiredisParser when reading during a disconnect() (#2349)

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -187,12 +187,13 @@ class BaseParser:
         except Exception:
             pass
 
-    def parse_error(self, response: str) -> ResponseError:
+    @classmethod
+    def parse_error(cls, response: str) -> ResponseError:
         """Parse an error response"""
         error_code = response.split(" ")[0]
-        if error_code in self.EXCEPTION_CLASSES:
+        if error_code in cls.EXCEPTION_CLASSES:
             response = response[len(error_code) + 1 :]
-            exception_class = self.EXCEPTION_CLASSES[error_code]
+            exception_class = cls.EXCEPTION_CLASSES[error_code]
             if isinstance(exception_class, dict):
                 exception_class = exception_class.get(response, ResponseError)
             return exception_class(response)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -158,12 +158,13 @@ class BaseParser:
         "NOPERM": NoPermissionError,
     }
 
-    def parse_error(self, response):
+    @classmethod
+    def parse_error(cls, response):
         "Parse an error response"
         error_code = response.split(" ")[0]
-        if error_code in self.EXCEPTION_CLASSES:
+        if error_code in cls.EXCEPTION_CLASSES:
             response = response[len(error_code) + 1 :]
-            exception_class = self.EXCEPTION_CLASSES[error_code]
+            exception_class = cls.EXCEPTION_CLASSES[error_code]
             if isinstance(exception_class, dict):
                 exception_class = exception_class.get(response, ResponseError)
             return exception_class(response)


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [X] Was the change added to CHANGES file?

### Description of change

Change `BaseParser.parse_error` to be a class method, so that no reference is being held from `hiredis.Reader` to the `HiredisParser` instance. This is a workaround until a proper fix in [hiredis-py ](https://github.com/redis/hiredis-py)is implemented (<https://github.com/redis/hiredis-py/pull/163>).