### PR TITLE
Really do not use asyncio's timeout lib before 3.11.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'importlib-metadata >= 1.0; python_version < "3.8"',
         'typing-extensions; python_version<"3.8"',
-        'async-timeout>=4.0.2; python_version<="3.11.2"',
+        'async-timeout>=4.0.2; python_full_version<="3.11.2"',
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This is a follow-up to 480253037afe4c12e38a0f98cadd3019a3724254 / #2659 . There was an issue in asyncio timeout that was fixed in Python 3.11.3. The intent was to pull this package as dependency only on 3.11.2 and earlier.

However, [dependency environment marker `python_version` only considers first two numbers from Python version tuple](https://peps.python.org/pep-0508/). So it compared "3.11" to "3.11.2", evaluated that to True and pulled in dependency even on Python 3.11.3.

Since we want to compare against full version number, `python_full_version` marker should be used instead.

Test case:

```
$ python --version
Python 3.11.3
$ pip install redis
Collecting redis
  Using cached redis-4.5.4-py3-none-any.whl (238 kB)
Collecting async-timeout>=4.0.2
  Using cached async_timeout-4.0.2-py3-none-any.whl (5.8 kB)
Installing collected packages: async-timeout, redis
Successfully installed async-timeout-4.0.2 redis-4.5.4
```

Expected:

```
$ pip install redis
Collecting redis
  Using cached redis-4.5.4-py3-none-any.whl (238 kB)
Installing collected packages: redis
Successfully installed redis-4.5.4
```

