### PR TITLE
Update example of Redisearch creating index

### DIFF
--- a/docs/redismodules.rst
+++ b/docs/redismodules.rst
@@ -119,7 +119,11 @@ below, an index named *my_index* is being created. When an index name is not spe
 
     r = redis.Redis()
     index_name = "my_index"
-    r.ft(index_name).create_index(TextField("play", weight=5.0), TextField("ball"))
+    schema = (
+        TextField("play", weight=5.0),
+        TextField("ball"),
+    )
+    r.ft(index_name).create_index(schema)
     print(r.ft(index_name).info())
 
 


### PR DESCRIPTION
When creating index, fields should be passed inside an iterable (e.g. list or tuple)
otherwise, if passing multiple fields, any field after the first one is not included in the schema when executing `FT.CREATE` command.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Fixed the example, to pass fields inside a tuple (as `schema`), so all the fields get included in the schema when creating index (when executing command `FT.CREATE`)

The existing code:

`r.ft(index_name).create_index(TextField("play", weight=5.0), TextField("ball"))`

results in:

`['FT.CREATE', '1:shoppinghistory:index', 'NOOFFSETS', 'SCHEMA', 'play', 'TEXT', 'WEIGHT', 5.0]`

As you can see, it does not include field `ball`
