### PR TITLE
Add RedisCluster.remap_host_port, Update tests for CWE 404

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -441,7 +441,7 @@ def mock_cluster_resp_slaves(request, **kwargs):
 def master_host(request):
     url = request.config.getoption("--redis-url")
     parts = urlparse(url)
-    yield parts.hostname, parts.port
+    return parts.hostname, (parts.port or 6379)
 
 
 @pytest.fixture()

--- a/tests/test_asyncio/conftest.py
+++ b/tests/test_asyncio/conftest.py
@@ -1,7 +1,6 @@
 import random
 from contextlib import asynccontextmanager as _asynccontextmanager
 from typing import Union
-from urllib.parse import urlparse
 
 import pytest
 import pytest_asyncio
@@ -207,13 +206,6 @@ async def mock_cluster_resp_slaves(create_redis, **kwargs):
         "1447836789290 3 connected']"
     )
     return _gen_cluster_mock_resp(r, response)
-
-
-@pytest_asyncio.fixture(scope="session")
-def master_host(request):
-    url = request.config.getoption("--redis-url")
-    parts = urlparse(url)
-    return parts.hostname
 
 
 async def wait_for_command(

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -136,14 +136,14 @@ class TestConnectionPool:
             assert connection.kwargs == connection_kwargs
 
     async def test_multiple_connections(self, master_host):
-        connection_kwargs = {"host": master_host}
+        connection_kwargs = {"host": master_host[0]}
         async with self.get_pool(connection_kwargs=connection_kwargs) as pool:
             c1 = await pool.get_connection("_")
             c2 = await pool.get_connection("_")
             assert c1 != c2
 
     async def test_max_connections(self, master_host):
-        connection_kwargs = {"host": master_host}
+        connection_kwargs = {"host": master_host[0]}
         async with self.get_pool(
             max_connections=2, connection_kwargs=connection_kwargs
         ) as pool:
@@ -153,7 +153,7 @@ class TestConnectionPool:
                 await pool.get_connection("_")
 
     async def test_reuse_previously_released_connection(self, master_host):
-        connection_kwargs = {"host": master_host}
+        connection_kwargs = {"host": master_host[0]}
         async with self.get_pool(connection_kwargs=connection_kwargs) as pool:
             c1 = await pool.get_connection("_")
             await pool.release(c1)
@@ -237,7 +237,7 @@ class TestBlockingConnectionPool:
 
     async def test_connection_pool_blocks_until_timeout(self, master_host):
         """When out of connections, block for timeout seconds, then raise"""
-        connection_kwargs = {"host": master_host}
+        connection_kwargs = {"host": master_host[0]}
         async with self.get_pool(
             max_connections=1, timeout=0.1, connection_kwargs=connection_kwargs
         ) as pool:
@@ -270,7 +270,7 @@ class TestBlockingConnectionPool:
             assert asyncio.get_running_loop().time() - start >= 0.1
 
     async def test_reuse_previously_released_connection(self, master_host):
-        connection_kwargs = {"host": master_host}
+        connection_kwargs = {"host": master_host[0]}
         async with self.get_pool(connection_kwargs=connection_kwargs) as pool:
             c1 = await pool.get_connection("_")
             await pool.release(c1)

--- a/tests/test_asyncio/test_cwe_404.py
+++ b/tests/test_asyncio/test_cwe_404.py
@@ -120,9 +120,10 @@ async def test_standalone_pipeline(delay, redis_addr):
             pipe.get("bar")
             pipe.ping()
             pipe.get("foo")
-            pipe.reset()
+            await pipe.reset()
 
-            assert await pipe.execute() is None
+            # check that the pipeline is empty after reset
+            assert await pipe.execute() == []
 
             # validating that the pipeline can be used as it could previously
             pipe.get("bar")

--- a/tests/test_asyncio/test_cwe_404.py
+++ b/tests/test_asyncio/test_cwe_404.py
@@ -138,6 +138,7 @@ async def test_standalone(delay, redis_addr):
                 assert await r.get("foo") == b"foo"
 
 
+@pytest.mark.xfail(reason="cancel does not cause disconnect")
 @pytest.mark.onlynoncluster
 @pytest.mark.parametrize("delay", argvalues=[0.05, 0.5, 1, 2])
 async def test_standalone_pipeline(delay, redis_addr):

--- a/tests/test_asyncio/test_cwe_404.py
+++ b/tests/test_asyncio/test_cwe_404.py
@@ -172,8 +172,8 @@ async def test_standalone_pipeline(delay, redis_addr):
                 with pytest.raises(asyncio.CancelledError):
                     await t
 
-                # we have now cancelled the pieline in the middle of a request, make sure
-                # that the connection is still usable
+                # we have now cancelled the pieline in the middle of a request,
+                # make sure that the connection is still usable
                 pipe.get("bar")
                 pipe.ping()
                 pipe.get("foo")

--- a/tests/test_asyncio/test_sentinel.py
+++ b/tests/test_asyncio/test_sentinel.py
@@ -15,7 +15,7 @@ from redis.asyncio.sentinel import (
 
 @pytest_asyncio.fixture(scope="module")
 def master_ip(master_host):
-    yield socket.gethostbyname(master_host)
+    yield socket.gethostbyname(master_host[0])
 
 
 class SentinelTestClient:


### PR DESCRIPTION
### Pull Request check-list

This is a spin-off from PR #2695.  It only contains updates/fixes to the new unittest `test_cwe_404.py` and disables a test which doesn't work currently.

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

- Respect configuration settings
- Add an event to know when DelayProxy has finished sending a chunk to the server
- Default with 0 delay, but turn it on at critical parts (performance)
- Add missing `await` and fix incorrect tests
- Mark still-failing "Pipeline" tests
- Add code to the `RedisCluster` allowing host port remapping so that proxies can be used in front of a cluster.
- Update the "cluster" tests to use a set of DelayProxies, for each cluster node.

This change does not document the "host_port_remap" feature.  It if is considered a worthwhile addition to redis-py on its own, I can put it into a separate PR and add a test and documentation.
