### PR TITLE
Skip 64-bit specific tests for asyncio

### DIFF
--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -2213,6 +2213,7 @@ class TestRedisCommands:
             None,
         ]
 
+    @skip_unless_arch_bits(64)
     @skip_if_server_version_lt("3.2.0")
     async def test_geopos(self, r: redis.Redis):
         values = (2.1909389952632, 41.433791470673, "place1") + (


### PR DESCRIPTION
Same fix as for #899.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

Alternative tests executed: [openSUSE test build](https://build.opensuse.org/package/show/home:AndreasStieger:branches:devel:languages:python/python-redis), [log](https://build.opensuse.org/package/live_build_log/home:AndreasStieger:branches:devel:languages:python/python-redis/openSUSE_Tumbleweed/i586) on top of 4.3.6..

### Description of change

Obvious fix from for #972 from #899 copies to asyncio tests.