### PR TITLE
Fix incorrect usage of once flag in async Sentinel

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Fix incorrect usage of once flag in async Sentinel
     * asyncio: Fix memory leak caused by hiredis (#2693)
     * Allow data to drain from async PythonParser when reading during a disconnect()
     * Use asyncio.timeout() instead of async_timeout.timeout() for python >= 3.11 (#2602)

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -220,13 +220,13 @@ class Sentinel(AsyncSentinelCommands):
             kwargs.pop("once")
 
         if once:
+            await random.choice(self.sentinels).execute_command(*args, **kwargs)
+        else:
             tasks = [
                 asyncio.Task(sentinel.execute_command(*args, **kwargs))
                 for sentinel in self.sentinels
             ]
             await asyncio.gather(*tasks)
-        else:
-            await random.choice(self.sentinels).execute_command(*args, **kwargs)
         return True
 
     def __repr__(self):


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

In the execute_command of the async Sentinel, the once flag was being
used incorrectly, with its meaning inverted (which could also be checked by comparing
with the non-async version), so I just inverted the if and else bodies.

This isn't being caught by the tests currently because the tests of commands
that use this flag do not check their results/effects (for example the "test_ckquorum"
test), but the code is covered. I'm not sure what could be done here, as I'm not yet an expert
with the Sentinel feature, and also I'm not used with the tests in this repo. If this is something that is really
wanted, could you provide some pointers as to how you think we should test this?

In the checklist above, I've left the CI tests unmarked because I do not know how to enable them in my fork, I don't have any experience with Github Actions (I tried, but it seems I need to configure a self-hosted runner? Maybe I'm not looking at the right places).