### PR TITLE
Fix potential race condition during disconnection

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -778,20 +778,22 @@ class AbstractConnection:
     def disconnect(self, *args):
         "Disconnects from the Redis server"
         self._parser.on_disconnect()
-        if self._sock is None:
+
+        conn_sock = self._sock
+        self._sock = None
+        if conn_sock is None:
             return
 
         if os.getpid() == self.pid:
             try:
-                self._sock.shutdown(socket.SHUT_RDWR)
+                conn_sock.shutdown(socket.SHUT_RDWR)
             except OSError:
                 pass
 
         try:
-            self._sock.close()
+            conn_sock.close()
         except OSError:
             pass
-        self._sock = None
 
     def _send_ping(self):
         """Send PING, expect PONG in return"""


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

When the `disconnect()` function is called twice in parallel it is possible that one thread deletes the `self._sock` reference, while the other thread will attempt to call `.close()` on it, leading to an `AttributeError`.

This situation can routinely be encountered by closing the connection in a `PubSubWorkerThread` error handler in a blocking thread (ie. with `sleep_time==None`), and then calling `.close()` on the `PubSub` object. The main thread will then run into the `disconnect()` function, and the listener thread is woken up by the closure and will race into the `disconnect()` function, too.

This can be fixed easily by copying the object reference before doing the `None`-check, [similar to what we do in the `redis.client.close()` function](https://github.com/redis/redis-py/blob/7fc4c76c778163c21d396f99dcc710d99942895f/redis/client.py#L1218-L1228).
