### PR TITLE
add "address_remap" feature to RedisCluster

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Add `address_remap` parameter to `RedisCluster`
     * Fix incorrect usage of once flag in async Sentinel
     * asyncio: Fix memory leak caused by hiredis (#2693)
     * Allow data to drain from async PythonParser when reading during a disconnect()

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -149,6 +149,12 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
           maximum number of connections are already created, a
           :class:`~.MaxConnectionsError` is raised. This error may be retried as defined
           by :attr:`connection_error_retry_attempts`
+    :param address_remap:
+        | An optional callable which, when provided with an internal network
+          address of a node, e.g. a `(host, port)` tuple, will return the address
+          where the node is reachable.  This can be used to map the addresses at
+          which the nodes _think_ they are, to addresses at which a client may
+          reach them, such as when they sit behind a proxy.
 
     | Rest of the arguments will be passed to the
       :class:`~redis.asyncio.connection.Connection` instances when created

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -252,7 +252,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         ssl_certfile: Optional[str] = None,
         ssl_check_hostname: bool = False,
         ssl_keyfile: Optional[str] = None,
-        host_port_remap: Optional[Callable[[str, int], Tuple[str, int]]] = None,
+        address_remap: Optional[Callable[[str, int], Tuple[str, int]]] = None,
     ) -> None:
         if db:
             raise RedisClusterException(
@@ -344,7 +344,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             startup_nodes,
             require_full_coverage,
             kwargs,
-            host_port_remap=host_port_remap,
+            address_remap=address_remap,
         )
         self.encoder = Encoder(encoding, encoding_errors, decode_responses)
         self.read_from_replicas = read_from_replicas
@@ -1067,7 +1067,7 @@ class NodesManager:
         "require_full_coverage",
         "slots_cache",
         "startup_nodes",
-        "host_port_remap",
+        "address_remap",
     )
 
     def __init__(
@@ -1075,12 +1075,12 @@ class NodesManager:
         startup_nodes: List["ClusterNode"],
         require_full_coverage: bool,
         connection_kwargs: Dict[str, Any],
-        host_port_remap: Optional[Callable[[str, int], Tuple[str, int]]] = None,
+        address_remap: Optional[Callable[[str, int], Tuple[str, int]]] = None,
     ) -> None:
         self.startup_nodes = {node.name: node for node in startup_nodes}
         self.require_full_coverage = require_full_coverage
         self.connection_kwargs = connection_kwargs
-        self.host_port_remap = host_port_remap
+        self.address_remap = address_remap
 
         self.default_node: "ClusterNode" = None
         self.nodes_cache: Dict[str, "ClusterNode"] = {}
@@ -1338,8 +1338,8 @@ class NodesManager:
         internal value.  Useful if the client is not connecting directly
         to the cluster.
         """
-        if self.host_port_remap:
-            return self.host_port_remap(host, port)
+        if self.address_remap:
+            return self.address_remap((host, port))
         return host, port
 
 

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -466,7 +466,7 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         read_from_replicas: bool = False,
         dynamic_startup_nodes: bool = True,
         url: Optional[str] = None,
-        host_port_remap: Optional[Callable[[str, int], Tuple[str, int]]] = None,
+        address_remap: Optional[Callable[[str, int], Tuple[str, int]]] = None,
         **kwargs,
     ):
         """
@@ -595,7 +595,7 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
             from_url=from_url,
             require_full_coverage=require_full_coverage,
             dynamic_startup_nodes=dynamic_startup_nodes,
-            host_port_remap=host_port_remap,
+            address_remap=address_remap,
             **kwargs,
         )
 
@@ -1271,7 +1271,7 @@ class NodesManager:
         lock=None,
         dynamic_startup_nodes=True,
         connection_pool_class=ConnectionPool,
-        host_port_remap: Optional[Callable[[str, int], Tuple[str, int]]] = None,
+        address_remap: Optional[Callable[[str, int], Tuple[str, int]]] = None,
         **kwargs,
     ):
         self.nodes_cache = {}
@@ -1283,7 +1283,7 @@ class NodesManager:
         self._require_full_coverage = require_full_coverage
         self._dynamic_startup_nodes = dynamic_startup_nodes
         self.connection_pool_class = connection_pool_class
-        self.host_port_remap = host_port_remap
+        self.address_remap = address_remap
         self._moved_exception = None
         self.connection_kwargs = kwargs
         self.read_load_balancer = LoadBalancer()
@@ -1603,8 +1603,8 @@ class NodesManager:
         internal value.  Useful if the client is not connecting directly
         to the cluster.
         """
-        if self.host_port_remap:
-            return self.host_port_remap(host, port)
+        if self.address_remap:
+            return self.address_remap((host, port))
         return host, port
 
 

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -515,6 +515,12 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
             reinitialize_steps to 1.
             To avoid reinitializing the cluster on moved errors, set
             reinitialize_steps to 0.
+        :param address_remap:
+            An optional callable which, when provided with an internal network
+            address of a node, e.g. a `(host, port)` tuple, will return the address
+            where the node is reachable.  This can be used to map the addresses at
+            which the nodes _think_ they are, to addresses at which a client may
+            reach them, such as when they sit behind a proxy.
 
          :**kwargs:
              Extra arguments that will be sent into Redis instance when created

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -11,7 +11,7 @@ import pytest_asyncio
 from _pytest.fixtures import FixtureRequest
 
 from redis.asyncio.cluster import ClusterNode, NodesManager, RedisCluster
-from redis.asyncio.connection import Connection, SSLConnection
+from redis.asyncio.connection import Connection, SSLConnection, async_timeout
 from redis.asyncio.parser import CommandsParser
 from redis.asyncio.retry import Retry
 from redis.backoff import ExponentialBackoff, NoBackoff, default_backoff
@@ -47,6 +47,71 @@ default_cluster_slots = [
     [0, 8191, ["127.0.0.1", 7000, "node_0"], ["127.0.0.1", 7003, "node_3"]],
     [8192, 16383, ["127.0.0.1", 7001, "node_1"], ["127.0.0.1", 7002, "node_2"]],
 ]
+
+
+class NodeProxy:
+    """A class to proxy a node connection to a different port"""
+
+    def __init__(self, addr, redis_addr):
+        self.addr = addr
+        self.redis_addr = redis_addr
+        self.send_event = asyncio.Event()
+        self.server = None
+        self.task = None
+        self.n_connections = 0
+
+    async def start(self):
+        # test that we can connect to redis
+        async with async_timeout(2):
+            _, redis_writer = await asyncio.open_connection(*self.redis_addr)
+        redis_writer.close()
+        self.server = await asyncio.start_server(
+            self.handle, *self.addr, reuse_address=True
+        )
+        self.task = asyncio.create_task(self.server.serve_forever())
+
+    async def handle(self, reader, writer):
+        # establish connection to redis
+        redis_reader, redis_writer = await asyncio.open_connection(*self.redis_addr)
+        try:
+            self.n_connections += 1
+            pipe1 = asyncio.create_task(self.pipe(reader, redis_writer))
+            pipe2 = asyncio.create_task(self.pipe(redis_reader, writer))
+            await asyncio.gather(pipe1, pipe2)
+        finally:
+            redis_writer.close()
+
+    async def aclose(self):
+        self.task.cancel()
+        try:
+            await self.task
+        except asyncio.CancelledError:
+            pass
+        await self.server.wait_closed()
+
+    async def pipe(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ):
+        while True:
+            data = await reader.read(1000)
+            if not data:
+                break
+            writer.write(data)
+            await writer.drain()
+
+
+@pytest.fixture
+def redis_addr(request):
+    redis_url = request.config.getoption("--redis-url")
+    scheme, netloc = urlparse(redis_url)[:2]
+    assert scheme == "redis"
+    if ":" in netloc:
+        host, port = netloc.split(":")
+        return host, int(port)
+    else:
+        return netloc, 6379
 
 
 @pytest_asyncio.fixture()
@@ -808,6 +873,48 @@ class TestRedisClusterObj:
         assert r.get_default_node() != curr_default_node
         # Rollback to the old default node
         r.replace_default_node(curr_default_node)
+
+    async def test_host_port_remap(self, create_redis, redis_addr):
+        """Test that we can create a rediscluster object with
+        a host-port remapper and map connections through proxy objects
+        """
+
+        # we remap the first n nodes
+        offset = 1000
+        n = 6
+        ports = [redis_addr[1] + i for i in range(n)]
+
+        def host_port_remap(host, port):
+            # remap first three nodes to our local proxy
+            # old = host, port
+            if int(port) in ports:
+                host, port = "127.0.0.1", int(port) + offset
+            # print(f"{old} {host, port}")
+            return host, port
+
+        # create the proxies
+        proxies = [
+            NodeProxy(("127.0.0.1", port + offset), (redis_addr[0], port))
+            for port in ports
+        ]
+        await asyncio.gather(*[p.start() for p in proxies])
+        try:
+            # create cluster:
+            r = await create_redis(
+                cls=RedisCluster, flushdb=False, host_port_remap=host_port_remap
+            )
+            try:
+                assert await r.ping() is True
+                assert await r.set("byte_string", b"giraffe")
+                assert await r.get("byte_string") == b"giraffe"
+            finally:
+                await r.close()
+        finally:
+            await asyncio.gather(*[p.aclose() for p in proxies])
+
+        # verify that the proxies were indeed used
+        n_used = sum((1 if p.n_connections else 0) for p in proxies)
+        assert n_used > 1
 
 
 class TestClusterRedisCommands:

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -874,7 +874,7 @@ class TestRedisClusterObj:
         # Rollback to the old default node
         r.replace_default_node(curr_default_node)
 
-    async def test_host_port_remap(self, create_redis, redis_addr):
+    async def test_address_remap(self, create_redis, redis_addr):
         """Test that we can create a rediscluster object with
         a host-port remapper and map connections through proxy objects
         """
@@ -884,9 +884,10 @@ class TestRedisClusterObj:
         n = 6
         ports = [redis_addr[1] + i for i in range(n)]
 
-        def host_port_remap(host, port):
+        def address_remap(address):
             # remap first three nodes to our local proxy
             # old = host, port
+            host, port = address
             if int(port) in ports:
                 host, port = "127.0.0.1", int(port) + offset
             # print(f"{old} {host, port}")
@@ -901,7 +902,7 @@ class TestRedisClusterObj:
         try:
             # create cluster:
             r = await create_redis(
-                cls=RedisCluster, flushdb=False, host_port_remap=host_port_remap
+                cls=RedisCluster, flushdb=False, address_remap=address_remap
             )
             try:
                 assert await r.ping() is True

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -907,7 +907,7 @@ class TestRedisClusterObj:
         assert "myself" not in nodes.get(curr_default_node.name).get("flags")
         assert r.get_default_node() != curr_default_node
 
-    def test_host_port_remap(self, request, redis_addr):
+    def test_address_remap(self, request, redis_addr):
         """Test that we can create a rediscluster object with
         a host-port remapper and map connections through proxy objects
         """
@@ -917,9 +917,10 @@ class TestRedisClusterObj:
         n = 6
         ports = [redis_addr[1] + i for i in range(n)]
 
-        def host_port_remap(host, port):
+        def address_remap(address):
             # remap first three nodes to our local proxy
             # old = host, port
+            host, port = address
             if int(port) in ports:
                 host, port = "127.0.0.1", int(port) + offset
             # print(f"{old} {host, port}")
@@ -935,7 +936,7 @@ class TestRedisClusterObj:
         try:
             # create cluster:
             r = _get_client(
-                RedisCluster, request, flushdb=False, host_port_remap=host_port_remap
+                RedisCluster, request, flushdb=False, address_remap=address_remap
             )
             try:
                 assert r.ping() is True


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

### Description of change

A new parameter, `address_remap` is added to both both `RedisCluster` and `asyncio.RedisCluster`.  This allows remapping the addresses that the cluster nodes advertise about themselves, to something which is accessible to a client.  For example, the nodes might sit behind a NAT, or a reverse proxy, that the nodes themselves don't know about.  The `address_remap` will ensure that the `RedisCluster` object will connect to the _remapped_ addresses when connecting to the cluster.

This PR could be considered a precursor to  #2695 and #2706  since both of these provide this functionality in order to facilitate unit-tests, albeit only for the `asyncio.RedisCluster`.  Accepting this PR would allow those other PRs to be simplified.

### Reference

This feature is inspired by the `host_port_remap` feature described here: https://redis-py-cluster.readthedocs.io/en/stable/client.html
but we use a more flexible _callback_ based mechanism rather than a dictionary of rules.