### PR TITLE
Fix `ClusterCommandProtocol` not itself being marked as a protocol

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -43,6 +43,7 @@
     * Added a replacement for the default cluster node in the event of failure (#2463)
     * Fix for Unhandled exception related to self.host with unix socket (#2496)
     * Improve error output for master discovery 
+    * Make `ClusterCommandsProtocol` an actual Protocol
 
 * 4.1.3 (Feb 8, 2022)
     * Fix flushdb and flushall (#1926)

--- a/redis/typing.py
+++ b/redis/typing.py
@@ -47,7 +47,7 @@ class CommandsProtocol(Protocol):
         ...
 
 
-class ClusterCommandsProtocol(CommandsProtocol):
+class ClusterCommandsProtocol(CommandsProtocol, Protocol):
     encoder: Union["AsyncEncoder", "Encoder"]
 
     def execute_command(self, *args, **options) -> Union[Any, Awaitable]:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Fix `ClusterCommandProtocol` not itself being marked as a protocol
It should either also subclass `Protocol` to be a protocol, or implement `connection_pool`. Given the name and location of the class, imma assume the former.
![image](https://user-images.githubusercontent.com/1350584/235335739-c09bf01b-bb15-4cbd-bdb7-3c43823a61f2.png)

