### PR TITLE
Fixing CI

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -15,4 +15,5 @@ pytest-cov>=4.0.0
 vulture>=2.3.0
 ujson>=4.2.0
 wheel>=0.30.0
+urllib3<2
 uvloop


### PR DESCRIPTION
Need to pin urllib3 to a version prior to 2.0. tox-docker fails to start dockers due to [this issue](https://github.com/docker/docker-py/issues/3113).