### PR TITLE
Issue #2749: Remove unnecessary __del__ handlers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Fix #2749, remove unnecessary __del__ logic to close connections.
     * Fix #2754, adding a missing argument to SentinelManagedConnection
     * Fix `xadd` command to accept non-negative `maxlen` including 0
     * Revert #2104, #2673, add `disconnect_on_error` option to `read_response()` (issues #2506, #2624)

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -181,12 +181,6 @@ class BaseParser:
         self._read_size = socket_read_size
         self._connected = False
 
-    def __del__(self):
-        try:
-            self.on_disconnect()
-        except Exception:
-            pass
-
     @classmethod
     def parse_error(cls, response: str) -> ResponseError:
         """Parse an error response"""
@@ -569,18 +563,6 @@ class Connection:
         if self.client_name:
             pieces.append(("client_name", self.client_name))
         return pieces
-
-    def __del__(self):
-        try:
-            if self.is_connected:
-                loop = asyncio.get_running_loop()
-                coro = self.disconnect()
-                if loop.is_running():
-                    loop.create_task(coro)
-                else:
-                    loop.run_until_complete(coro)
-        except Exception:
-            pass
 
     @property
     def is_connected(self):


### PR DESCRIPTION
There normally should be no logic attached to del.  Cleanly disconnecting network resources is not needed at that time.

It is possible that this code was added in the past to address some problem, but there are no comments to suggest what they may have been.  As this is only invoked during garbage collection, no one cares anymore whether the socket is cleanly
and correctly closed.  Invoking new background at such time is not good practice.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
