### PR TITLE
Kristjan/issue #2754: Add missing argument to SentinelManagedConnection.read_response()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Fix #2754, adding a missing argument to SentinelManagedConnection
     * Fix `xadd` command to accept non-negative `maxlen` including 0
     * Revert #2104, #2673, add `disconnect_on_error` option to `read_response()` (issues #2506, #2624)
     * Add `address_remap` parameter to `RedisCluster`

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -67,11 +67,14 @@ class SentinelManagedConnection(Connection):
         self,
         disable_decoding: bool = False,
         timeout: Optional[float] = None,
+        *,
+        disconnect_on_error: Optional[float] = True,
     ):
         try:
             return await super().read_response(
                 disable_decoding=disable_decoding,
                 timeout=timeout,
+                disconnect_on_error=disconnect_on_error,
             )
         except ReadOnlyError:
             if self.connection_pool.is_master:

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -1,12 +1,12 @@
 import random
 import weakref
+from typing import Optional
 
 from redis.client import Redis
 from redis.commands import SentinelCommands
 from redis.connection import Connection, ConnectionPool, SSLConnection
 from redis.exceptions import ConnectionError, ReadOnlyError, ResponseError, TimeoutError
 from redis.utils import str_if_bytes
-from typing import Optional
 
 
 class MasterNotFoundError(ConnectionError):

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -6,6 +6,7 @@ from redis.commands import SentinelCommands
 from redis.connection import Connection, ConnectionPool, SSLConnection
 from redis.exceptions import ConnectionError, ReadOnlyError, ResponseError, TimeoutError
 from redis.utils import str_if_bytes
+from typing import Optional
 
 
 class MasterNotFoundError(ConnectionError):
@@ -53,9 +54,14 @@ class SentinelManagedConnection(Connection):
     def connect(self):
         return self.retry.call_with_retry(self._connect_retry, lambda error: None)
 
-    def read_response(self, disable_decoding=False):
+    def read_response(
+        self, disable_decoding=False, *, disconnect_on_error: Optional[bool] = False
+    ):
         try:
-            return super().read_response(disable_decoding=disable_decoding)
+            return super().read_response(
+                disable_decoding=disable_decoding,
+                disconnect_on_error=disconnect_on_error,
+            )
         except ReadOnlyError:
             if self.connection_pool.is_master:
                 # When talking to a master, a ReadOnlyError when likely

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -3051,7 +3051,7 @@ class TestRedisCommands:
         # the task is now sleeping, lets send it an exception
         task.cancel()
         # If all is well, the task should finish right away, otherwise fail with Timeout
-        async with async_timeout(0.1):
+        async with async_timeout(1.0):
             await task
 
 


### PR DESCRIPTION
We add a `disconnect_on_error` argument to `SentinelManagedConnection.read_response()`,
both sync and `asyncio` versions, to allow Sentinel connections to be used with `PubSub`

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
