### PR TITLE
Fixing asyncio import

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -15,4 +15,5 @@ pytest-cov>=4.0.0
 vulture>=2.3.0
 ujson>=4.2.0
 wheel>=0.30.0
+urllib3<2
 uvloop

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -3,6 +3,7 @@ import sys
 from redis.backoff import default_backoff
 from redis.client import Redis, StrictRedis
 from redis.cluster import RedisCluster
+from redis import asyncio
 from redis.connection import (
     BlockingConnectionPool,
     Connection,

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
+from redis import asyncio  # noqa
 from redis.backoff import default_backoff
 from redis.client import Redis, StrictRedis
 from redis.cluster import RedisCluster
-from redis import asyncio  # noqa
 from redis.connection import (
     BlockingConnectionPool,
     Connection,

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -3,7 +3,7 @@ import sys
 from redis.backoff import default_backoff
 from redis.client import Redis, StrictRedis
 from redis.cluster import RedisCluster
-from redis import asyncio
+from redis import asyncio  # noqa
 from redis.connection import (
     BlockingConnectionPool,
     Connection,


### PR DESCRIPTION
This PR should make it possible to:

```
import redis

r = redis.asyncio.Redis()
```

It may also improve dot completion