### PR TITLE
Removing compat

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -16,9 +16,11 @@ from typing import (
     MutableMapping,
     NoReturn,
     Optional,
+    Protocol,
     Set,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -45,7 +47,6 @@ from redis.commands import (
     AsyncSentinelCommands,
     list_or_args,
 )
-from redis.compat import Protocol, TypedDict
 from redis.credentials import CredentialProvider
 from redis.exceptions import (
     ConnectionError,

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -30,10 +30,10 @@ if sys.version_info.major >= 3 and sys.version_info.minor >= 11:
 else:
     from async_timeout import timeout as async_timeout
 
+from typing import Protocol, TypedDict
 
 from redis.asyncio.retry import Retry
 from redis.backoff import NoBackoff
-from redis.compat import Protocol, TypedDict
 from redis.credentials import CredentialProvider, UsernamePasswordCredentialProvider
 from redis.exceptions import (
     AuthenticationError,

--- a/redis/commands/cluster.py
+++ b/redis/commands/cluster.py
@@ -7,13 +7,13 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     Mapping,
     NoReturn,
     Optional,
     Union,
 )
 
-from redis.compat import Literal
 from redis.crc import key_slot
 from redis.exceptions import RedisClusterException, RedisError
 from redis.typing import (

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -4288,7 +4288,7 @@ class SortedSetCommands(CommandsProtocol):
         """
         if timeout is None:
             timeout = 0
-        keys: list[EncodableT] = list_or_args(keys, None)
+        keys = list_or_args(keys, None)
         keys.append(timeout)
         return self.execute_command("BZPOPMIN", *keys)
 

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -13,6 +13,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -21,7 +22,6 @@ from typing import (
     Union,
 )
 
-from redis.compat import Literal
 from redis.exceptions import ConnectionError, DataError, NoScriptError, RedisError
 from redis.typing import (
     AbsExpiryT,

--- a/redis/compat.py
+++ b/redis/compat.py
@@ -1,9 +1,0 @@
-# flake8: noqa
-try:
-    from typing import Literal, Protocol, TypedDict  # lgtm [py/unused-import]
-except ImportError:
-    from typing_extensions import (  # lgtm [py/unused-import]
-        Literal,
-        Protocol,
-        TypedDict,
-    )

--- a/redis/parsers/hiredis.py
+++ b/redis/parsers/hiredis.py
@@ -8,7 +8,7 @@ if sys.version_info.major >= 3 and sys.version_info.minor >= 11:
 else:
     from async_timeout import timeout as async_timeout
 
-from redis.compat import TypedDict
+from typing import TypedDict
 
 from ..exceptions import ConnectionError, InvalidResponse, RedisError
 from ..typing import EncodableT

--- a/redis/typing.py
+++ b/redis/typing.py
@@ -7,12 +7,11 @@ from typing import (
     Awaitable,
     Iterable,
     Mapping,
+    Protocol,
     Type,
     TypeVar,
     Union,
 )
-
-from redis.compat import Protocol
 
 if TYPE_CHECKING:
     from redis.asyncio.connection import ConnectionPool as AsyncConnectionPool

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 async-timeout>=4.0.2
-typing-extensions; python_version<"3.8"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         'importlib-metadata >= 1.0; python_version < "3.8"',
-        'typing-extensions; python_version<"3.8"',
         'async-timeout>=4.0.2; python_version<"3.11"',
     ],
     classifiers=[


### PR DESCRIPTION
compat was used to handle type loading - but those types are provided by typing. We need to run these through the python 3.7 tests, because it may fail entirely there - so this is a draft PR.