### PR TITLE
Docstring formatting fix

### DIFF
--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -131,6 +131,7 @@ class AskError(ResponseError):
     pertain to this hash slot, but only if the key in question exists,
     otherwise the query is forwarded using a -ASK redirection to the node that
     is target of the migration.
+
     src node: MIGRATING to dst node
         get > ASK error
         ask dst node > ASKING command


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?


### Description of change
Minor change: found while working on an unrelated item.

I think the formatting shown in the changed screenshot is closer to what the author intended for the rendered docstring

#### before

![image](https://github.com/redis/redis-py/assets/5386001/5810dd5b-41b9-4460-aae7-9c974dedd695)

#### this change

![image](https://github.com/redis/redis-py/assets/5386001/ef9cf1a7-110b-41d4-8417-0fba8a629d58)
