### PR TITLE
Fix type hints in SearchCommands

### DIFF
--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -385,7 +385,10 @@ class SearchCommands:
                 args.append(value)
         return args
 
-    def _mk_query_args(self, query, query_params: Union[Dict[str, Union[str, int, float, bytes]], None]):
+    def _mk_query_args(
+        self, 
+        query,
+        query_params: Union[Dict[str, Union[str, int, float, bytes]], None]):
         args = [self.index_name]
 
         if isinstance(query, str):

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -372,7 +372,7 @@ class SearchCommands:
         return dict(zip(it, it))
 
     def get_params_args(
-        self, query_params: Union[Dict[str, Union[str, int, float]], None]
+        self, query_params: Union[Dict[str, Union[str, int, float, bytes]], None]
     ):
         if query_params is None:
             return []
@@ -385,7 +385,7 @@ class SearchCommands:
                 args.append(value)
         return args
 
-    def _mk_query_args(self, query, query_params: Dict[str, Union[str, int, float]]):
+    def _mk_query_args(self, query, query_params: Union[Dict[str, Union[str, int, float, bytes]], None]):
         args = [self.index_name]
 
         if isinstance(query, str):
@@ -402,7 +402,7 @@ class SearchCommands:
     def search(
         self,
         query: Union[str, Query],
-        query_params: Dict[str, Union[str, int, float]] = None,
+        query_params: Union[Dict[str, Union[str, int, float, bytes]], None] = None,
     ):
         """
         Search the index for a given query, and return a result of documents

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -386,9 +386,8 @@ class SearchCommands:
         return args
 
     def _mk_query_args(
-        self, 
-        query,
-        query_params: Union[Dict[str, Union[str, int, float, bytes]], None]):
+        self, query, query_params: Union[Dict[str, Union[str, int, float, bytes]], None]
+    ):
         args = [self.index_name]
 
         if isinstance(query, str):


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

According to this https://redis-py.readthedocs.io/en/stable/examples/search_vector_similarity_examples.html#KNN-Queries, there is a missmatch between the type hints of the method and the actual expected usage. This makes mypy complain when being used