### PR TITLE
Adds doctest examples for the hash tutorial

### DIFF
--- a/doctests/README.md
+++ b/doctests/README.md
@@ -16,8 +16,8 @@ Examples are standalone python scripts, committed to the *doctests* directory. T
 ```requirements.txt``` and ```dev_requirements.txt``` from this repository have been installed, as per below.
 
 ```bash
-pip install requirements.txt
-pip install dev_requirements.txt
+pip install -r requirements.txt
+pip install -r dev_requirements.txt
 ```
 
 Note - the CI process, runs the basic ```black``` and ```isort``` linters against the examples. Assuming 

--- a/doctests/dt_hash.py
+++ b/doctests/dt_hash.py
@@ -14,7 +14,8 @@ res1 = r.hset(
         "price": 4972,
     },
 )
-print(res1)  # 4
+print(res1)  
+# >>> 4
 
 res2 = r.hget("bike:1", "model")
 print(res2)
@@ -25,9 +26,7 @@ print(res3)
 # >>> '4972'
 
 res4 = r.hgetall("bike:1")
-print(
-    res4
-)  
+print(res4)  
 # >>> {'model': 'Deimos', 'brand': 'Ergonom', 'type': 'Enduro bikes', 'price': '4972'}
 
 # STEP_END
@@ -46,7 +45,8 @@ assert res4 == {
 
 # STEP_START hmget
 res5 = r.hmget("bike:1", ["model", "price"])
-print(res5)  # ['Deimos', '4972']
+print(res5)  
+# >>> ['Deimos', '4972']
 # STEP_END
 
 # REMOVE_START
@@ -55,9 +55,11 @@ assert res5 == ["Deimos", "4972"]
 
 # STEP_START hincrby
 res6 = r.hincrby("bike:1", "price", 100)
-print(res6)  # 5072
+print(res6)  
+# >>> 5072
 res7 = r.hincrby("bike:1", "price", -100)
-print(res7)  # 4972
+print(res7)  
+# >>> 4972
 # STEP_END
 
 # REMOVE_START
@@ -68,19 +70,26 @@ assert res7 == 4972
 
 # STEP_START incrby_get_mget
 res11 = r.hincrby("bike:1:stats", "rides", 1)
-print(res11)  # 1
+print(res11)  
+# >>> 1
 res12 = r.hincrby("bike:1:stats", "rides", 1)
-print(res12)  # 2
+print(res12)  
+# >>> 2
 res13 = r.hincrby("bike:1:stats", "rides", 1)
-print(res13)  # 3
+print(res13)  
+# >>> 3
 res14 = r.hincrby("bike:1:stats", "crashes", 1)
-print(res14)  # 1
+print(res14)  
+# >>> 1
 res15 = r.hincrby("bike:1:stats", "owners", 1)
-print(res15)  # 1
+print(res15)  
+# >>> 1
 res16 = r.hget("bike:1:stats", "rides")
-print(res16)  # 3
+print(res16)  
+# >>> 3
 res17 = r.hmget("bike:1:stats", ["crashes", "owners"])
-print(res17)  # ['1', '1']
+print(res17)  
+# >>> ['1', '1']
 # STEP_END
 
 # REMOVE_START

--- a/doctests/dt_hash.py
+++ b/doctests/dt_hash.py
@@ -14,7 +14,7 @@ res1 = r.hset(
         "price": 4972,
     },
 )
-print(res1)  
+print(res1)
 # >>> 4
 
 res2 = r.hget("bike:1", "model")
@@ -22,11 +22,11 @@ print(res2)
 # >>> 'Deimos'
 
 res3 = r.hget("bike:1", "price")
-print(res3)  
+print(res3)
 # >>> '4972'
 
 res4 = r.hgetall("bike:1")
-print(res4)  
+print(res4)
 # >>> {'model': 'Deimos', 'brand': 'Ergonom', 'type': 'Enduro bikes', 'price': '4972'}
 
 # STEP_END
@@ -45,7 +45,7 @@ assert res4 == {
 
 # STEP_START hmget
 res5 = r.hmget("bike:1", ["model", "price"])
-print(res5)  
+print(res5)
 # >>> ['Deimos', '4972']
 # STEP_END
 
@@ -55,10 +55,10 @@ assert res5 == ["Deimos", "4972"]
 
 # STEP_START hincrby
 res6 = r.hincrby("bike:1", "price", 100)
-print(res6)  
+print(res6)
 # >>> 5072
 res7 = r.hincrby("bike:1", "price", -100)
-print(res7)  
+print(res7)
 # >>> 4972
 # STEP_END
 
@@ -70,25 +70,25 @@ assert res7 == 4972
 
 # STEP_START incrby_get_mget
 res11 = r.hincrby("bike:1:stats", "rides", 1)
-print(res11)  
+print(res11)
 # >>> 1
 res12 = r.hincrby("bike:1:stats", "rides", 1)
-print(res12)  
+print(res12)
 # >>> 2
 res13 = r.hincrby("bike:1:stats", "rides", 1)
-print(res13)  
+print(res13)
 # >>> 3
 res14 = r.hincrby("bike:1:stats", "crashes", 1)
-print(res14)  
+print(res14)
 # >>> 1
 res15 = r.hincrby("bike:1:stats", "owners", 1)
-print(res15)  
+print(res15)
 # >>> 1
 res16 = r.hget("bike:1:stats", "rides")
-print(res16)  
+print(res16)
 # >>> 3
 res17 = r.hmget("bike:1:stats", ["crashes", "owners"])
-print(res17)  
+print(res17)
 # >>> ['1', '1']
 # STEP_END
 

--- a/doctests/dt_hash.py
+++ b/doctests/dt_hash.py
@@ -23,8 +23,9 @@ res3 = r.hget("bike:1", "price")
 print(res3)  # '4972'
 
 res4 = r.hgetall("bike:1")
-print(res4)  
-#  {'model': 'Deimos', 'brand': 'Ergonom', 'type': 'Enduro bikes', 'price': '4972'}
+print(
+    res4
+)  #  {'model': 'Deimos', 'brand': 'Ergonom', 'type': 'Enduro bikes', 'price': '4972'}
 
 # STEP_END
 

--- a/doctests/dt_hash.py
+++ b/doctests/dt_hash.py
@@ -1,0 +1,90 @@
+# EXAMPLE: hash_tutorial
+# HIDE_START
+import redis
+
+r = redis.Redis(decode_responses=True)
+# HIDE_END
+# STEP_START set_get_getall
+res1 = r.hset(
+    "bike:1",
+    mapping={
+        "model": "Deimos",
+        "brand": "Ergonom",
+        "type": "Enduro bikes",
+        "price": 4972,
+    },
+)
+print(res1)  # 4
+
+res2 = r.hget("bike:1", "model")
+print(res2)  # 'Deimos'
+
+res3 = r.hget("bike:1", "price")
+print(res3)  # '4972'
+
+res4 = r.hgetall("bike:1")
+print(
+    res4
+)  #  {'model': 'Deimos', 'brand': 'Ergonom', 'type': 'Enduro bikes', 'price': '4972'}
+# STEP_END
+
+# REMOVE_START
+assert res1 == 4
+assert res2 == "Deimos"
+assert res3 == "4972"
+assert res4 == {
+    "model": "Deimos",
+    "brand": "Ergonom",
+    "type": "Enduro bikes",
+    "price": "4972",
+}
+# REMOVE_END
+
+# STEP_START hmget
+res5 = r.hmget("bike:1", ["model", "price"])
+print(res5)  # ['Deimos', '4972']
+# STEP_END
+
+# REMOVE_START
+assert res5 == ["Deimos", "4972"]
+# REMOVE_END
+
+# STEP_START hincrby
+res6 = r.hincrby("bike:1", "price", 100)
+print(res6)  # 5072
+res7 = r.hincrby("bike:1", "price", -100)
+print(res7)  # 4972
+# STEP_END
+
+# REMOVE_START
+assert res6 == 5072
+assert res7 == 4972
+# REMOVE_END
+
+
+# STEP_START incryby_get_mget
+res11 = r.hincrby("bike:1:stats", "rides", 1)
+print(res11)  # 1
+res12 = r.hincrby("bike:1:stats", "rides", 1)
+print(res12)  # 2
+res13 = r.hincrby("bike:1:stats", "rides", 1)
+print(res13)  # 3
+res14 = r.hincrby("bike:1:stats", "crashes", 1)
+print(res14)  # 1
+res15 = r.hincrby("bike:1:stats", "owners", 1)
+print(res15)  # 1
+res16 = r.hget("bike:1:stats", "rides")
+print(res16)  # 3
+res17 = r.hmget("bike:1:stats", ["crashes", "owners"])
+print(res17)  # ['1', '1']
+# STEP_END
+
+# REMOVE_START
+assert res11 == 1
+assert res12 == 2
+assert res13 == 3
+assert res14 == 1
+assert res15 == 1
+assert res16 == "3"
+assert res17 == ["1", "1"]
+# REMOVE_END

--- a/doctests/dt_hash.py
+++ b/doctests/dt_hash.py
@@ -17,15 +17,18 @@ res1 = r.hset(
 print(res1)  # 4
 
 res2 = r.hget("bike:1", "model")
-print(res2)  # 'Deimos'
+print(res2)
+# >>> 'Deimos'
 
 res3 = r.hget("bike:1", "price")
-print(res3)  # '4972'
+print(res3)  
+# >>> '4972'
 
 res4 = r.hgetall("bike:1")
 print(
     res4
-)  #  {'model': 'Deimos', 'brand': 'Ergonom', 'type': 'Enduro bikes', 'price': '4972'}
+)  
+# >>> {'model': 'Deimos', 'brand': 'Ergonom', 'type': 'Enduro bikes', 'price': '4972'}
 
 # STEP_END
 

--- a/doctests/dt_hash.py
+++ b/doctests/dt_hash.py
@@ -4,7 +4,7 @@ import redis
 
 r = redis.Redis(decode_responses=True)
 # HIDE_END
-# STEP_START set_get_getall
+# STEP_START set_get_all
 res1 = r.hset(
     "bike:1",
     mapping={
@@ -23,9 +23,9 @@ res3 = r.hget("bike:1", "price")
 print(res3)  # '4972'
 
 res4 = r.hgetall("bike:1")
-print(
-    res4
-)  #  {'model': 'Deimos', 'brand': 'Ergonom', 'type': 'Enduro bikes', 'price': '4972'}
+print(res4)  
+#  {'model': 'Deimos', 'brand': 'Ergonom', 'type': 'Enduro bikes', 'price': '4972'}
+
 # STEP_END
 
 # REMOVE_START
@@ -62,7 +62,7 @@ assert res7 == 4972
 # REMOVE_END
 
 
-# STEP_START incryby_get_mget
+# STEP_START incrby_get_mget
 res11 = r.hincrby("bike:1:stats", "rides", 1)
 print(res11)  # 1
 res12 = r.hincrby("bike:1:stats", "rides", 1)


### PR DESCRIPTION
creating the python hash data type examples that will be used in conjunction with the hashes.md file in docs to show tabbed examples

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
Adding the python examples to be used in tabbed examples for the hash datatype.