### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@
     * asyncio: Fix memory leak caused by hiredis (#2693)
     * Allow data to drain from async PythonParser when reading during a disconnect()
     * Use asyncio.timeout() instead of async_timeout.timeout() for python >= 3.11 (#2602)
+    * Add a Dependabot configuration to auto-update GitHub action versions.
     * Add test and fix async HiredisParser when reading during a disconnect() (#2349)
     * Use hiredis-py pack_command if available.
     * Support `.unlink()` in ClusterPipeline


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

**Note: This PR introduces no code changes**

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._

I observed that several GitHub actions are using old versions and are emitting Node 12 deprecation warnings (recent examples: [actions/upload-artifact in `integration.yaml`](https://github.com/redis/redis-py/actions/runs/5549535174) and [actions/stale in `stale-issues.yml`](https://github.com/redis/redis-py/actions/runs/5559377638)).

Rather than address these with a one-off PR, I've introduced a Dependabot configuration that will regularly submit PRs to keep actions up-to-date. If this PR is merged, you can anticipate that Dependabot will immediately submit several PRs to update individual actions.

As this change does not touch code nor directly modify the CI test suite, I don't think most of the checkboxes above are applicable. I've read through the contributing doc and think I've followed the document, but please let me know if there's anything additional that needs to be done! :grinning: 

Thanks for your work on redis-py!