### PR TITLE
Fix socket garbage collection

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-    * Fix #2831, closing connections and sockets when garbage collected.
+    * Fix #2831, add auto_close_connection_pool=True arg to asyncio.Redis.from_url()
     * Fix incorrect redis.asyncio.Cluster type hint for `retry_on_error`
     * Fix dead weakref in sentinel connection causing ReferenceError (#2767)
     * Fix #2768, Fix KeyError: 'first-entry' in parse_xinfo_stream.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Fix #2831, closing connections and sockets when garbage collected.
     * Fix incorrect redis.asyncio.Cluster type hint for `retry_on_error`
     * Fix dead weakref in sentinel connection causing ReferenceError (#2767)
     * Fix #2768, Fix KeyError: 'first-entry' in parse_xinfo_stream.

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -104,7 +104,13 @@ class Redis(
     response_callbacks: MutableMapping[Union[str, bytes], ResponseCallbackT]
 
     @classmethod
-    def from_url(cls, url: str, **kwargs):
+    def from_url(
+        cls,
+        url: str,
+        single_connection_client: bool = False,
+        auto_close_connection_pool: bool = True,
+        **kwargs,
+    ):
         """
         Return a Redis client object configured from the given URL
 
@@ -144,8 +150,6 @@ class Redis(
         arguments always win.
 
         """
-        single_connection_client = kwargs.pop("single_connection_client", False)
-        auto_close_connection_pool = kwargs.pop("auto_close_connection_pool", True)
         connection_pool = ConnectionPool.from_url(url, **kwargs)
         redis = cls(
             connection_pool=connection_pool,

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -146,10 +146,12 @@ class Redis(
         """
         single_connection_client = kwargs.pop("single_connection_client", False)
         connection_pool = ConnectionPool.from_url(url, **kwargs)
-        return cls(
+        redis = cls(
             connection_pool=connection_pool,
             single_connection_client=single_connection_client,
         )
+        redis.auto_close_connection_pool = True
+        return redis
 
     def __init__(
         self,

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -145,12 +145,13 @@ class Redis(
 
         """
         single_connection_client = kwargs.pop("single_connection_client", False)
+        auto_close_connection_pool = kwargs.pop("auto_close_connection_pool", True)
         connection_pool = ConnectionPool.from_url(url, **kwargs)
         redis = cls(
             connection_pool=connection_pool,
             single_connection_client=single_connection_client,
         )
-        redis.auto_close_connection_pool = True
+        redis.auto_close_connection_pool = auto_close_connection_pool
         return redis
 
     def __init__(

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -383,12 +383,16 @@ class AbstractConnection:
     def _close_socket(self):
         """Close the socket directly.  Used during garbage collection to
         make sure the underlying socket is released.  This does not happen
-        reliably when the stream is garbage collected.
+        reliably when the stream is garbage collected.  This is a safety
+        precaution, correct use of the library should ensure that
+        sockets are disconnected properly.
         """
-        if self._writer:
+        # some test classes don't even have this
+        writer = getattr(self, "_writer", None)
+        if writer:
             if os.getpid() == self.pid:
                 try:
-                    self._writer.close()
+                    writer.close()
                 except RuntimeError:
                     # This may fail if the event loop is already closed,
                     # even though this is not an async call.  In this

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -300,6 +300,26 @@ async def test_pool_auto_close(request, from_url):
 
     r1 = await get_redis_connection()
     assert r1.auto_close_connection_pool is True
+    await r1.close()
+
+
+@pytest.mark.parametrize("from_url", (True, False))
+async def test_pool_auto_close_disable(request, from_url):
+    """Verify that auto_close_connection_pool can be disabled"""
+
+    url: str = request.config.getoption("--redis-url")
+    url_args = parse_url(url)
+
+    async def get_redis_connection():
+        if from_url:
+            return Redis.from_url(url, auto_close_connection_pool=False)
+        url_args["auto_close_connection_pool"] = False
+        return Redis(**url_args)
+
+    r1 = await get_redis_connection()
+    assert r1.auto_close_connection_pool is False
+    await r1.connection_pool.disconnect()
+    await r1.close()
 
 
 @pytest.mark.onlynoncluster

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -301,6 +301,7 @@ async def test_pool_auto_close(request, from_url):
     assert r1.auto_close_connection_pool is True
 
 
+@pytest.mark.onlynoncluster
 @pytest.mark.parametrize("from_url", (True, False))
 async def test_connection_socket_cleanup(request, from_url):
     """Verify that connections are cleaned up when they

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -1,4 +1,5 @@
 import asyncio
+import platform
 import socket
 import types
 from unittest.mock import Mock, patch
@@ -307,6 +308,8 @@ async def test_connection_socket_cleanup(request, from_url):
     """Verify that connections are cleaned up when they
     are garbage collected
     """
+    if platform.python_implementation() != "CPython":
+        pytest.skip("only works on CPython")
     url: str = request.config.getoption("--redis-url")
     url_args = parse_url(url)
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -61,6 +61,8 @@ def test_tcp_ssl_connect(tcp_address):
 
 def _assert_connect(conn, server_address, certfile=None, keyfile=None):
     if isinstance(server_address, str):
+        if not _RedisUDSServer:
+            pytest.skip("Unix domain sockets are not supported on this platform")
         server = _RedisUDSServer(server_address, _RedisRequestHandler)
     else:
         server = _RedisTCPServer(
@@ -113,24 +115,29 @@ class _RedisTCPServer(socketserver.TCPServer):
         return connstream, fromaddr
 
 
-class _RedisUDSServer(socketserver.UnixStreamServer):
-    def __init__(self, *args, **kw) -> None:
-        self._ready_event = threading.Event()
-        self._stop_requested = False
-        super().__init__(*args, **kw)
+if hasattr(socket, "UnixStreamServer"):
 
-    def service_actions(self):
-        self._ready_event.set()
+    class _RedisUDSServer(socketserver.UnixStreamServer):
+        def __init__(self, *args, **kw) -> None:
+            self._ready_event = threading.Event()
+            self._stop_requested = False
+            super().__init__(*args, **kw)
 
-    def wait_online(self):
-        self._ready_event.wait()
+        def service_actions(self):
+            self._ready_event.set()
 
-    def stop(self):
-        self._stop_requested = True
-        self.shutdown()
+        def wait_online(self):
+            self._ready_event.wait()
 
-    def is_serving(self):
-        return not self._stop_requested
+        def stop(self):
+            self._stop_requested = True
+            self.shutdown()
+
+        def is_serving(self):
+            return not self._stop_requested
+
+else:
+    _RedisUDSServer = None
 
 
 class _RedisRequestHandler(socketserver.StreamRequestHandler):


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Issue #2831 shows how connections are kept open when they are simply discarded.
The problem is two-fold:

1. Redis connections opened with `from-url` don't have their `auto_close_connection` boolean set to `True`, as is the default for a pool which is created automatically.  Therefore, when `Redis.close()` was called, the pool would not close its collections.
2. Even so, garbage collection of the `Connection` objects _ought_ to have closed the sockets associated with the underlying `StreamWriter` objects.  This apparently does not reliably happen, so we re-instate a `__del__` handler for the `AbstractConnection` which does the bare minimum required, calling `StreamWriter.close()`.
3. Add an `auto_close_connection_pool` argument to `asyncio.Redis.from_url()` which defaults to true, same as for `asyncio.Redis()`

A fix was added to an unrelated test which caused unit tests to fail on non-linux platforms.

###  Update

I've changed the PR so as to remove the _2_, above.  In general for `asyncio` Python, socket cleanup is _not_ done on garbage collection (since it involves async operations).  Instead, it is assumed that a well written program performs proper disconnects as needed.  `__del__` handlers instead are used to emit _warnings_, that is, if a socket (or other resource) is found to be not closed when purging an object, a warning is emitted.  This is to make sure resources are released properly by the application.

 Fixing of (1) above ensures that the connection pool is indeed cleaned up correctly.  Trying to put cleanup and IO logic into destructors is in general not thought to be a good practice and should be avoided whenever possible.  Correct program operation should not rely on the prompt execution of `__del__` handlers, and implementing them would deprive us of the built-in resource warnings which would otherwise be emitted.