### PR TITLE
Dependabot label change

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels:
+      - "maintenance"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
In keeping in theme with the release drafter, dependabot should label things maintenance instead of dependencies