### PR TITLE
Updating client license to clear, MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022, Redis, inc.
+Copyright (c) 2022-2023, Redis, inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request exists to unify all of our clients until the MIT license. In the case of some repositories this is more permissive, than the prior BSD-3-Clause.