### PR TITLE
add pagination, sorting and grouping examples to search json example

### DIFF
--- a/docs/examples/search_json_examples.ipynb
+++ b/docs/examples/search_json_examples.ipynb
@@ -34,7 +34,7 @@
     "from redis.commands.search.query import NumericFilter, Query\n",
     "\n",
     "\n",
-    "r = redis.Redis(host='localhost', port=36379)\n",
+    "r = redis.Redis(host='localhost', port=6379)\n",
     "user1 = {\n",
     "    \"user\":{\n",
     "        \"name\": \"Paul John\",\n",
@@ -59,9 +59,19 @@
     "        \"city\": \"Tel Aviv\"\n",
     "    }\n",
     "}\n",
+    "\n",
+    "user4 = {\n",
+    "    \"user\":{\n",
+    "        \"name\": \"Sarah Zamir\",\n",
+    "        \"email\": \"sarah.zamir@example.com\",\n",
+    "        \"age\": 30,\n",
+    "        \"city\": \"Paris\"\n",
+    "    }\n",
+    "}\n",
     "r.json().set(\"user:1\", Path.root_path(), user1)\n",
     "r.json().set(\"user:2\", Path.root_path(), user2)\n",
     "r.json().set(\"user:3\", Path.root_path(), user3)\n",
+    "r.json().set(\"user:4\", Path.root_path(), user4)\n",
     "\n",
     "schema = (TextField(\"$.user.name\", as_name=\"name\"),TagField(\"$.user.city\", as_name=\"city\"), NumericField(\"$.user.age\", as_name=\"age\"))\n",
     "r.ft().create_index(schema, definition=IndexDefinition(prefix=[\"user:\"], index_type=IndexType.JSON))"
@@ -102,6 +112,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -133,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Projecting using JSON Path expressions "
+    "### Paginating and Ordering search Results"
    ]
   },
   {
@@ -144,11 +155,70 @@
     {
      "data": {
       "text/plain": [
+       "Result{4 total, docs: [Document {'id': 'user:1', 'payload': None, 'age': '42', 'json': '{\"user\":{\"name\":\"Paul John\",\"email\":\"paul.john@example.com\",\"age\":42,\"city\":\"London\"}}'}, Document {'id': 'user:3', 'payload': None, 'age': '35', 'json': '{\"user\":{\"name\":\"Paul Zamir\",\"email\":\"paul.zamir@example.com\",\"age\":35,\"city\":\"Tel Aviv\"}}'}]}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Search for all users, returning 2 users at a time and sorting by age in descending order\n",
+    "offset = 0\n",
+    "num = 2\n",
+    "q = Query(\"*\").paging(offset, num).sort_by(\"age\", asc=False) # pass asc=True to sort in ascending order\n",
+    "r.ft().search(q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Counting the total number of Items"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = Query(\"*\").paging(0, 0)\n",
+    "r.ft().search(q).total"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Projecting using JSON Path expressions "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
        "[Document {'id': 'user:1', 'payload': None, 'city': 'London'},\n",
        " Document {'id': 'user:3', 'payload': None, 'city': 'Tel Aviv'}]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -166,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -175,13 +245,43 @@
        "[[b'age', b'35'], [b'age', b'42']]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "req = aggregations.AggregateRequest(\"Paul\").sort_by(\"@age\")\n",
+    "r.ft().aggregate(req).rows"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Count the total number of Items"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[b'total', b'4']]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The group_by expects a string or list of strings to group the results before applying the aggregation function to\n",
+    "# each group. Passing an empty list here acts as `GROUPBY 0` which applies the aggregation function to the whole results\n",
+    "req = aggregations.AggregateRequest(\"*\").group_by([], reducers.count().alias(\"total\"))\n",
     "r.ft().aggregate(req).rows"
    ]
   }
@@ -191,9 +291,9 @@
    "hash": "d45c99ba0feda92868abafa8257cbb4709c97f1a0b5dc62bbeebdf89d4fad7fe"
   },
   "kernelspec": {
-   "display_name": "Python 3.8.12 64-bit ('venv': venv)",
+   "display_name": "redis-py",
    "language": "python",
-   "name": "python3"
+   "name": "redis-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -205,10 +305,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
-  },
-  "orig_nbformat": 4
+   "version": "3.11.3"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
Added more examples to searching JSON documents illustrating pagination, sorting, ordering of results and using groups to apply aggregation functions
