### PR TITLE
Fix: SentinelManagedConnection.read_response() got an unexpected keyword argument 'push_request'

### DIFF
--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -55,12 +55,17 @@ class SentinelManagedConnection(Connection):
         return self.retry.call_with_retry(self._connect_retry, lambda error: None)
 
     def read_response(
-        self, disable_decoding=False, *, disconnect_on_error: Optional[bool] = False
+        self,
+        disable_decoding=False,
+        *,
+        disconnect_on_error: Optional[bool] = False,
+        push_request: Optional[bool] = False,
     ):
         try:
             return super().read_response(
                 disable_decoding=disable_decoding,
                 disconnect_on_error=disconnect_on_error,
+                push_request=push_request,
             )
         except ReadOnlyError:
             if self.connection_pool.is_master:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

closes #2893 