### PR TITLE
Fix: automatically close connection pool for async Sentinel

### DIFF
--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -335,10 +335,13 @@ class Sentinel(AsyncSentinelCommands):
         kwargs["is_master"] = True
         connection_kwargs = dict(self.connection_kwargs)
         connection_kwargs.update(kwargs)
+
+        connection_pool = connection_pool_class(service_name, self, **connection_kwargs)
+        # The Redis object "owns" the pool
+        auto_close_connection_pool = True
         return redis_class(
-            connection_pool=connection_pool_class(
-                service_name, self, **connection_kwargs
-            )
+            connection_pool=connection_pool,
+            auto_close_connection_pool=auto_close_connection_pool,
         )
 
     def slave_for(
@@ -368,8 +371,11 @@ class Sentinel(AsyncSentinelCommands):
         kwargs["is_master"] = False
         connection_kwargs = dict(self.connection_kwargs)
         connection_kwargs.update(kwargs)
+
+        connection_pool = connection_pool_class(service_name, self, **connection_kwargs)
+        # The Redis object "owns" the pool
+        auto_close_connection_pool = True
         return redis_class(
-            connection_pool=connection_pool_class(
-                service_name, self, **connection_kwargs
-            )
+            connection_pool=connection_pool,
+            auto_close_connection_pool=auto_close_connection_pool,
         )

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -381,4 +381,3 @@ class Sentinel(AsyncSentinelCommands):
         )
         client.auto_close_connection_pool = auto_close_connection_pool
         return client
-

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -339,10 +339,11 @@ class Sentinel(AsyncSentinelCommands):
         connection_pool = connection_pool_class(service_name, self, **connection_kwargs)
         # The Redis object "owns" the pool
         auto_close_connection_pool = True
-        return redis_class(
+        client = redis_class(
             connection_pool=connection_pool,
-            auto_close_connection_pool=auto_close_connection_pool,
         )
+        client.auto_close_connection_pool = auto_close_connection_pool
+        return client
 
     def slave_for(
         self,
@@ -375,7 +376,9 @@ class Sentinel(AsyncSentinelCommands):
         connection_pool = connection_pool_class(service_name, self, **connection_kwargs)
         # The Redis object "owns" the pool
         auto_close_connection_pool = True
-        return redis_class(
+        client = redis_class(
             connection_pool=connection_pool,
-            auto_close_connection_pool=auto_close_connection_pool,
         )
+        client.auto_close_connection_pool = auto_close_connection_pool
+        return client
+

--- a/tests/test_asyncio/test_sentinel.py
+++ b/tests/test_asyncio/test_sentinel.py
@@ -246,7 +246,8 @@ async def test_reset(cluster, sentinel):
 @pytest.mark.parametrize("method_name", ["master_for", "slave_for"])
 async def test_auto_close_pool(cluster, sentinel, method_name):
     """
-    Check that the connection pool created by the sentinel client is automatically closed
+    Check that the connection pool created by the sentinel client is
+    automatically closed
     """
 
     method = getattr(sentinel, method_name)
@@ -259,7 +260,7 @@ async def test_auto_close_pool(cluster, sentinel, method_name):
         nonlocal calls
         calls += 1
 
-    with mock.patch.object(pool, "disconnect", mock_disconnect) as disconnect:
+    with mock.patch.object(pool, "disconnect", mock_disconnect):
         await client.close()
 
     assert calls == 1

--- a/tests/test_asyncio/test_sentinel.py
+++ b/tests/test_asyncio/test_sentinel.py
@@ -1,4 +1,5 @@
 import socket
+from unittest import mock
 
 import pytest
 import pytest_asyncio
@@ -239,3 +240,27 @@ async def test_flushconfig(cluster, sentinel):
 async def test_reset(cluster, sentinel):
     cluster.master["is_odown"] = True
     assert await sentinel.sentinel_reset("mymaster")
+
+
+@pytest.mark.onlynoncluster
+@pytest.mark.parametrize("method_name", ["master_for", "slave_for"])
+async def test_auto_close_pool(cluster, sentinel, method_name):
+    """
+    Check that the connection pool created by the sentinel client is automatically closed
+    """
+
+    method = getattr(sentinel, method_name)
+    client = method("mymaster", db=9)
+    pool = client.connection_pool
+    assert client.auto_close_connection_pool is True
+    calls = 0
+
+    async def mock_disconnect():
+        nonlocal calls
+        calls += 1
+
+    with mock.patch.object(pool, "disconnect", mock_disconnect) as disconnect:
+        await client.close()
+
+    assert calls == 1
+    await pool.disconnect()


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

A `Redis` object returned by `redis.asyncio.sentinel.Sentinel()` has its _own_ `ConnectionPool`, but this is not closed automatically when the `Redis` object goes out of scope.

By setting the `auto_close_connection_pool` Redis attribute, it is ensured that connections are closed properly.

This fixes another issue raised in #2831 

_Please provide a description of the change here._
