### PR TITLE
Fix: unsubscribe/punsubscribe should be async functions in async client

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -899,7 +899,7 @@ class PubSub:
         self.pending_unsubscribe_patterns.difference_update(new_patterns)
         return ret_val
 
-    async def punsubscribe(self, *args: ChannelT) -> Awaitable:
+    async def punsubscribe(self, *args: ChannelT) -> int:
         """
         Unsubscribe from the supplied patterns. If empty, unsubscribe from
         all patterns.
@@ -935,7 +935,7 @@ class PubSub:
         self.pending_unsubscribe_channels.difference_update(new_channels)
         return ret_val
 
-    async def unsubscribe(self, *args) -> Awaitable:
+    async def unsubscribe(self, *args) -> int:
         """
         Unsubscribe from the supplied channels. If empty, unsubscribe from
         all channels

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -899,7 +899,7 @@ class PubSub:
         self.pending_unsubscribe_patterns.difference_update(new_patterns)
         return ret_val
 
-    def punsubscribe(self, *args: ChannelT) -> Awaitable:
+    async def punsubscribe(self, *args: ChannelT) -> Awaitable:
         """
         Unsubscribe from the supplied patterns. If empty, unsubscribe from
         all patterns.
@@ -912,7 +912,7 @@ class PubSub:
             parsed_args = []
             patterns = self.patterns
         self.pending_unsubscribe_patterns.update(patterns)
-        return self.execute_command("PUNSUBSCRIBE", *parsed_args)
+        return await self.execute_command("PUNSUBSCRIBE", *parsed_args)
 
     async def subscribe(self, *args: ChannelT, **kwargs: Callable):
         """
@@ -935,7 +935,7 @@ class PubSub:
         self.pending_unsubscribe_channels.difference_update(new_channels)
         return ret_val
 
-    def unsubscribe(self, *args) -> Awaitable:
+    async def unsubscribe(self, *args) -> Awaitable:
         """
         Unsubscribe from the supplied channels. If empty, unsubscribe from
         all channels
@@ -947,7 +947,7 @@ class PubSub:
             parsed_args = []
             channels = self.channels
         self.pending_unsubscribe_channels.update(channels)
-        return self.execute_command("UNSUBSCRIBE", *parsed_args)
+        return await self.execute_command("UNSUBSCRIBE", *parsed_args)
 
     async def listen(self) -> AsyncIterator:
         """Listen for messages on channels this client has been subscribed to"""


### PR DESCRIPTION
`execute_command()` is an `async` function; since `unsubscribe()` and `punsubscribe()` call it, they should be `async` functions, and should `await` `execute_command()`.

---

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
