### PR TITLE
Add aliases for nonatomic versions of mget/mset

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -54,6 +54,7 @@
     * Fix for Unhandled exception related to self.host with unix socket (#2496)
     * Improve error output for master discovery 
     * Make `ClusterCommandsProtocol` an actual Protocol
+    * Add alias for Redis version of mget_nonatomic/mset_nonatomic
 
 * 4.1.3 (Feb 8, 2022)
   * Fix flushdb and flushall (#1926)

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -2014,6 +2014,8 @@ class BasicKeyCommands(CommandsProtocol):
             options[EMPTY_RESPONSE] = []
         return self.execute_command("MGET", *args, **options)
 
+    mget_nonatomic = mget
+
     def mset(self, mapping: Mapping[AnyKeyT, EncodableT]) -> ResponseT:
         """
         Sets key/values based on a mapping. Mapping is a dictionary of
@@ -2026,6 +2028,8 @@ class BasicKeyCommands(CommandsProtocol):
         for pair in mapping.items():
             items.extend(pair)
         return self.execute_command("MSET", *items)
+
+    mset_nonatomic = mset
 
     def msetnx(self, mapping: Mapping[AnyKeyT, EncodableT]) -> ResponseT:
         """


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `$ tox` pass with this change (including linting)? `Not sure how to run this but I believe it's ok`
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)? `Not sure how to run these`
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? `Don't believe there's a needed change here`
- [ ] Is there an example added to the examples folder (if applicable)? `Existing example should suffice`
- [X] Was the change added to CHANGES file?

### Description of change

RedisCluster provides functions for handling when multiple keys are used with separate key slots, so alias the single server versions so code can use them without caring which type of server is running
