### PR TITLE
Add `Redis.from_pool()` class method, for explicitly owning and closing a ConnectionPool

### DIFF
--- a/docs/examples/asyncio_examples.ipynb
+++ b/docs/examples/asyncio_examples.ipynb
@@ -46,6 +46,26 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you create custom `ConnectionPool` for the `Redis` instance to use, use the `from_pool` argument.  This will cause the pool to be disconnected along with the Redis instance. Disconnecting the connection pool simply disconnects all connections hosted in the pool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import redis.asyncio as redis\n",
+    "\n",
+    "pool = redis.ConnectionPool.from_url(\"redis://localhost\")\n",
+    "connection = redis.Redis(from_pool=pool)\n",
+    "await connection.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -53,7 +73,8 @@
     }
    },
    "source": [
-    "If you supply a custom `ConnectionPool` that is supplied to several `Redis` instances, you may want to disconnect the connection pool explicitly. Disconnecting the connection pool simply disconnects all connections hosted in the pool."
+    "\n",
+    "However, If you supply a `ConnectionPool` that is shared several `Redis` instances, you may want to disconnect the connection pool explicitly. use the `connection_pool` argument in that case."
    ]
   },
   {
@@ -69,10 +90,12 @@
    "source": [
     "import redis.asyncio as redis\n",
     "\n",
-    "connection = redis.Redis(auto_close_connection_pool=False)\n",
-    "await connection.close()\n",
-    "# Or: await connection.close(close_connection_pool=False)\n",
-    "await connection.connection_pool.disconnect()"
+    "pool = redis.ConnectionPool.from_url(\"redis://localhost\")\n",
+    "connection1 = redis.Redis(connection_pool=pool)\n",
+    "connection2 = redis.Redis(connection_pool=pool)\n",
+    "await connection1.close()\n",
+    "await connection2.close()\n",
+    "await pool.disconnect()"
    ]
   },
   {

--- a/docs/examples/asyncio_examples.ipynb
+++ b/docs/examples/asyncio_examples.ipynb
@@ -48,7 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you create custom `ConnectionPool` for the `Redis` instance to use, use the `from_pool` argument.  This will cause the pool to be disconnected along with the Redis instance. Disconnecting the connection pool simply disconnects all connections hosted in the pool."
+    "If you create custom `ConnectionPool` for the `Redis` instance to use alone, use the `from_pool` class method to create it.  This will cause the pool to be disconnected along with the Redis instance. Disconnecting the connection pool simply disconnects all connections hosted in the pool."
    ]
   },
   {
@@ -60,7 +60,7 @@
     "import redis.asyncio as redis\n",
     "\n",
     "pool = redis.ConnectionPool.from_url(\"redis://localhost\")\n",
-    "connection = redis.Redis(from_pool=pool)\n",
+    "connection = redis.Redis.from_pool(pool)\n",
     "await connection.close()"
    ]
   },

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -114,7 +114,7 @@ class Redis(
         cls,
         url: str,
         single_connection_client: bool = False,
-        auto_close_connection_pool: bool = True,
+        auto_close_connection_pool: Optional[bool] = None,
         **kwargs,
     ):
         """
@@ -164,12 +164,17 @@ class Redis(
             connection_pool=connection_pool,
             single_connection_client=single_connection_client,
         )
-        # We should probably deprecate the `auto_close_connection_pool`
-        # argument.
-        # If the caller doesn't want the pool auto-closed, a better
-        # pattern is to create the pool manually (maybe using from_url()),
-        # pass it in using the `connection_pool`, and hold on to it to close
-        # it later.
+        if auto_close_connection_pool is not None:
+            warnings.warn(
+                DeprecationWarning(
+                    '"auto_close_connection_pool" is deprecated '
+                    "since version 5.0.0. "
+                    "Please create a ConnectionPool explicitly and "
+                    "provide to the Redis() constructor instead."
+                )
+            )
+        else:
+            auto_close_connection_pool = True
         client.auto_close_connection_pool = auto_close_connection_pool
         return client
 
@@ -223,7 +228,7 @@ class Redis(
         username: Optional[str] = None,
         retry: Optional[Retry] = None,
         # deprecated. create a pool and use connection_pool instead
-        auto_close_connection_pool: bool = True,
+        auto_close_connection_pool: Optional[bool] = None,
         redis_connect_func=None,
         credential_provider: Optional[CredentialProvider] = None,
         protocol: Optional[int] = 2,
@@ -236,6 +241,18 @@ class Redis(
         To retry on TimeoutError, `retry_on_timeout` can also be set to `True`.
         """
         kwargs: Dict[str, Any]
+
+        if auto_close_connection_pool is not None:
+            warnings.warn(
+                DeprecationWarning(
+                    '"auto_close_connection_pool" is deprecated '
+                    "since version 5.0.0. "
+                    "Please create a ConnectionPool explicitly and "
+                    "provide to the Redis() constructor instead."
+                )
+            )
+        else:
+            auto_close_connection_pool = True
 
         if not connection_pool:
             # Create internal connection pool, expected to be closed by Redis instance

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -114,6 +114,7 @@ class Redis(
         cls,
         url: str,
         single_connection_client: bool = False,
+        auto_close_connection_pool: bool = True,
         **kwargs,
     ):
         """
@@ -163,7 +164,13 @@ class Redis(
             connection_pool=connection_pool,
             single_connection_client=single_connection_client,
         )
-        client.auto_close_connection_pool = True
+        # We should probably deprecate the `auto_close_connection_pool`
+        # argument.
+        # If the caller doesn't want the pool auto-closed, a better
+        # pattern is to create the pool manually (maybe using from_url()),
+        # pass it in using the `connection_pool`, and hold on to it to close
+        # it later.
+        client.auto_close_connection_pool = auto_close_connection_pool
         return client
 
     @classmethod

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1107,7 +1107,7 @@ class BlockingConnectionPool(ConnectionPool):
     A blocking connection pool::
 
         >>> from redis.asyncio.client import Redis
-        >>> client = Redis(connection_pool=BlockingConnectionPool())
+        >>> client = Redis(from_pool=BlockingConnectionPool())
 
     It performs the same function as the default
     :py:class:`~redis.asyncio.ConnectionPool` implementation, in that,

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1106,8 +1106,8 @@ class BlockingConnectionPool(ConnectionPool):
     """
     A blocking connection pool::
 
-        >>> from redis.asyncio.client import Redis
-        >>> client = Redis(from_pool=BlockingConnectionPool())
+        >>> from redis.asyncio import Redis, BlockingConnectionPool
+        >>> client = Redis.from_pool(BlockingConnectionPool())
 
     It performs the same function as the default
     :py:class:`~redis.asyncio.ConnectionPool` implementation, in that,

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -340,12 +340,9 @@ class Sentinel(AsyncSentinelCommands):
 
         connection_pool = connection_pool_class(service_name, self, **connection_kwargs)
         # The Redis object "owns" the pool
-        auto_close_connection_pool = True
-        client = redis_class(
-            connection_pool=connection_pool,
+        return redis_class(
+            from_pool=connection_pool,
         )
-        client.auto_close_connection_pool = auto_close_connection_pool
-        return client
 
     def slave_for(
         self,
@@ -377,9 +374,6 @@ class Sentinel(AsyncSentinelCommands):
 
         connection_pool = connection_pool_class(service_name, self, **connection_kwargs)
         # The Redis object "owns" the pool
-        auto_close_connection_pool = True
-        client = redis_class(
-            connection_pool=connection_pool,
+        return redis_class(
+            from_pool=connection_pool,
         )
-        client.auto_close_connection_pool = auto_close_connection_pool
-        return client

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -340,9 +340,7 @@ class Sentinel(AsyncSentinelCommands):
 
         connection_pool = connection_pool_class(service_name, self, **connection_kwargs)
         # The Redis object "owns" the pool
-        return redis_class(
-            from_pool=connection_pool,
-        )
+        return redis_class.from_pool(connection_pool)
 
     def slave_for(
         self,
@@ -374,6 +372,4 @@ class Sentinel(AsyncSentinelCommands):
 
         connection_pool = connection_pool_class(service_name, self, **connection_kwargs)
         # The Redis object "owns" the pool
-        return redis_class(
-            from_pool=connection_pool,
-        )
+        return redis_class.from_pool(connection_pool)

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -353,8 +353,8 @@ class Sentinel(SentinelCommands):
         kwargs["is_master"] = True
         connection_kwargs = dict(self.connection_kwargs)
         connection_kwargs.update(kwargs)
-        return redis_class(
-            from_pool=connection_pool_class(service_name, self, **connection_kwargs)
+        return redis_class.from_pool(
+            connection_pool_class(service_name, self, **connection_kwargs)
         )
 
     def slave_for(
@@ -384,6 +384,6 @@ class Sentinel(SentinelCommands):
         kwargs["is_master"] = False
         connection_kwargs = dict(self.connection_kwargs)
         connection_kwargs.update(kwargs)
-        return redis_class(
-            from_pool=connection_pool_class(service_name, self, **connection_kwargs)
+        return redis_class.from_pool(
+            connection_pool_class(service_name, self, **connection_kwargs)
         )

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -354,9 +354,7 @@ class Sentinel(SentinelCommands):
         connection_kwargs = dict(self.connection_kwargs)
         connection_kwargs.update(kwargs)
         return redis_class(
-            connection_pool=connection_pool_class(
-                service_name, self, **connection_kwargs
-            )
+            from_pool=connection_pool_class(service_name, self, **connection_kwargs)
         )
 
     def slave_for(
@@ -387,7 +385,5 @@ class Sentinel(SentinelCommands):
         connection_kwargs = dict(self.connection_kwargs)
         connection_kwargs.update(kwargs)
         return redis_class(
-            connection_pool=connection_pool_class(
-                service_name, self, **connection_kwargs
-            )
+            from_pool=connection_pool_class(service_name, self, **connection_kwargs)
         )

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -305,15 +305,23 @@ async def test_pool_auto_close(request, from_url):
     await r1.close()
 
 
+async def test_pool_from_url_deprecation(request):
+    url: str = request.config.getoption("--redis-url")
+
+    with pytest.deprecated_call():
+        return Redis.from_url(url, auto_close_connection_pool=False)
+
+
 async def test_pool_auto_close_disable(request):
-    """Verify that auto_close_connection_pool can be disabled"""
+    """Verify that auto_close_connection_pool can be disabled (deprecated)"""
 
     url: str = request.config.getoption("--redis-url")
     url_args = parse_url(url)
 
     async def get_redis_connection():
         url_args["auto_close_connection_pool"] = False
-        return Redis(**url_args)
+        with pytest.deprecated_call():
+            return Redis(**url_args)
 
     r1 = await get_redis_connection()
     assert r1.auto_close_connection_pool is False
@@ -394,7 +402,8 @@ async def test_redis_pool_auto_close_arg(request, auto_close):
     pool = ConnectionPool.from_url(url)
 
     async def get_redis_connection():
-        client = Redis(connection_pool=pool, auto_close_connection_pool=auto_close)
+        with pytest.deprecated_call():
+            client = Redis(connection_pool=pool, auto_close_connection_pool=auto_close)
         return client
 
     called = 0

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -5,9 +5,15 @@ from unittest.mock import patch
 
 import pytest
 import redis
+from redis import ConnectionPool, Redis
 from redis._parsers import _HiredisParser, _RESP2Parser, _RESP3Parser
 from redis.backoff import NoBackoff
-from redis.connection import Connection, SSLConnection, UnixDomainSocketConnection
+from redis.connection import (
+    Connection,
+    SSLConnection,
+    UnixDomainSocketConnection,
+    parse_url,
+)
 from redis.exceptions import ConnectionError, InvalidResponse, TimeoutError
 from redis.retry import Retry
 from redis.utils import HIREDIS_AVAILABLE
@@ -209,3 +215,84 @@ def test_create_single_connection_client_from_url():
         "redis://localhost:6379/0?", single_connection_client=True
     )
     assert client.connection is not None
+
+
+@pytest.mark.parametrize("from_url", (True, False), ids=("from_url", "from_args"))
+def test_pool_auto_close(request, from_url):
+    """Verify that basic Redis instances have auto_close_connection_pool set to True"""
+
+    url: str = request.config.getoption("--redis-url")
+    url_args = parse_url(url)
+
+    def get_redis_connection():
+        if from_url:
+            return Redis.from_url(url)
+        return Redis(**url_args)
+
+    r1 = get_redis_connection()
+    assert r1.auto_close_connection_pool is True
+    r1.close()
+
+
+@pytest.mark.parametrize("from_url", (True, False), ids=("from_url", "from_args"))
+def test_redis_connection_pool(request, from_url):
+    """Verify that basic Redis instances using `connection_pool`
+    have auto_close_connection_pool set to False"""
+
+    url: str = request.config.getoption("--redis-url")
+    url_args = parse_url(url)
+
+    pool = None
+
+    def get_redis_connection():
+        nonlocal pool
+        if from_url:
+            pool = ConnectionPool.from_url(url)
+        else:
+            pool = ConnectionPool(**url_args)
+        return Redis(connection_pool=pool)
+
+    called = 0
+
+    def mock_disconnect(_):
+        nonlocal called
+        called += 1
+
+    with patch.object(ConnectionPool, "disconnect", mock_disconnect):
+        with get_redis_connection() as r1:
+            assert r1.auto_close_connection_pool is False
+
+    assert called == 0
+    pool.disconnect()
+
+
+@pytest.mark.parametrize("from_url", (True, False), ids=("from_url", "from_args"))
+def test_redis_from_pool(request, from_url):
+    """Verify that basic Redis instances using `from_pool`
+    have auto_close_connection_pool set to True"""
+
+    url: str = request.config.getoption("--redis-url")
+    url_args = parse_url(url)
+
+    pool = None
+
+    def get_redis_connection():
+        nonlocal pool
+        if from_url:
+            pool = ConnectionPool.from_url(url)
+        else:
+            pool = ConnectionPool(**url_args)
+        return Redis(from_pool=pool)
+
+    called = 0
+
+    def mock_disconnect(_):
+        nonlocal called
+        called += 1
+
+    with patch.object(ConnectionPool, "disconnect", mock_disconnect):
+        with get_redis_connection() as r1:
+            assert r1.auto_close_connection_pool is True
+
+    assert called == 1
+    pool.disconnect()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -268,7 +268,7 @@ def test_redis_connection_pool(request, from_url):
 
 @pytest.mark.parametrize("from_url", (True, False), ids=("from_url", "from_args"))
 def test_redis_from_pool(request, from_url):
-    """Verify that basic Redis instances using `from_pool`
+    """Verify that basic Redis instances created using `from_pool()`
     have auto_close_connection_pool set to True"""
 
     url: str = request.config.getoption("--redis-url")
@@ -282,7 +282,7 @@ def test_redis_from_pool(request, from_url):
             pool = ConnectionPool.from_url(url)
         else:
             pool = ConnectionPool(**url_args)
-        return Redis(from_pool=pool)
+        return Redis.from_pool(pool)
 
     called = 0
 


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

Traditionally, synchronous `redis-py` has relied on `__del__` to disconnect any `ConnectionPool` owned by a `Redis` object.
Explicitly closing those has been possible, via `client.connection_pool.disconnect()`, but this does not work well with
using context managers and other approaches.  Relying on `__del__()` to clean up sockets is not considered good practice since it relies on the peculiarities of the particular implementation, garbage collection and such things.

In async redis, a mechanism was added to make an `asyncio.Redis` object _own_ a connection and close it, to provide
better connection over connection lifetime.  This was done here:
https://github.com/aio-libs-abandoned/aioredis-py/pull/1256
This mechanism carried over when that library was added to redis-py, and we increasinly rely on it to properly clean up sockets used in asynchronous mode.  However, the mechanism added was cumbersome to use and overly verbose.  In particular, it made it awkward to create a custom `ConnectionPool` instance, hand it to a new `Redis` object, and expect it to close it automatically.

This PR, aims to:

1. fix #2901, adding a new `from_pool()` class method to use instead of the `auto_close_connection_pool` constructor argument.
2. apply the same semantics to the synchronous Redis.
3. Discourage the use of the `auto_close_connection_pool` argument.

The following now applies for both _synchronous_ and _asynchronous_ redis:

- A `Redis` object created without providing a `ConnectionPool` instance, e.g. via `Redis()` or `Redis.from_url()`, will now automatically call `connection_pool.disconnect()` when `call()` is closed.
- A `Redis` object created `Redis.from_pool()`  similarly _takes ownership_ of the pool, and will disconnect the pool.
- As before, if the `connection_pool` argument is used by `Redis.__init__()` this is __not__ done, instead it is assumed the caller
will close the pool.
- A `Sentinel` object, will use a `from_pool()` class method constructing a `Redis` object to return from the `master_for()` and `slave_for()` methods.
- An `auto_close_connection_pool` `Redis.__init__()` argument is not provided for `redis.Redis`, but kept in place for backwards compatibility for `redis.asyncio.Redis`

The above behaviour is controlled by the `auto_close_connection_pool` property of `Redis`.


