### PR TITLE
Fix async sentinel: add `push_request` keyword argument to `read_response`

### DIFF
--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -69,12 +69,14 @@ class SentinelManagedConnection(Connection):
         timeout: Optional[float] = None,
         *,
         disconnect_on_error: Optional[float] = True,
+        push_request: Optional[bool] = False,
     ):
         try:
             return await super().read_response(
                 disable_decoding=disable_decoding,
                 timeout=timeout,
                 disconnect_on_error=disconnect_on_error,
+                push_request=push_request,
             )
         except ReadOnlyError:
             if self.connection_pool.is_master:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

closes #2921 