### PR TITLE
Partial clean up of Python 3.7 compatibility

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -57,7 +57,7 @@ jobs:
        max-parallel: 15
        fail-fast: false
        matrix:
-         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+         python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.9']
          test-type: ['standalone', 'cluster']
          connection-type: ['hiredis', 'plain']
      env:
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.11']
+        python-version: ['3.11']
         test-type: ['standalone', 'cluster']
         connection-type: ['hiredis', 'plain']
         protocol: ['3']
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.9']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.8', '3.11']
         test-type: ['standalone', 'cluster']
         connection-type: ['hiredis', 'plain']
         protocol: ['3']

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -1,14 +1,12 @@
 import asyncio
 import socket
 import sys
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, TypedDict, Union
 
 if sys.version_info.major >= 3 and sys.version_info.minor >= 11:
     from asyncio import timeout as async_timeout
 else:
     from async_timeout import timeout as async_timeout
-
-from redis.compat import TypedDict
 
 from ..exceptions import ConnectionError, InvalidResponse, RedisError
 from ..typing import EncodableT

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -15,9 +15,11 @@ from typing import (
     Mapping,
     MutableMapping,
     Optional,
+    Protocol,
     Set,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -49,7 +51,6 @@ from redis.commands import (
     AsyncSentinelCommands,
     list_or_args,
 )
-from redis.compat import Protocol, TypedDict
 from redis.credentials import CredentialProvider
 from redis.exceptions import (
     ConnectionError,

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -17,9 +17,11 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Protocol,
     Set,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
 )
@@ -34,7 +36,6 @@ else:
 
 from redis.asyncio.retry import Retry
 from redis.backoff import NoBackoff
-from redis.compat import Protocol, TypedDict
 from redis.connection import DEFAULT_RESP_VERSION
 from redis.credentials import CredentialProvider, UsernamePasswordCredentialProvider
 from redis.exceptions import (

--- a/redis/commands/cluster.py
+++ b/redis/commands/cluster.py
@@ -7,13 +7,13 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     Mapping,
     NoReturn,
     Optional,
     Union,
 )
 
-from redis.compat import Literal
 from redis.crc import key_slot
 from redis.exceptions import RedisClusterException, RedisError
 from redis.typing import (

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -13,6 +13,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -21,7 +22,6 @@ from typing import (
     Union,
 )
 
-from redis.compat import Literal
 from redis.exceptions import ConnectionError, DataError, NoScriptError, RedisError
 from redis.typing import (
     AbsExpiryT,

--- a/redis/compat.py
+++ b/redis/compat.py
@@ -1,6 +1,0 @@
-# flake8: noqa
-try:
-    from typing import Literal, Protocol, TypedDict  # lgtm [py/unused-import]
-except ImportError:
-    from typing_extensions import Literal  # lgtm [py/unused-import]
-    from typing_extensions import Protocol, TypedDict

--- a/redis/typing.py
+++ b/redis/typing.py
@@ -7,12 +7,11 @@ from typing import (
     Awaitable,
     Iterable,
     Mapping,
+    Protocol,
     Type,
     TypeVar,
     Union,
 )
-
-from redis.compat import Protocol
 
 if TYPE_CHECKING:
     from redis._parsers import Encoder

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,8 @@ setup(
     },
     author="Redis Inc.",
     author_email="oss@redis.com",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
-        'importlib-metadata >= 1.0; python_version < "3.8"',
         'async-timeout>=4.0.2; python_full_version<="3.11.2"',
     ],
     classifiers=[
@@ -48,7 +47,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         'importlib-metadata >= 1.0; python_version < "3.8"',
-        'typing-extensions; python_version<"3.8"',
         'async-timeout>=4.0.2; python_full_version<="3.11.2"',
     ],
     classifiers=[


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
  - No, Tox is no longer a thing 
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
  - See https://github.com/akx/redis-py/pull/2 
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?
  - No, since CHANGES is unspeakably out-of-date at this point (see #2833).
 
### Description of change

Since 5.0.0 was the last version to support Python 3.7, this PR starts cleaning up some now-unnecessary compatibility code.
