### PR TITLE
Remove mentions of Tox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 **/__pycache__
 **/*.pyc
-.tox
 .coverage
 .coverage.*

--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,6 @@ exclude =
     *.egg-info,
     *.pyc,
     .git,
-    .tox,
     .venv*,
     build,
     docs/*,

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 _Please make sure to review and check all of these items:_
 
-- [ ] Does `$ tox` pass with this change (including linting)?
+- [ ] Do tests and lints pass with this change?
 - [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
 - [ ] Is the new or changed code fully tested?
 - [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -132,7 +132,6 @@ thevalueofmykey
 timeseries
 toctree
 topk
-tox
 triaging
 txt
 un

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ redis.egg-info
 build/
 dist/
 dump.rdb
-/.tox
 _build
 vagrant/.vagrant
 .python-version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,15 +78,8 @@ It is possible to run only Redis client tests (with cluster mode disabled) by
 using `invoke standalone-tests`; similarly, RedisCluster tests can be run by using
 `invoke cluster-tests`.
 
-Each run of tox starts and stops the various dockers required. Sometimes
+Each run of tests starts and stops the various dockers required. Sometimes
 things get stuck, an `invoke clean` can help.
-
-Continuous Integration uses these same wrappers to run all of these
-tests against multiple versions of python. Feel free to test your
-changes against all the python versions supported, as declared by the
-tox.ini file (eg: tox -e py39). If you have the various python versions
-on your desktop, you can run *tox* by itself, to test all supported
-versions.
 
 ### Docker Tips
 
@@ -97,10 +90,6 @@ To get a bash shell inside of a container:
 
 `$ docker run -it <service> /bin/bash`
 
-**Note**: The term \"service\" refers to the \"services\" defined in the
-`tox.ini` file at the top of the repo: \"master\", \"replicaof\",
-\"sentinel_1\", \"sentinel_2\", \"sentinel_3\".
-
 Containers run a minimal Debian image that probably lacks tools you want
 to use. To install packages, first get a bash session (see previous tip)
 and then run:
@@ -110,23 +99,6 @@ and then run:
 You can see the logging output of a containers like this:
 
 `$ docker logs -f <service>`
-
-The command make test runs all tests in all tested Python
-environments. To run the tests in a single environment, like Python 3.9,
-use a command like this:
-
-`$ docker-compose run test tox -e py39 -- --redis-url=redis://master:6379/9`
-
-Here, the flag `-e py39` runs tests against the Python 3.9 tox
-environment. And note from the example that whenever you run tests like
-this, instead of using make test, you need to pass
-`-- --redis-url=redis://master:6379/9`. This points the tests at the
-\"master\" container.
-
-Our test suite uses `pytest`. You can run a specific test suite against
-a specific Python version like this:
-
-`$ docker-compose run test tox -e py37 -- --redis-url=redis://master:6379/9 tests/test_commands.py`
 
 ### Troubleshooting
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -8,7 +8,6 @@ packaging>=20.4
 pytest==7.2.0
 pytest-timeout==2.1.0
 pytest-asyncio>=0.20.2
-tox==3.27.1
 invoke==1.7.3
 pytest-cov>=4.0.0
 vulture>=2.3.0


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
  - Unsurprisingly, no, since there is no Tox configuration. 
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?
  - No, since the CHANGES file is currently very out of date.

### Description of change

The PR checklist and other documentation refers to `tox`, but it was removed in #2849.