### PR TITLE
Avoid creating ref cycles

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -513,7 +513,10 @@ class AbstractConnection:
             self.next_health_check = time() + self.health_check_interval
 
         if isinstance(response, ResponseError):
-            raise response
+            try:
+                raise response
+            finally:
+                del response  # avoid creating ref cycles
         return response
 
     def pack_command(self, *args):


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

This won't meaningfully affect most users, so I won't feel bad if this is closed :-)

It's often important for performance to control when garbage collection runs and to reduce the need to run garbage collection in the first place.

During AbstractionConnection.on_connect, it's common to raise and catch ResponseError, since e.g. CLIENT SETINFO is very new. However, because response is in a local, it creates ref cycles that keep all locals in all calling stack frames alive.

The use of a local to store the exception is unfortunate, since exceptions hold references to their tracebacks, which hold references to the relevant frames, which holds a reference to the local exception. See https://peps.python.org/pep-0344/#open-issue-garbage-collection and https://peps.python.org/pep-3110/#rationale

This breaks the cycle by deleting the local when we raise, so frames are destroyed by the normal reference counting mechanism.

Fix suggested by JelleZijlstra