### PR TITLE
Support timeout = 0 in search query

### DIFF
--- a/redis/commands/search/query.py
+++ b/redis/commands/search/query.py
@@ -135,7 +135,7 @@ class Query:
     def timeout(self, timeout):
         """overrides the timeout parameter of the module"""
         if isinstance(timeout, int) and timeout >= 0:
-            self._timeout = timeou
+            self._timeout = timeout
         else:
             raise AttributeError("TIMEOUT requires a non negative integer.")
         return self

--- a/redis/commands/search/query.py
+++ b/redis/commands/search/query.py
@@ -194,8 +194,10 @@ class Query:
             args += self._ids
         if self._slop >= 0:
             args += ["SLOP", self._slop]
-        if self._timeout is not None:
+        if isinstance(self._timeout, int) and self._timeout >= 0:
             args += ["TIMEOUT", self._timeout]
+        else:
+            raise AttributeError("TIMEOUT requires a non negative integer.")
         if self._in_order:
             args.append("INORDER")
         if self._return_fields:

--- a/redis/commands/search/query.py
+++ b/redis/commands/search/query.py
@@ -194,7 +194,7 @@ class Query:
             args += self._ids
         if self._slop >= 0:
             args += ["SLOP", self._slop]
-        if self._timeout:
+        if self._timeout is not None:
             args += ["TIMEOUT", self._timeout]
         if self._in_order:
             args.append("INORDER")

--- a/redis/commands/search/query.py
+++ b/redis/commands/search/query.py
@@ -134,10 +134,7 @@ class Query:
 
     def timeout(self, timeout):
         """overrides the timeout parameter of the module"""
-        if isinstance(timeout, int) and timeout >= 0:
-            self._timeout = timeou
-        else:
-            raise AttributeError("TIMEOUT requires a non negative integer.")
+        self._timeout = timeout
         return self
 
     def in_order(self):
@@ -197,8 +194,10 @@ class Query:
             args += self._ids
         if self._slop >= 0:
             args += ["SLOP", self._slop]
-        if self._timeout is not None:
+        if isinstance(self._timeout, int) and self._timeout >= 0:
             args += ["TIMEOUT", self._timeout]
+        else:
+            raise AttributeError("TIMEOUT requires a non negative integer.")
         if self._in_order:
             args.append("INORDER")
         if self._return_fields:

--- a/redis/commands/search/query.py
+++ b/redis/commands/search/query.py
@@ -194,10 +194,8 @@ class Query:
             args += self._ids
         if self._slop >= 0:
             args += ["SLOP", self._slop]
-        if isinstance(self._timeout, int) and self._timeout >= 0:
+        if self._timeout is not None:
             args += ["TIMEOUT", self._timeout]
-        else:
-            raise AttributeError("TIMEOUT requires a non negative integer.")
         if self._in_order:
             args.append("INORDER")
         if self._return_fields:

--- a/redis/commands/search/query.py
+++ b/redis/commands/search/query.py
@@ -135,7 +135,7 @@ class Query:
     def timeout(self, timeout):
         """overrides the timeout parameter of the module"""
         if isinstance(timeout, int) and timeout >= 0:
-            self._timeout = timeout
+            self._timeout = timeou
         else:
             raise AttributeError("TIMEOUT requires a non negative integer.")
         return self

--- a/redis/commands/search/query.py
+++ b/redis/commands/search/query.py
@@ -134,7 +134,10 @@ class Query:
 
     def timeout(self, timeout):
         """overrides the timeout parameter of the module"""
-        self._timeout = timeout
+        if isinstance(timeout, int) and timeout >= 0:
+            self._timeout = timeou
+        else:
+            raise AttributeError("TIMEOUT requires a non negative integer.")
         return self
 
     def in_order(self):
@@ -194,10 +197,8 @@ class Query:
             args += self._ids
         if self._slop >= 0:
             args += ["SLOP", self._slop]
-        if isinstance(self._timeout, int) and self._timeout >= 0:
+        if self._timeout is not None:
             args += ["TIMEOUT", self._timeout]
-        else:
-            raise AttributeError("TIMEOUT requires a non negative integer.")
         if self._in_order:
             args.append("INORDER")
         if self._return_fields:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2266,6 +2266,5 @@ def test_query_timeout(r: redis.Redis):
     assert q1.get_args() == ["foo", "TIMEOUT", 5000, "LIMIT", 0, 10]
     q1 = Query("foo").timeout(0)
     assert q1.get_args() == ["foo", "TIMEOUT", 0, "LIMIT", 0, 10]
-    q2 = Query("foo").timeout("not_a_number")
     with pytest.raises(AttributeError):
-        r.ft().search(q2)
+        Query("foo").timeout("not_a_number")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2266,5 +2266,6 @@ def test_query_timeout(r: redis.Redis):
     assert q1.get_args() == ["foo", "TIMEOUT", 5000, "LIMIT", 0, 10]
     q1 = Query("foo").timeout(0)
     assert q1.get_args() == ["foo", "TIMEOUT", 0, "LIMIT", 0, 10]
+    q2 = Query("foo").timeout("not_a_number")
     with pytest.raises(AttributeError):
-        Query("foo").timeout("not_a_number")
+        r.ft().search(q2)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2267,5 +2267,5 @@ def test_query_timeout(r: redis.Redis):
     q1 = Query("foo").timeout(0)
     assert q1.get_args() == ["foo", "TIMEOUT", 0, "LIMIT", 0, 10]
     q2 = Query("foo").timeout("not_a_number")
-    with pytest.raises(redis.ResponseError):
+    with pytest.raises(AttributeError):
         r.ft().search(q2)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2267,5 +2267,5 @@ def test_query_timeout(r: redis.Redis):
     q1 = Query("foo").timeout(0)
     assert q1.get_args() == ["foo", "TIMEOUT", 0, "LIMIT", 0, 10]
     q2 = Query("foo").timeout("not_a_number")
-    with pytest.raises(AttributeError):
+    with pytest.raises(redis.ResponseError):
         r.ft().search(q2)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2264,6 +2264,8 @@ def test_withsuffixtrie(client: redis.Redis):
 def test_query_timeout(r: redis.Redis):
     q1 = Query("foo").timeout(5000)
     assert q1.get_args() == ["foo", "TIMEOUT", 5000, "LIMIT", 0, 10]
+    q1 = Query("foo").timeout(0)
+    assert q1.get_args() == ["foo", "TIMEOUT", 0, "LIMIT", 0, 10]
     q2 = Query("foo").timeout("not_a_number")
     with pytest.raises(redis.ResponseError):
         r.ft().search(q2)


### PR DESCRIPTION
In RediSearch query timeout = 0 means unlimited timeout. In the current implementation, the query timeout is only updated `if timeout` which in case of 0, translates to false. Since the default timeout of the `query` class is None, replacing the condition with `if self._timeout is not None` will also work for 0. If the parameter is not a positive integer, redis server will raise an exception.

related issue: #2839 
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
