### PR TITLE
chore: add from clause when raising ConnectionError in BlockingConnec…

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1297,10 +1297,10 @@ class BlockingConnectionPool(ConnectionPool):
         try:
             async with async_timeout(self.timeout):
                 connection = await self.pool.get()
-        except (asyncio.QueueEmpty, asyncio.TimeoutError):
+        except (asyncio.QueueEmpty, asyncio.TimeoutError) as exception:
             # Note that this is not caught by the redis client and will be
             # raised unless handled by application code. If you want never to
-            raise ConnectionError("No connection available.")
+            raise ConnectionError("No connection available.") from exception
 
         # If the ``connection`` is actually ``None`` then that's a cue to make
         # a new connection to add to the pool.


### PR DESCRIPTION
…tionPool

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Add from clause when raising ConnectionError in BlockingConnectionPool to add a more informative stacktrace.

Conceptually speaking the library should raise a `ConnectionError("Too many connections")` when the `await self.pool.get()` raises a `asyncio.QueueEmpty` exception like we do [here](https://github.com/redis/redis-py/blob/1596ac6a0bbc1e00e57c6a48e255a8f917498e39/redis/asyncio/connection.py#L1138). I started to add a from clause to have a more informative description from the stacktrace (without it the log/debug seems cut by Python because the exception is catched).