### PR TITLE
Add fake redis server to properly test connection handshake

### DIFF
--- a/tests/resp.py
+++ b/tests/resp.py
@@ -1,0 +1,93 @@
+import itertools
+from types import NoneType
+from typing import Any, Optional
+
+
+class RespEncoder:
+    """
+    A class for simple RESP protocol encodign for unit tests
+    """
+
+    def __init__(self, protocol: int = 2, encoding: str = "utf-8") -> None:
+        self.protocol = protocol
+        self.encoding = encoding
+
+    def encode(self, data: Any, hint: Optional[str] = None) -> bytes:
+        if isinstance(data, dict):
+            if self.protocol > 2:
+                result = f"%{len(data)}\r\n".encode()
+                for key, val in data.items():
+                    result += self.encode(key) + self.encode(val)
+                return result
+            else:
+                # Automatically encode dicts as flattened key, value arrays
+                mylist = list(
+                    itertools.chain(*((key, val) for (key, val) in data.items()))
+                )
+                return self.encode(mylist)
+
+        elif isinstance(data, list):
+            result = f"*{len(data)}\r\n".encode()
+            for val in data:
+                result += self.encode(val)
+            return result
+
+        elif isinstance(data, set):
+            if self.protocol > 2:
+                result = f"~{len(data)}\r\n".encode()
+                for val in data:
+                    result += self.encode(val)
+                return result
+            else:
+                return self.encode(list(data))
+
+        elif isinstance(data, str):
+            enc = data.encode(self.encoding)
+            # long strings or strings with control characters must be encoded as bulk
+            # strings
+            if hint or len(enc) > 20 or b"\r" in enc or b"\n" in enc:
+                return self.encode_bulkstr(enc, hint)
+            return b"+" + enc + b"\r\n"
+
+        elif isinstance(data, bytes):
+            return self.encode_bulkstr(data, hint)
+
+        elif isinstance(data, bool):
+            if self.protocol == 2:
+                return b":1\r\n" if data else b":0\r\n"
+            else:
+                return b"t\r\n" if data else b"f\r\n"
+
+        elif isinstance(data, int):
+            if (data > 2**63 - 1) or (data < -(2**63)):
+                if self.protocol > 2:
+                    return f"({data}\r\n".encode()  # resp3 big int
+                else:
+                    return f"+{data}\r\n".encode()  # force to simple string
+            return f":{data}\r\n".encode()
+        elif isinstance(data, float):
+            if self.protocol > 2:
+                return f",{data}\r\n".encode()  # resp3 double
+            else:
+                return f"+{data}\r\n".encode()  # simple string
+
+        elif isinstance(data, NoneType):
+            if self.protocol > 2:
+                return b"_\r\n"  # resp3 null
+            else:
+                return b"$-1\r\n"  # Null bulk string
+                # some commands return null array: b"*-1\r\n"
+
+        else:
+            raise NotImplementedError
+
+    def encode_bulkstr(self, bstr: bytes, hint: Optional[str]) -> bytes:
+        if self.protocol > 2 and hint is not None:
+            # a resp3 verbatim string
+            return f"={len(bstr)}\r\n{hint}:".encode() + bstr + b"\r\n"
+        else:
+            return f"${len(bstr)}\r\n".encode() + bstr + b"\r\n"
+
+
+def encode(value: Any, protocol: int = 2, hint: Optional[str] = None) -> bytes:
+    return RespEncoder(protocol).encode(value, hint)

--- a/tests/resp.py
+++ b/tests/resp.py
@@ -1,11 +1,38 @@
 import itertools
+from contextlib import closing
 from types import NoneType
-from typing import Any, Optional
+from typing import Any, Generator, List, Optional, Tuple, Union
+
+CRNL = b"\r\n"
+
+
+class VerbatimString(bytes):
+    """
+    A string that is encoded as a resp3 verbatim string
+    """
+
+    def __new__(cls, value: bytes, hint: str) -> "VerbatimString":
+        return bytes.__new__(cls, value)
+
+    def __init__(self, value: bytes, hint: str) -> None:
+        self.hint = hint
+
+    def __repr__(self) -> str:
+        return f"VerbatimString({super().__repr__()}, {self.hint!r})"
+
+
+class PushData(list):
+    """
+    A special type of list indicating data from a push response
+    """
+
+    def __repr__(self) -> str:
+        return f"PushData({super().__repr__()})"
 
 
 class RespEncoder:
     """
-    A class for simple RESP protocol encodign for unit tests
+    A class for simple RESP protocol encoding for unit tests
     """
 
     def __init__(self, protocol: int = 2, encoding: str = "utf-8") -> None:
@@ -27,7 +54,10 @@ class RespEncoder:
                 return self.encode(mylist)
 
         elif isinstance(data, list):
-            result = f"*{len(data)}\r\n".encode()
+            if isinstance(data, PushData) and self.protocol > 2:
+                result = f">{len(data)}\r\n".encode()
+            else:
+                result = f"*{len(data)}\r\n".encode()
             for val in data:
                 result += self.encode(val)
             return result
@@ -55,39 +85,243 @@ class RespEncoder:
         elif isinstance(data, bool):
             if self.protocol == 2:
                 return b":1\r\n" if data else b":0\r\n"
-            else:
-                return b"t\r\n" if data else b"f\r\n"
+            return b"t\r\n" if data else b"f\r\n"
 
         elif isinstance(data, int):
             if (data > 2**63 - 1) or (data < -(2**63)):
                 if self.protocol > 2:
                     return f"({data}\r\n".encode()  # resp3 big int
-                else:
-                    return f"+{data}\r\n".encode()  # force to simple string
+                return f"+{data}\r\n".encode()  # force to simple string
             return f":{data}\r\n".encode()
         elif isinstance(data, float):
             if self.protocol > 2:
                 return f",{data}\r\n".encode()  # resp3 double
-            else:
-                return f"+{data}\r\n".encode()  # simple string
+            return f"+{data}\r\n".encode()  # simple string
 
         elif isinstance(data, NoneType):
             if self.protocol > 2:
                 return b"_\r\n"  # resp3 null
-            else:
-                return b"$-1\r\n"  # Null bulk string
-                # some commands return null array: b"*-1\r\n"
+            return b"$-1\r\n"  # Null bulk string
+            # some commands return null array: b"*-1\r\n"
 
         else:
-            raise NotImplementedError
+            raise NotImplementedError(f"encode not implemented for {type(data)}")
 
     def encode_bulkstr(self, bstr: bytes, hint: Optional[str]) -> bytes:
         if self.protocol > 2 and hint is not None:
             # a resp3 verbatim string
             return f"={len(bstr)}\r\n{hint}:".encode() + bstr + b"\r\n"
-        else:
-            return f"${len(bstr)}\r\n".encode() + bstr + b"\r\n"
+        # regular bulk string
+        return f"${len(bstr)}\r\n".encode() + bstr + b"\r\n"
 
 
 def encode(value: Any, protocol: int = 2, hint: Optional[str] = None) -> bytes:
+    """
+    Encode a value using the RESP protocol
+    """
     return RespEncoder(protocol).encode(value, hint)
+
+
+# a stateful RESP parser implemented via a generator
+def resp_parse(
+    buffer: bytes,
+) -> Generator[Optional[Tuple[Any, bytes]], Union[None, bytes], None]:
+    """
+    A stateful, generator based, RESP parser.
+    Returns a generator producing at most a single top-level primitive.
+    Yields tuple of (data_item, unparsed), or None if more data is needed.
+    It is fed more data with generator.send()
+    """
+    # Read the first line of resp or yield to get more data
+    while CRNL not in buffer:
+        incoming = yield None
+        assert incoming is not None
+        buffer += incoming
+    cmd, rest = buffer.split(CRNL, 1)
+
+    code, arg = cmd[:1], cmd[1:]
+
+    if code == b":" or code == b"(":  # integer, resp3 large int
+        yield int(arg), rest
+
+    elif code == b"t":  # resp3 true
+        yield True, rest
+
+    elif code == b"f":  # resp3 false
+        yield False, rest
+
+    elif code == b"_":  # resp3 null
+        yield None, rest
+
+    elif code == b",":  # resp3 double
+        yield float(arg), rest
+
+    elif code == b"+":  # simple string
+        # we decode them automatically
+        yield arg.decode(), rest
+
+    elif code == b"$":  # bulk string
+        count = int(arg)
+        expect = count + 2  # +2 for the trailing CRNL
+        while len(rest) < expect:
+            incoming = yield (None)
+            assert incoming is not None
+            rest += incoming
+        bulkstr = rest[:count]
+        # bulk strings are not decoded, could contain binary data
+        yield bulkstr, rest[expect:]
+
+    elif code == b"=":  # verbatim strings
+        count = int(arg)
+        expect = count + 4 + 2  # 4 type and colon +2 for the trailing CRNL
+        while len(rest) < expect:
+            incoming = yield (None)
+            assert incoming is not None
+            rest += incoming
+        hint = rest[:3]
+        result = rest[4 : (count + 4)]
+        # verbatim strings are not decoded, could contain binary data
+        yield VerbatimString(result, hint.decode()), rest[expect:]
+
+    elif code in b"*>":  # array or push data
+        count = int(arg)
+        result_array = []
+        for _ in range(count):
+            # recursively parse the next array item
+            with closing(resp_parse(rest)) as parser:
+                parsed = parser.send(None)
+                while parsed is None:
+                    incoming = yield None
+                    parsed = parser.send(incoming)
+            value, rest = parsed
+            result_array.append(value)
+        if code == b">":
+            yield PushData(result_array), rest
+        else:
+            yield result_array, rest
+
+    elif code == b"~":  # set
+        count = int(arg)
+        result_set = set()
+        for _ in range(count):
+            # recursively parse the next set item
+            with closing(resp_parse(rest)) as parser:
+                parsed = parser.send(None)
+                while parsed is None:
+                    incoming = yield None
+                    parsed = parser.send(incoming)
+            value, rest = parsed
+            result_set.add(value)
+        yield result_set, rest
+
+    elif code == b"%":  # map
+        count = int(arg)
+        result_map = {}
+        for _ in range(count):
+            # recursively parse the next key, and value
+            with closing(resp_parse(rest)) as parser:
+                parsed = parser.send(None)
+                while parsed is None:
+                    incoming = yield None
+                    parsed = parser.send(incoming)
+            key, rest = parsed
+            with closing(resp_parse(rest)) as parser:
+                parsed = parser.send(None)
+                while parsed is None:
+                    incoming = yield None
+                    parsed = parser.send(incoming)
+            value, rest = parsed
+            result_map[key] = value
+        yield result_map, rest
+    else:
+        if code in b"-!":
+            raise NotImplementedError(f"resp opcode '{code.decode()}' not implemented")
+        raise ValueError(f"Unknown opcode '{code.decode()}'")
+
+
+class NeedMoreData(RuntimeError):
+    """
+    Raised when more data is needed to complete a parse
+    """
+
+
+class RespParser:
+    """
+    A class for simple RESP protocol decoding for unit tests
+    """
+
+    def __init__(self) -> None:
+        self.parser: Optional[
+            Generator[Optional[Tuple[Any, bytes]], Union[None, bytes], None]
+        ] = None
+        # which has not resulted in a parsed value
+        self.consumed: List[bytes] = []
+
+    def parse(self, buffer: bytes) -> Optional[Any]:
+        """
+        Parse a buffer of data, return a tuple of a single top-level primitive and the
+        remaining buffer or raise NeedMoreData if more data is needed
+        """
+        if self.parser is None:
+            # create a new parser generator, initializing it with
+            # any unparsed data from previous calls
+            buffer = b"".join(self.consumed) + buffer
+            del self.consumed[:]
+            self.parser = resp_parse(buffer)
+            parsed = self.parser.send(None)
+        else:
+            # sen more data to the parser
+            parsed = self.parser.send(buffer)
+
+        if parsed is None:
+            self.consumed.append(buffer)
+            raise NeedMoreData()
+
+        # got a value, close the parser, store the remaining buffer
+        self.parser.close()
+        self.parser = None
+        value, remaining = parsed
+        self.consumed = [remaining]
+        return value
+
+    def get_unparsed(self) -> bytes:
+        return b"".join(self.consumed)
+
+    def close(self) -> None:
+        if self.parser is not None:
+            self.parser.close()
+            self.parser = None
+        del self.consumed[:]
+
+
+def parse_all(buffer: bytes) -> Tuple[List[Any], bytes]:
+    """
+    Parse all the data in the buffer, returning the list of top-level objects and the
+    remaining buffer
+    """
+    with closing(RespParser()) as parser:
+        result: List[Any] = []
+        while True:
+            try:
+                result.append(parser.parse(buffer))
+                buffer = b""
+            except NeedMoreData:
+                return result, parser.get_unparsed()
+
+
+def parse_chunks(buffers: List[bytes]) -> Tuple[List[Any], bytes]:
+    """
+    Parse all the data in the buffers, returning the list of top-level objects and the
+    remaining buffer.
+    Used primarily for testing, since it will parse the data in chunks
+    """
+    result: List[Any] = []
+    with closing(RespParser()) as parser:
+        for buffer in buffers:
+            while True:
+                try:
+                    result.append(parser.parse(buffer))
+                    buffer = b""
+                except NeedMoreData:
+                    break
+        return result, parser.get_unparsed()

--- a/tests/resp.py
+++ b/tests/resp.py
@@ -361,7 +361,7 @@ class RespParser:
             # create a new parser generator, initializing it with
             # any unparsed data from previous calls
             buffer = b"".join(self.consumed) + buffer
-            del self.consumed[:]
+            self.consumed.clear()
             self.generator = self.parser.parse(buffer)
             parsed = self.generator.send(None)
         else:
@@ -386,7 +386,7 @@ class RespParser:
         if self.generator is not None:
             self.generator.close()
             self.generator = None
-        del self.consumed[:]
+        self.consumed.clear()
 
 
 def parse_all(buffer: bytes) -> Tuple[List[Any], bytes]:

--- a/tests/resp.py
+++ b/tests/resp.py
@@ -420,3 +420,25 @@ def parse_chunks(buffers: List[bytes]) -> Tuple[List[Any], bytes]:
                 except NeedMoreData:
                     break
         return result, parser.get_unparsed()
+
+
+class RespServer:
+    """A simple, dummy, REDIS server for unit tests.
+    Accepts RESP commands and returns RESP responses.
+    """
+
+    _CLIENT_NAME = "test-suite-client"
+    _SUCCESS_RESP = b"+OK" + CRNL
+    _ERROR_RESP = b"-ERR" + CRNL
+    _SUPPORTED_CMDS = {f"CLIENT SETNAME {_CLIENT_NAME}": _SUCCESS_RESP}
+
+    def command(self, cmd: Any) -> bytes:
+        """Process a single command and return the response"""
+        if not isinstance(cmd, list):
+            return f"-ERR unknown command {cmd!r}\r\n".encode()
+
+        # currently supports only a single command
+        command = " ".join(cmd)
+        if command in self._SUPPORTED_CMDS:
+            return self._SUPPORTED_CMDS[command]
+        return self._ERROR_RESP

--- a/tests/resp.py
+++ b/tests/resp.py
@@ -1,6 +1,5 @@
 import itertools
 from contextlib import closing
-from types import NoneType
 from typing import Any, Generator, List, Optional, Tuple, Union
 
 CRNL = b"\r\n"
@@ -145,7 +144,7 @@ class RespEncoder:
                 return f",{data}\r\n".encode()  # resp3 double
             return f"+{data}\r\n".encode()  # simple string
 
-        elif isinstance(data, NoneType):
+        elif data is None:
             if self.protocol > 2:
                 return b"_\r\n"  # resp3 null
             return b"$-1\r\n"  # Null bulk string

--- a/tests/test_asyncio/test_connect.py
+++ b/tests/test_asyncio/test_connect.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import socket
 import ssl
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +20,7 @@ _logger = logging.getLogger(__name__)
 
 
 _CLIENT_NAME = "test-suite-client"
+PY37 = sys.version_info[:2] == (3, 7)
 
 
 @pytest.fixture
@@ -77,14 +79,15 @@ async def test_tcp_ssl_connect(tcp_address):
         (6, 3, True, True),
     ],
 )
-# @pytest.mark.parametrize("use_protocol", [2, 3])
-# @pytest.mark.parametrize("use_auth", [False, True])
 async def test_tcp_auth(
     tcp_address, use_protocol, use_auth, use_server_ver, use_client_name
 ):
     """
     Test that various initial handshake cases are handled correctly by the client
     """
+    if use_protocol == 3 and PY37:
+        pytest.skip("Python 3.7 does not support protocol 3 for asyncio")
+
     got_auth = []
     got_protocol = None
     got_name = None

--- a/tests/test_asyncio/test_connect.py
+++ b/tests/test_asyncio/test_connect.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import socket
 import ssl
-import sys
 from unittest.mock import patch
 
 import pytest
@@ -20,7 +19,6 @@ _logger = logging.getLogger(__name__)
 
 
 _CLIENT_NAME = "test-suite-client"
-PY37 = sys.version_info[:2] == (3, 7)
 
 
 @pytest.fixture
@@ -79,15 +77,14 @@ async def test_tcp_ssl_connect(tcp_address):
         (6, 3, True, True),
     ],
 )
+# @pytest.mark.parametrize("use_protocol", [2, 3])
+# @pytest.mark.parametrize("use_auth", [False, True])
 async def test_tcp_auth(
     tcp_address, use_protocol, use_auth, use_server_ver, use_client_name
 ):
     """
     Test that various initial handshake cases are handled correctly by the client
     """
-    if use_protocol == 3 and PY37:
-        pytest.skip("Python 3.7 does not support protocol 3 for asyncio")
-
     got_auth = []
     got_protocol = None
     got_name = None

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -75,6 +75,8 @@ def test_tcp_ssl_connect(tcp_address):
         (6, 3, True, True),
     ],
 )
+# @pytest.mark.parametrize("use_protocol", [2, 3])
+# @pytest.mark.parametrize("use_auth", [False, True])
 def test_tcp_auth(tcp_address, use_protocol, use_auth, use_server_ver, use_client_name):
     """
     Test that various initial handshake cases are handled correctly by the client

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -75,8 +75,6 @@ def test_tcp_ssl_connect(tcp_address):
         (6, 3, True, True),
     ],
 )
-# @pytest.mark.parametrize("use_protocol", [2, 3])
-# @pytest.mark.parametrize("use_auth", [False, True])
 def test_tcp_auth(tcp_address, use_protocol, use_auth, use_server_ver, use_client_name):
     """
     Test that various initial handshake cases are handled correctly by the client

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import socket
 import socketserver
 import ssl
@@ -8,16 +7,13 @@ import threading
 import pytest
 from redis.connection import Connection, SSLConnection, UnixDomainSocketConnection
 
+from . import resp
 from .ssl_utils import get_ssl_filename
 
 _logger = logging.getLogger(__name__)
 
 
 _CLIENT_NAME = "test-suite-client"
-_CMD_SEP = b"\r\n"
-_SUCCESS_RESP = b"+OK" + _CMD_SEP
-_ERROR_RESP = b"-ERR" + _CMD_SEP
-_SUPPORTED_CMDS = {f"CLIENT SETNAME {_CLIENT_NAME}": _SUCCESS_RESP}
 
 
 @pytest.fixture
@@ -148,44 +144,31 @@ class _RedisRequestHandler(socketserver.StreamRequestHandler):
         _logger.info("%s disconnected", self.client_address)
 
     def handle(self):
+        parser = resp.RespParser()
+        server = resp.RespServer()
         buffer = b""
-        command = None
-        command_ptr = None
-        fragment_length = None
-        while self.server.is_serving() or buffer:
-            try:
-                buffer += self.request.recv(1024)
-            except socket.timeout:
-                continue
-            if not buffer:
-                continue
-            parts = re.split(_CMD_SEP, buffer)
-            buffer = parts[-1]
-            for fragment in parts[:-1]:
-                fragment = fragment.decode()
-                _logger.info("Command fragment: %s", fragment)
-
-                if fragment.startswith("*") and command is None:
-                    command = [None for _ in range(int(fragment[1:]))]
-                    command_ptr = 0
-                    fragment_length = None
+        try:
+            # if client performs pipelining, we may need
+            # to adjust this code to not block when sending
+            # responses.
+            while self.server.is_serving():
+                try:
+                    command = parser.parse(buffer)
+                    buffer = b""
+                except resp.NeedMoreData:
+                    try:
+                        buffer = self.request.recv(1024)
+                    except socket.timeout:
+                        buffer = b""
+                        continue
+                    if not buffer:
+                        break  # EOF
                     continue
-
-                if fragment.startswith("$") and command[command_ptr] is None:
-                    fragment_length = int(fragment[1:])
-                    continue
-
-                assert len(fragment) == fragment_length
-                command[command_ptr] = fragment
-                command_ptr += 1
-
-                if command_ptr < len(command):
-                    continue
-
-                command = " ".join(command)
                 _logger.info("Command %s", command)
-                resp = _SUPPORTED_CMDS.get(command, _ERROR_RESP)
-                _logger.info("Response %s", resp)
-                self.request.sendall(resp)
-                command = None
-        _logger.info("Exit handler")
+                response = server.command(command)
+                _logger.info("Response %s", response)
+                self.request.sendall(response)
+        except Exception:
+            _logger.exception("Exception in handler")
+        finally:
+            _logger.info("Exit handler")

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -3,9 +3,15 @@ import socket
 import socketserver
 import ssl
 import threading
+from unittest.mock import patch
 
 import pytest
-from redis.connection import Connection, SSLConnection, UnixDomainSocketConnection
+from redis.connection import (
+    Connection,
+    ResponseError,
+    SSLConnection,
+    UnixDomainSocketConnection,
+)
 
 from . import resp
 from .ssl_utils import get_ssl_filename
@@ -53,6 +59,88 @@ def test_tcp_ssl_connect(tcp_address):
         socket_timeout=10,
     )
     _assert_connect(conn, tcp_address, certfile=certfile, keyfile=keyfile)
+
+
+@pytest.mark.parametrize(
+    ("use_server_ver", "use_protocol", "use_auth", "use_client_name"),
+    [
+        (5, 2, False, True),
+        (5, 2, True, True),
+        (5, 3, True, True),
+        (6, 2, False, True),
+        (6, 2, True, True),
+        (6, 3, False, False),
+        (6, 3, True, False),
+        (6, 3, False, True),
+        (6, 3, True, True),
+    ],
+)
+# @pytest.mark.parametrize("use_protocol", [2, 3])
+# @pytest.mark.parametrize("use_auth", [False, True])
+def test_tcp_auth(tcp_address, use_protocol, use_auth, use_server_ver, use_client_name):
+    """
+    Test that various initial handshake cases are handled correctly by the client
+    """
+    got_auth = []
+    got_protocol = None
+    got_name = None
+
+    def on_auth(self, auth):
+        got_auth[:] = auth
+
+    def on_protocol(self, proto):
+        nonlocal got_protocol
+        got_protocol = proto
+
+    def on_setname(self, name):
+        nonlocal got_name
+        got_name = name
+
+    def get_server_version(self):
+        return use_server_ver
+
+    if use_auth:
+        auth_args = {"username": "myuser", "password": "mypassword"}
+    else:
+        auth_args = {}
+    got_protocol = None
+    host, port = tcp_address
+    conn = Connection(
+        host=host,
+        port=port,
+        client_name=_CLIENT_NAME if use_client_name else None,
+        socket_timeout=10,
+        protocol=use_protocol,
+        **auth_args,
+    )
+    try:
+        with patch.multiple(
+            resp.RespServer,
+            on_auth=on_auth,
+            get_server_version=get_server_version,
+            on_protocol=on_protocol,
+            on_setname=on_setname,
+        ):
+            if use_server_ver < 6 and use_protocol > 2:
+                with pytest.raises(ResponseError):
+                    _assert_connect(conn, tcp_address)
+                return
+
+            _assert_connect(conn, tcp_address)
+            if use_protocol == 3:
+                assert got_protocol == use_protocol
+            if use_auth:
+                if use_server_ver < 6:
+                    assert got_auth == ["mypassword"]
+                else:
+                    assert got_auth == ["myuser", "mypassword"]
+
+            if use_client_name:
+                assert got_name == _CLIENT_NAME
+            else:
+                assert got_name is None
+    finally:
+        conn.disconnect()
 
 
 def _assert_connect(conn, server_address, certfile=None, keyfile=None):

--- a/tests/test_resp.py
+++ b/tests/test_resp.py
@@ -1,6 +1,6 @@
-from .resp import encode
-
 import pytest
+
+from .resp import PushData, VerbatimString, encode, parse_all, parse_chunks
 
 
 @pytest.fixture(params=[2, 3])
@@ -44,6 +44,13 @@ class TestEncoder:
 
     def test_array(self):
         assert encode([1, 2, 3]) == b"*3\r\n:1\r\n:2\r\n:3\r\n"
+
+    def test_push_data(self, resp_version):
+        data = encode(PushData([1, 2, 3]), protocol=resp_version)
+        if resp_version == 2:
+            assert data == b"*3\r\n:1\r\n:2\r\n:3\r\n"
+        else:
+            assert data == b">3\r\n:1\r\n:2\r\n:3\r\n"
 
     def test_set(self, resp_version):
         data = encode({1, 2, 3}, protocol=resp_version)
@@ -95,3 +102,95 @@ class TestEncoder:
             assert data == b":0\r\n"
         else:
             assert data == b"f\r\n"
+
+
+@pytest.mark.parametrize("chunk_size", [0, 1, 2, -2])
+class TestParser:
+    def breakup_bytes(self, data, chunk_size=2):
+        insert_empty = False
+        if chunk_size < 0:
+            insert_empty = True
+            chunk_size = -chunk_size
+        chunks = [data[i : i + chunk_size] for i in range(0, len(data), chunk_size)]
+        if insert_empty:
+            empty = len(chunks) * [b""]
+            chunks = [item for pair in zip(chunks, empty) for item in pair]
+        return chunks
+
+    def parse_data(self, chunk_size, data):
+        """helper to parse either a single blob, or a list of chunks"""
+        if chunk_size == 0:
+            return parse_all(data)
+        else:
+            return parse_chunks(self.breakup_bytes(data, chunk_size))
+
+    def test_int(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b":123\r\n")
+        assert parsed == ([123], b"")
+
+        parsed = self.parse_data(chunk_size, b":123\r\nfoo")
+        assert parsed == ([123], b"foo")
+
+    def test_double(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b",1.23\r\njunk")
+        assert parsed == ([1.23], b"junk")
+
+    def test_array(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b"*3\r\n:1\r\n:2\r\n:3\r\n")
+        assert parsed == ([[1, 2, 3]], b"")
+
+        parsed = self.parse_data(chunk_size, b"*3\r\n:1\r\n:2\r\n:3\r\nfoo")
+        assert parsed == ([[1, 2, 3]], b"foo")
+
+    def test_push_data(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b">3\r\n:1\r\n:2\r\n:3\r\n")
+        assert isinstance(parsed[0][0], PushData)
+        assert parsed == ([[1, 2, 3]], b"")
+
+    def test_incomplete_list(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b"*3\r\n:1\r\n:2\r\n")
+        assert parsed == ([], b"*3\r\n:1\r\n:2\r\n")
+
+    def test_invalid_token(self, chunk_size):
+        with pytest.raises(ValueError):
+            self.parse_data(chunk_size, b")foo\r\n")
+        with pytest.raises(NotImplementedError):
+            self.parse_data(chunk_size, b"!foo\r\n")
+
+    def test_multiple_ints(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b":1\r\n:2\r\n:3\r\n")
+        assert parsed == ([1, 2, 3], b"")
+
+    def test_multiple_ints_and_junk(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b":1\r\n:2\r\n:3\r\n*3\r\n:1\r\n:2\r\n")
+        assert parsed == ([1, 2, 3], b"*3\r\n:1\r\n:2\r\n")
+
+    def test_set(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b"~3\r\n:1\r\n:2\r\n:3\r\n")
+        assert parsed == ([{1, 2, 3}], b"")
+
+    def test_list_of_sets(self, chunk_size):
+        parsed = self.parse_data(
+            chunk_size, b"*2\r\n~3\r\n:1\r\n:2\r\n:3\r\n~2\r\n:4\r\n:5\r\n"
+        )
+        assert parsed == ([[{1, 2, 3}, {4, 5}]], b"")
+
+    def test_map(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b"%2\r\n:1\r\n:2\r\n:3\r\n:4\r\n")
+        assert parsed == ([{1: 2, 3: 4}], b"")
+
+    def test_simple_string(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b"+foo\r\n")
+        assert parsed == (["foo"], b"")
+
+    def test_bulk_string(self, chunk_size):
+        parsed = parse_all(b"$3\r\nfoo\r\nbar")
+        assert parsed == ([b"foo"], b"bar")
+
+    def test_bulk_string_with_ctrl_chars(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b"$8\r\nfoo\r\nbar\r\n")
+        assert parsed == ([b"foo\r\nbar"], b"")
+
+    def test_verbatim_string(self, chunk_size):
+        parsed = self.parse_data(chunk_size, b"=3\r\ntxt:foo\r\nbar")
+        assert parsed == ([VerbatimString(b"foo", "txt")], b"bar")

--- a/tests/test_resp.py
+++ b/tests/test_resp.py
@@ -1,0 +1,97 @@
+from .resp import encode
+
+import pytest
+
+
+@pytest.fixture(params=[2, 3])
+def resp_version(request):
+    return request.param
+
+
+class TestEncoder:
+    def test_simple_str(self):
+        assert encode("foo") == b"+foo\r\n"
+
+    def test_long_str(self):
+        text = "fooling around with the sword in the mud"
+        assert len(text) == 40
+        assert encode(text) == b"$40\r\n" + text.encode() + b"\r\n"
+
+    # test strings with control characters
+    def test_str_with_ctrl_chars(self):
+        text = "foo\r\nbar"
+        assert encode(text) == b"$8\r\nfoo\r\nbar\r\n"
+
+    def test_bytes(self):
+        assert encode(b"foo") == b"$3\r\nfoo\r\n"
+
+    def test_int(self):
+        assert encode(123) == b":123\r\n"
+
+    def test_float(self, resp_version):
+        data = encode(1.23, protocol=resp_version)
+        if resp_version == 2:
+            assert data == b"+1.23\r\n"
+        else:
+            assert data == b",1.23\r\n"
+
+    def test_large_int(self, resp_version):
+        data = encode(2**63, protocol=resp_version)
+        if resp_version == 2:
+            assert data == b"+9223372036854775808\r\n"
+        else:
+            assert data == b"(9223372036854775808\r\n"
+
+    def test_array(self):
+        assert encode([1, 2, 3]) == b"*3\r\n:1\r\n:2\r\n:3\r\n"
+
+    def test_set(self, resp_version):
+        data = encode({1, 2, 3}, protocol=resp_version)
+        if resp_version == 2:
+            assert data == b"*3\r\n:1\r\n:2\r\n:3\r\n"
+        else:
+            assert data == b"~3\r\n:1\r\n:2\r\n:3\r\n"
+
+    def test_map(self, resp_version):
+        data = encode({1: 2, 3: 4}, protocol=resp_version)
+        if resp_version == 2:
+            assert data == b"*4\r\n:1\r\n:2\r\n:3\r\n:4\r\n"
+        else:
+            assert data == b"%2\r\n:1\r\n:2\r\n:3\r\n:4\r\n"
+
+    def test_nested_array(self):
+        assert encode([1, [2, 3]]) == b"*2\r\n:1\r\n*2\r\n:2\r\n:3\r\n"
+
+    def test_nested_map(self, resp_version):
+        data = encode({1: {2: 3}}, protocol=resp_version)
+        if resp_version == 2:
+            assert data == b"*2\r\n:1\r\n*2\r\n:2\r\n:3\r\n"
+        else:
+            assert data == b"%1\r\n:1\r\n%1\r\n:2\r\n:3\r\n"
+
+    def test_null(self, resp_version):
+        data = encode(None, protocol=resp_version)
+        if resp_version == 2:
+            assert data == b"$-1\r\n"
+        else:
+            assert data == b"_\r\n"
+
+    def test_mixed_array(self, resp_version):
+        data = encode([1, "foo", 2.3, None, True], protocol=resp_version)
+        if resp_version == 2:
+            assert data == b"*5\r\n:1\r\n+foo\r\n+2.3\r\n$-1\r\n:1\r\n"
+        else:
+            assert data == b"*5\r\n:1\r\n+foo\r\n,2.3\r\n_\r\nt\r\n"
+
+    def test_bool(self, resp_version):
+        data = encode(True, protocol=resp_version)
+        if resp_version == 2:
+            assert data == b":1\r\n"
+        else:
+            assert data == b"t\r\n"
+
+        data = encode(False, resp_version)
+        if resp_version == 2:
+            assert data == b":0\r\n"
+        else:
+            assert data == b"f\r\n"


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

This PR provides a transport agnostic RESP parser and encoder for the unit tests.
It also provides a simple, transport agnostic, RESP server.  This allows us to share code and logic
between sync and async code.
A parametrized test is added to test the connection handshake for different client settings against different fake REDIS servers,
both sync and async.

- the RESP parser / encoder is simple, assumes utf8 encoding, and always does decoding (from bytes to string.)
-  Decoding uses the 'surrogateescape' convention, so that if binary data was intended (a blob) it can always be recovered by re-encoding.
- Decoding supports most RESP 3 data types
- Encoding assumes utf8, and chooses RESP3 types if protocol 3 is enabled, when appropriate.
- RESP server receives resp command arrays and has handlers to respond.  Can be expanded to perform more extensive Redis emulation
- RESP server can be plugged into a sync or async request handler to simplify testing.

