### PR TITLE
Update reported version deprecation in asyncio.client

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -168,7 +168,7 @@ class Redis(
             warnings.warn(
                 DeprecationWarning(
                     '"auto_close_connection_pool" is deprecated '
-                    "since version 5.0.0. "
+                    "since version 5.0.1. "
                     "Please create a ConnectionPool explicitly and "
                     "provide to the Redis() constructor instead."
                 )
@@ -247,7 +247,7 @@ class Redis(
             warnings.warn(
                 DeprecationWarning(
                     '"auto_close_connection_pool" is deprecated '
-                    "since version 5.0.0. "
+                    "since version 5.0.1. "
                     "Please create a ConnectionPool explicitly and "
                     "provide to the Redis() constructor instead."
                 )
@@ -565,7 +565,7 @@ class Redis(
         ):
             await self.connection_pool.disconnect()
 
-    @deprecated_function(version="5.0.0", reason="Use aclose() instead", name="close")
+    @deprecated_function(version="5.0.1", reason="Use aclose() instead", name="close")
     async def close(self, close_connection_pool: Optional[bool] = None) -> None:
         """
         Alias for aclose(), for backwards compatibility
@@ -802,12 +802,12 @@ class PubSub:
             self.patterns = {}
             self.pending_unsubscribe_patterns = set()
 
-    @deprecated_function(version="5.0.0", reason="Use aclose() instead", name="close")
+    @deprecated_function(version="5.0.1", reason="Use aclose() instead", name="close")
     async def close(self) -> None:
         """Alias for aclose(), for backwards compatibility"""
         await self.aclose()
 
-    @deprecated_function(version="5.0.0", reason="Use aclose() instead", name="reset")
+    @deprecated_function(version="5.0.1", reason="Use aclose() instead", name="reset")
     async def reset(self) -> None:
         """Alias for aclose(), for backwards compatibility"""
         await self.aclose()


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] ~Do tests and lints pass with this change?~ N/A
- [ ] ~Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?~ N/A
- [ ] ~Is the new or changed code fully tested?~ N/A
- [ ] ~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~ N/A
- [ ] ~Is there an example added to the examples folder (if applicable)?~ N/A
- [ ] Was the change added to CHANGES file?


### Description of change

Update the reported version in which several things were deprecated in `redis.asyncio.client` in #2898 and #2913.  They may have been intended for 5.0.0, but they actually landed in 5.0.1 (as I found out when updating from one to the other today ;) ).
