### PR TITLE
Update client.py sleep_time typing for run_in_thread function

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1100,7 +1100,7 @@ class PubSub:
 
     def run_in_thread(
         self,
-        sleep_time: int = 0,
+        sleep_time: float = 0.0,
         daemon: bool = False,
         exception_handler: Optional[Callable] = None,
     ) -> "PubSubWorkerThread":


### PR DESCRIPTION

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

### Description of change

Changed from 
`sleep_time: int = 0`
to
`sleep_time: float = 0.0`
To avoid Pylance complaining: 
`Argument of type "float" cannot be assigned to parameter "sleep_time" of type "int" in function "run_in_thread"
  "float" is incompatible with "int"`

