### PR TITLE
Fix SlotNotCoveredError when cluster is resharding

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1195,7 +1195,11 @@ class NodesManager:
                 node_idx = self.read_load_balancer.get_server_index(
                     primary_name, len(self.slots_cache[slot])
                 )
-                return self.slots_cache[slot][node_idx]
+
+                # we use the node returned by RR in the load balancer
+                # if it's part of the slots cache, otherwise we use primary
+                node = node_idx if node_idx in self.slots_cache[slot] else 0
+                return self.slots_cache[slot][node]
             return self.slots_cache[slot][0]
         except (IndexError, TypeError):
             raise SlotNotCoveredError(

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1198,7 +1198,7 @@ class NodesManager:
 
                 # we use the node returned by RR in the load balancer
                 # if it's part of the slots cache, otherwise we use primary
-                node = node_idx if node_idx in self.slots_cache[slot] else 0
+                node = node_idx if node_idx < len(self.slots_cache[slot]) else 0
                 return self.slots_cache[slot][node]
             return self.slots_cache[slot][0]
         except (IndexError, TypeError):


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._

Fixes https://github.com/redis/redis-py/issues/2988