### PR TITLE
Fixes Redis.from_url() return type

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -94,7 +94,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
     """
 
     @classmethod
-    def from_url(cls, url: str, **kwargs) -> None:
+    def from_url(cls, url: str, **kwargs) -> "Redis":
         """
         Return a Redis client object configured from the given URL
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [√] Do tests and lints pass with this change?
- [√] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

Fixes return type of Redis.from_url() (was None, now "Redis") 

fixes #2971 
