### PR TITLE
Better deal with "lost" connections for async Redis

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -546,6 +546,7 @@ class Redis(
                 _grl().call_exception_handler(context)
             except RuntimeError:
                 pass
+            self.connection._close()
 
     async def aclose(self, close_connection_pool: Optional[bool] = None) -> None:
         """

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -5,6 +5,7 @@ import inspect
 import socket
 import ssl
 import sys
+import warnings
 import weakref
 from abc import abstractmethod
 from itertools import chain
@@ -203,6 +204,24 @@ class AbstractConnection:
             if p < 2 or p > 3:
                 raise ConnectionError("protocol must be either 2 or 3")
             self.protocol = protocol
+
+    def __del__(self, _warnings: Any = warnings):
+        # For some reason, the individual streams don't get properly garbage
+        # collected and therefore produce no resource warnings.  We add one
+        # here, in the same style as those from the stdlib.
+        if getattr(self, "_writer", None):
+            _warnings.warn(
+                f"unclosed Connection {self!r}", ResourceWarning, source=self
+            )
+            self._close()
+
+    def _close(self):
+        """
+        Internal method to silently close the connection without waiting
+        """
+        if self._writer:
+            self._writer.close()
+            self._writer = self._reader = None
 
     def __repr__(self):
         repr_args = ",".join((f"{k}={v}" for k, v in self.repr_pieces()))
@@ -1017,7 +1036,7 @@ class ConnectionPool:
 
     def reset(self):
         self._available_connections = []
-        self._in_use_connections = set()
+        self._in_use_connections = weakref.WeakSet()
 
     def can_get_connection(self) -> bool:
         """Return True if a connection can be retrieved from the pool."""

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -436,3 +436,50 @@ async def test_redis_pool_auto_close_arg(request, auto_close):
 
     assert called == 0
     await pool.disconnect()
+
+
+async def test_client_garbage_collection(request):
+    """
+    Test that a Redis client will call _close() on any
+    connection that it holds at time of destruction
+    """
+
+    url: str = request.config.getoption("--redis-url")
+    pool = ConnectionPool.from_url(url)
+
+    # create a client with a connection from the pool
+    client = Redis(connection_pool=pool, single_connection_client=True)
+    await client.initialize()
+    with mock.patch.object(client, "connection") as a:
+        # we cannot, in unittests, or from asyncio, reliably trigger garbage collection
+        # so we must just invoke the handler
+        client.__del__()
+        assert a._close.called
+
+    await client.aclose()
+    await pool.aclose()
+
+
+async def test_connection_garbage_collection(request):
+    """
+    Test that a Connection object will call close() on the
+    stream that it holds.
+    """
+
+    url: str = request.config.getoption("--redis-url")
+    pool = ConnectionPool.from_url(url)
+
+    # create a client with a connection from the pool
+    client = Redis(connection_pool=pool, single_connection_client=True)
+    await client.initialize()
+    conn = client.connection
+
+    with mock.patch.object(conn, "_reader"):
+        with mock.patch.object(conn, "_writer") as a:
+            # we cannot, in unittests, or from asyncio, reliably trigger garbage collection
+            # so we must just invoke the handler
+            conn.__del__()
+            assert a.close.called
+
+    await client.aclose()
+    await pool.aclose()

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -478,8 +478,8 @@ async def test_connection_garbage_collection(request):
 
     with mock.patch.object(conn, "_reader"):
         with mock.patch.object(conn, "_writer") as a:
-            # we cannot, in unittests, or from asyncio, reliably trigger garbage collection
-            # so we must just invoke the handler
+            # we cannot, in unittests, or from asyncio, reliably trigger
+            # garbage collection so we must just invoke the handler
             with pytest.warns(ResourceWarning):
                 conn.__del__()
                 assert a.close.called


### PR DESCRIPTION
ConnectionPool keeps a WeakSet of in_use connections, allowing lost ones to be collected. Collection produces a warning and closes the underlying transport.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Recent changes, which removed the __del__ handling of lost connections, have illustrated how fragile many applications
are.  This PR attempts to improve on this, by better tracking "lost" connections.
See #2995 for various manifestations of this problem.

- `ConnectionPool` objects now keep a `WeakSet` of `in_use_connections`.  This allows the garbage collector to find such
  objects if they are not returned to the pool for some reason.
- Connection objects now have a `__del__` method which outputs a `ResourceWarning` in the same way as other IO classes
  in the standard library.  For some reason, the underlying "stream" objects do not get garbage collected promptly.  The
  `Connection` will perform a non-async `close()` call on these connections.  This may or may not work, since there may or may
  not be an active event loop in place, but in that case, an error is emitted.  In both cases, the developer should become aware
  of there being a problem.
- `Redis` objects call `_close()` on their connection objects if _they_ get garbage collected.

NOTE:  To see the `ResourceWarnings`, they need to be enabled.  By default they are suppressed.  Add, for instance
the `-W default::ResourceWarning` to the python command line.
