### PR TITLE
Fix ConnectionPool deadlock triggered by gc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -55,6 +55,7 @@
     * Fix for Unhandled exception related to self.host with unix socket (#2496)
     * Improve error output for master discovery 
     * Make `ClusterCommandsProtocol` an actual Protocol
+    * Fix ConnectionPool deadlock triggered by gc
 
 * 4.1.3 (Feb 8, 2022)
   * Fix flushdb and flushall (#1926)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1008,7 +1008,7 @@ class ConnectionPool:
         )
 
     def reset(self) -> None:
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._created_connections = 0
         self._available_connections = []
         self._in_use_connections = set()


### PR DESCRIPTION
Garbage collector sometimes are invoked in block of code which acquired ConnectionPool._lock. This cause deadlock blocking indefinitely whole thread.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
