### PR TITLE
Adding lock_name to LockError

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Add an optional lock_name attribute to LockError.
     * Add 'aclose()' methods to async classes, deprecate async close().
     * Fix #2831, add auto_close_connection_pool=True arg to asyncio.Redis.from_url()
     * Fix incorrect redis.asyncio.Cluster type hint for `retry_on_error`

--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -81,7 +81,10 @@ class LockError(RedisError, ValueError):
     "Errors acquiring or releasing a lock"
     # NOTE: For backwards compatibility, this class derives from ValueError.
     # This was originally chosen to behave like threading.Lock.
-    pass
+
+    def __init__(self, message, lock_name=None):
+        self.message = message
+        self.lock_name = lock_name
 
 
 class LockNotOwnedError(LockError):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -242,6 +242,13 @@ class TestLock:
             with self.get_lock(r, "foo", timeout=10, blocking=False):
                 r.set("foo", "a")
 
+    def test_lock_error_gives_correct_lock_name(self, r):
+        r.set("foo", "bar")
+        with pytest.raises(LockError) as excinfo:
+            with self.get_lock(r, "foo", blocking_timeout=0.1):
+                pass
+            assert excinfo.value.lock_name == "foo"
+
 
 class TestLockClassSelection:
     def test_lock_class_argument(self, r):


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [X] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This PR adds an optional `lock_name` attribute to `LockError`.
The main goal behind this PR is to be able to retrieve which Lock failed when excepting a `LockError` exception.
