### PR TITLE
Add "sum" to DUPLICATE_POLICY documentation of TS.CREATE, TS.ADD and TS.ALTER

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -55,6 +55,7 @@
     * Fix for Unhandled exception related to self.host with unix socket (#2496)
     * Improve error output for master discovery 
     * Make `ClusterCommandsProtocol` an actual Protocol
+    * Add `sum` to DUPLICATE_POLICY documentation of `TS.CREATE`, `TS.ADD` and `TS.ALTER`
 
 * 4.1.3 (Feb 8, 2022)
   * Fix flushdb and flushall (#1926)

--- a/redis/commands/timeseries/commands.py
+++ b/redis/commands/timeseries/commands.py
@@ -59,6 +59,9 @@ class TimeSeriesCommands:
             - 'last': override with latest value.
             - 'min': only override if the value is lower than the existing value.
             - 'max': only override if the value is higher than the existing value.
+            - 'sum': If a previous sample exists, add the new sample to it so that \
+            the updated value is equal to (previous + new). If no previous sample \
+            exists, set the updated value equal to the new value.
 
         For more information: https://redis.io/commands/ts.create/
         """  # noqa
@@ -103,6 +106,9 @@ class TimeSeriesCommands:
             - 'last': override with latest value.
             - 'min': only override if the value is lower than the existing value.
             - 'max': only override if the value is higher than the existing value.
+            - 'sum': If a previous sample exists, add the new sample to it so that \
+            the updated value is equal to (previous + new). If no previous sample \
+            exists, set the updated value equal to the new value.
 
         For more information: https://redis.io/commands/ts.alter/
         """  # noqa
@@ -154,6 +160,9 @@ class TimeSeriesCommands:
             - 'last': override with latest value.
             - 'min': only override if the value is lower than the existing value.
             - 'max': only override if the value is higher than the existing value.
+            - 'sum': If a previous sample exists, add the new sample to it so that \
+            the updated value is equal to (previous + new). If no previous sample \
+            exists, set the updated value equal to the new value.
 
         For more information: https://redis.io/commands/ts.add/
         """  # noqa


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

The `sum` option in `DUPLICATE_POLICY` was added in RedisTimeSeries v1.4.6, but it was missing from the documentation of the following three functions:
- `TS.CREATE`
- `TS.ADD`
- `TS.ALTER`