### PR TITLE
Add lock to Pubsub.execute_command to ensure only one connection is created

### DIFF
--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1153,3 +1153,22 @@ class TestBaseException:
 
         # the timeout on the read should not cause disconnect
         assert is_connected()
+
+
+@pytest.mark.onlynoncluster
+class TestConnectionLeak:
+    def test_connection_leak(self, r: redis.Redis):
+        pubsub = r.pubsub()
+
+        def test():
+            tid = threading.get_ident()
+            pubsub.subscribe(f"foo{tid}")
+
+        threads = [threading.Thread(target=test) for _ in range(10)]
+        for thread in threads:
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        assert r.connection_pool._created_connections == 2


### PR DESCRIPTION
### Pull Request check-list

- [v] Do tests and lints pass with this change?
- [v] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [v] Is the new or changed code fully tested?
- [] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

If multiple threads sharing single pubsub instance calls pubsub command simultaneously, connection leak is observed from pubsub's `execute_command` function.

This PR fixes the issue by adding the lock on connection fetch.