### PR TITLE
Fix parsing of `FT.PROFILE` result

### DIFF
--- a/redis/commands/helpers.py
+++ b/redis/commands/helpers.py
@@ -64,6 +64,11 @@ def parse_list_to_dict(response):
     for i in range(0, len(response), 2):
         if isinstance(response[i], list):
             res["Child iterators"].append(parse_list_to_dict(response[i]))
+            try:
+                if isinstance(response[i + 1], list):
+                    res["Child iterators"].append(parse_list_to_dict(response[i + 1]))
+            except IndexError:
+                pass
         elif isinstance(response[i + 1], list):
             res["Child iterators"] = [parse_list_to_dict(response[i + 1])]
         else:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -41,6 +41,7 @@ def test_parse_to_dict():
                 "Child iterators",
                 ["Type", "bar", "Time", "0.0729", "Counter", 3],
                 ["Type", "barbar", "Time", "0.058", "Counter", 3],
+                ["Type", "barbarbar", "Time", "0.0234", "Counter", 3],
             ],
         ],
     ]
@@ -49,6 +50,7 @@ def test_parse_to_dict():
             "Child iterators": [
                 {"Counter": 3.0, "Time": 0.0729, "Type": "bar"},
                 {"Counter": 3.0, "Time": 0.058, "Type": "barbar"},
+                {"Counter": 3.0, "Time": 0.0234, "Type": "barbarbar"},
             ],
             "Counter": 3.0,
             "Time": 0.2089,


### PR DESCRIPTION
### Description of change

Fix the parsing of ft.profile result - before this fix, if there are more than 2 child iterators some of them are skipped (because the loop is in pairs), and the result is wrong