### PR TITLE
unused example ID causes entire file to be shown

### DIFF
--- a/doctests/dt_stream.py
+++ b/doctests/dt_stream.py
@@ -76,6 +76,10 @@ except redis.exceptions.ResponseError as e:
     print(e)  # >>> WRONGID
 # STEP_END
 
+# STEP_START xadd_7
+# Not yet implemented
+# STEP_END
+
 # STEP_START xrange_all
 res11 = r.xrange("race:france", "-", "+")
 print(


### PR DESCRIPTION
xadd_7 is a redis 7 feature and had not yet been implemented - will update when it is but currently it leads to unexpected behavior on the website to have it missing