### PR TITLE
Fix return types in json commands

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Fix return types for `get`, `set_path` and `strappend` in JSONCommands
     * Fix async `read_response` to use `disable_decoding`.
     * Add 'aclose()' methods to async classes, deprecate async close().
     * Fix #2831, add auto_close_connection_pool=True arg to asyncio.Redis.from_url()

--- a/redis/commands/json/commands.py
+++ b/redis/commands/json/commands.py
@@ -173,7 +173,7 @@ class JSONCommands:
 
     def get(
         self, name: str, *args, no_escape: Optional[bool] = False
-    ) -> List[JsonType]:
+    ) -> Optional[List[JsonType]]:
         """
         Get the object stored as a JSON value at key ``name``.
 
@@ -324,7 +324,7 @@ class JSONCommands:
         nx: Optional[bool] = False,
         xx: Optional[bool] = False,
         decode_keys: Optional[bool] = False,
-    ) -> List[Dict[str, bool]]:
+    ) -> Dict[str, bool]:
         """
         Iterate over ``root_folder`` and set each JSON file to a value
         under ``json_path`` with the file name as the key.
@@ -377,7 +377,7 @@ class JSONCommands:
         return self.execute_command("JSON.TOGGLE", name, str(path))
 
     def strappend(
-        self, name: str, value: str, path: Optional[int] = Path.root_path()
+        self, name: str, value: str, path: Optional[str] = Path.root_path()
     ) -> Union[int, List[Optional[int]]]:
         """Append to the string JSON value. If two options are specified after
         the key name, the path is determined to be the first. If a single


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] ~Is the new or changed code fully tested?~ N/A
- [ ] ~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~ N/A
- [ ] ~Is there an example added to the examples folder (if applicable)?~ N/A
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Fix return types for `get`, `set_path` and `strappend` in `redis.commands.json.commands.JSONCommands`
