### PR TITLE
Fix Specifying Target Nodes broken hyperlink

### DIFF
--- a/docs/clustering.rst
+++ b/docs/clustering.rst
@@ -92,7 +92,7 @@ The ‘target_nodes’ parameter is explained in the following section,
    >>> # target-node: default-node
    >>> rc.ping()
 
-Specfiying Target Nodes
+Specifying Target Nodes
 -----------------------
 
 As mentioned above, all non key-based RedisCluster commands accept the


### PR DESCRIPTION
The typo cause hyperlinks to fail.