### PR TITLE
fix(docs): organize cluster mode part of lua scripting

### DIFF
--- a/docs/lua_scripting.rst
+++ b/docs/lua_scripting.rst
@@ -92,19 +92,24 @@ Cluster Mode
 
 Cluster mode has limited support for lua scripting.
 
-The following commands are supported, with caveats: - ``EVAL`` and
-``EVALSHA``: The command is sent to the relevant node, depending on the
-keys (i.e., in ``EVAL "<script>" num_keys key_1 ... key_n ...``). The
-keys *must* all be on the same node. If the script requires 0 keys, *the
-command is sent to a random (primary) node*. - ``SCRIPT EXISTS``: The
-command is sent to all primaries. The result is a list of booleans
-corresponding to the input SHA hashes. Each boolean is an AND of “does
-the script exist on each node?”. In other words, each boolean is True
-iff the script exists on all nodes. - ``SCRIPT FLUSH``: The command is
-sent to all primaries. The result is a bool AND over all nodes’
-responses. - ``SCRIPT LOAD``: The command is sent to all primaries. The
-result is the SHA1 digest.
+The following commands are supported, with caveats:
 
-The following commands are not supported: - ``EVAL_RO`` - ``EVALSHA_RO``
+- ``EVAL`` and ``EVALSHA``: The command is sent to the relevant node,
+  depending on the keys (i.e., in ``EVAL "<script>" num_keys key_1 ...
+  key_n ...``). The keys *must* all be on the same node. If the script
+  requires 0 keys, *the command is sent to a random (primary) node*.
+- ``SCRIPT EXISTS``: The command is sent to all primaries. The result
+  is a list of booleans corresponding to the input SHA hashes. Each
+  boolean is an AND of “does the script exist on each node?”. In other
+  words, each boolean is True iff the script exists on all nodes.
+- ``SCRIPT FLUSH``: The command is sent to all primaries. The result
+  is a bool AND over all nodes’ responses.
+- ``SCRIPT LOAD``: The command is sent to all primaries. The result
+  is the SHA1 digest.
+
+The following commands are not supported:
+
+- ``EVAL_RO``
+- ``EVALSHA_RO``
 
 Using scripting within pipelines in cluster mode is **not supported**.


### PR DESCRIPTION
### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change?  
   -> [link](https://github.com/mattwang44/redis-py/pull/1)
- [x] Is the new or changed code fully tested?
   -> N/A,  only doc change
- [x] Is a documentation update included?
- [x] Is there an example added to the examples folder (if applicable)?
   -> Not applicable
- [x] Was the change added to CHANGES file?
   -> No need


### Description of change

Current doc preview ([link](https://redis-py.readthedocs.io/en/stable/lua_scripting.html)):

<img width="789" alt="image" src="https://github.com/redis/redis-py/assets/24987826/4c092348-a95d-44f7-9cbd-7d8478230efb">


PR preview:

<img width="798" alt="image" src="https://github.com/redis/redis-py/assets/24987826/9c818286-4779-47c1-b138-6b45b16219da">
