### PR TITLE
Allow multiple LOAD arguments with wildcard LOAD aggregations

### DIFF
--- a/redis/commands/search/aggregation.py
+++ b/redis/commands/search/aggregation.py
@@ -321,7 +321,10 @@ class AggregateRequest:
         if self._loadall:
             ret.append("LOAD")
             ret.append("*")
-        elif self._loadfields:
+
+        # NOTE(imalinovskyi): Users should be able to use @__key attribute
+        # in wildcard queries
+        if self._loadfields:
             ret.append("LOAD")
             ret.append(str(len(self._loadfields)))
             ret.extend(self._loadfields)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Users should be able to use `@__key` attribute alongside with `LOAD *`. Currently, it's not possible to build an aggregation request for the command like this:
```
    res = r.execute_command(
        'ft.aggregate', 'games', '*', 'LOAD', '2', '@nonexist', '@price',
        'SORTBY', 1, '@nonexist', 'MAX', 10,
        'LOAD', '3', '@__key', 'AS', 'key',
    )
```   