### PR TITLE
PythonRespSerializer: better chunking

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -309,9 +309,9 @@ class TestPythonRespSerializer:
 
     def test_pack_buffer_cutoff_average(self):
         expected = [
-            b"*2\r\n$3\r\nGET\r\n$1\r\n",
-            b"a",
-            b"\r\n",
+            b"*2\r\n$3\r\n",
+            b"GET\r\n",
+            b"$1\r\na\r\n",
         ]
         assert b"".join(expected) == self.GET_A_ENCODED
 
@@ -322,11 +322,11 @@ class TestPythonRespSerializer:
 
     def test_pack_buffer_cutoff_min(self):
         expected = [
-            b"*2\r\n$3\r\n",
-            b"GET",
-            b"\r\n$1\r\n",
-            b"a",
-            b"\r\n",
+            b"*2\r\n",
+            b"$3\r\n",
+            b"GET\r\n",
+            b"$1\r\n",
+            b"a\r\n",
         ]
         assert b"".join(expected) == self.GET_A_ENCODED
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Previous implementation made no difference between memoryviews, that must be sent separately to avoid copying, and just reaching buffer_cutoff. That resulted in some single values being sent separately for no reason, so a chunk could be just a single encoded integer, even though the buffer_cutoff is pretty large.
