### PR TITLE
skip `ssl` import if not available

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -80,10 +80,8 @@ from redis.utils import (
 )
 
 if TYPE_CHECKING and SSL_AVAILABLE:
-    import ssl
     from ssl import TLSVersion
 else:
-    ssl = None
     TLSVersion = None
 
 PubSubHandler = Callable[[Dict[str, str]], Awaitable[None]]

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -2,7 +2,6 @@ import asyncio
 import copy
 import inspect
 import re
-import ssl
 import warnings
 from typing import (
     TYPE_CHECKING,
@@ -72,12 +71,20 @@ from redis.exceptions import (
 from redis.typing import ChannelT, EncodableT, KeyT
 from redis.utils import (
     HIREDIS_AVAILABLE,
+    SSL_AVAILABLE,
     _set_info_logger,
     deprecated_function,
     get_lib_version,
     safe_str,
     str_if_bytes,
 )
+
+if TYPE_CHECKING and SSL_AVAILABLE:
+    import ssl
+    from ssl import TLSVersion
+else:
+    ssl = None
+    TLSVersion = None
 
 PubSubHandler = Callable[[Dict[str, str]], Awaitable[None]]
 _KeyT = TypeVar("_KeyT", bound=KeyT)
@@ -226,7 +233,7 @@ class Redis(
         ssl_ca_certs: Optional[str] = None,
         ssl_ca_data: Optional[str] = None,
         ssl_check_hostname: bool = False,
-        ssl_min_version: Optional[ssl.TLSVersion] = None,
+        ssl_min_version: Optional[TLSVersion] = None,
         ssl_ciphers: Optional[str] = None,
         max_connections: Optional[int] = None,
         single_connection_client: bool = False,

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -68,14 +68,12 @@ from redis.utils import (
     deprecated_function,
     get_lib_version,
     safe_str,
-    str_if_bytes
+    str_if_bytes,
 )
 
 if SSL_AVAILABLE:
-    import ssl
     from ssl import TLSVersion
 else:
-    ssl = None
     TLSVersion = None
 
 TargetNodesT = TypeVar(

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2,7 +2,6 @@ import asyncio
 import collections
 import random
 import socket
-import ssl
 import warnings
 from typing import (
     Any,
@@ -64,7 +63,20 @@ from redis.exceptions import (
     TryAgainError,
 )
 from redis.typing import AnyKeyT, EncodableT, KeyT
-from redis.utils import deprecated_function, get_lib_version, safe_str, str_if_bytes
+from redis.utils import (
+    SSL_AVAILABLE,
+    deprecated_function,
+    get_lib_version,
+    safe_str,
+    str_if_bytes
+)
+
+if SSL_AVAILABLE:
+    import ssl
+    from ssl import TLSVersion
+else:
+    ssl = None
+    TLSVersion = None
 
 TargetNodesT = TypeVar(
     "TargetNodesT", str, "ClusterNode", List["ClusterNode"], Dict[Any, "ClusterNode"]
@@ -247,7 +259,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         ssl_certfile: Optional[str] = None,
         ssl_check_hostname: bool = False,
         ssl_keyfile: Optional[str] = None,
-        ssl_min_version: Optional[ssl.TLSVersion] = None,
+        ssl_min_version: Optional[TLSVersion] = None,
         ssl_ciphers: Optional[str] = None,
         protocol: Optional[int] = 2,
         address_remap: Optional[Callable[[Tuple[str, int]], Tuple[str, int]]] = None,

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -10,7 +10,6 @@ from abc import abstractmethod
 from itertools import chain
 from types import MappingProxyType
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Iterable,
@@ -29,7 +28,7 @@ from urllib.parse import ParseResult, parse_qs, unquote, urlparse
 
 from ..utils import SSL_AVAILABLE
 
-if TYPE_CHECKING and SSL_AVAILABLE:
+if SSL_AVAILABLE:
     import ssl
     from ssl import SSLContext, TLSVersion
 else:

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -31,7 +31,7 @@ from ..utils import SSL_AVAILABLE
 
 if TYPE_CHECKING and SSL_AVAILABLE:
     import ssl
-    from ssl import TLSVersion, SSLContext
+    from ssl import SSLContext, TLSVersion
 else:
     ssl = None
     TLSVersion = None

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,7 +1,6 @@
 import copy
 import os
 import socket
-import ssl
 import sys
 import threading
 import time
@@ -48,6 +47,11 @@ from .utils import (
     get_lib_version,
     str_if_bytes,
 )
+
+if SSL_AVAILABLE:
+    import ssl
+else:
+    ssl = None
 
 if HIREDIS_AVAILABLE:
     import hiredis


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

`utils.py` has support for detecting whether the `ssl` module is available, and we can use this to omit SSL-specific funcionality while still providing other features (e.g. unencrypted connections).

Prior to this patch, the `connection.py` modules both triggered an `ImportError` due to unconditional imports of the `ssl` module.  Now, we check `utils.SSL_AVAILABLE` prior to attempting the import and only raise an error later if (and only if) the application requests an encrypted connection.  This helps support platforms such as `wasm32-wasi` where the `ssl` module is not built by default.

Ideally, this would be tested in CI using a Python built without `ssl` support.  I'm not sure how feasible that is, though; I'm open to guidance on that aspect.