### PR TITLE
Make the connection Pool Class configurable

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -206,6 +206,7 @@ class Redis(
         socket_keepalive: Optional[bool] = None,
         socket_keepalive_options: Optional[Mapping[int, Union[int, bytes]]] = None,
         connection_pool: Optional[ConnectionPool] = None,
+        connection_pool_class: Type = ConnectionPool,
         unix_socket_path: Optional[str] = None,
         encoding: str = "utf-8",
         encoding_errors: str = "strict",
@@ -315,7 +316,7 @@ class Redis(
                     )
             # This arg only used if no pool is passed in
             self.auto_close_connection_pool = auto_close_connection_pool
-            connection_pool = ConnectionPool(**kwargs)
+            connection_pool = connection_pool_class(**kwargs)
         else:
             # If a pool is passed in, do not close it
             self.auto_close_connection_pool = False


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
If you want to constrict an Async Redis using a redis connection pool, you need to use a sentinel managed connection pool, but it's duplicating logic to construct one, and have logic to construct one. 
_Please provide a description of the change here._
