### PR TITLE
Always submitting codecov

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -89,7 +89,6 @@ jobs:
 
        - name: Upload codecov coverage
          uses: codecov/codecov-action@v3
-         if: ${{matrix.python-version == '3.11'}}
          with:
            fail_ci_if_error: false
 


### PR DESCRIPTION
Based on research, it turns out that codecov is already, and will generally merge coverage reports. That being the case, it doesn't make sense to limit this to Python 3.11 only.