### PR TITLE
Documentation update (asyncio_examples.ipynb)

### DIFF
--- a/docs/examples/asyncio_examples.ipynb
+++ b/docs/examples/asyncio_examples.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "## Connecting and Disconnecting\n",
     "\n",
-    "Utilizing asyncio Redis requires an explicit disconnect of the connection since there is no asyncio deconstructor magic method. By default, a connection pool is created on `redis.Redis()` and attached to this `Redis` instance. The connection pool closes automatically on the call to `Redis.aclose` which disconnects all connections."
+    "Using asyncio Redis requires an explicit disconnect of the connection since there is no asyncio deconstructor magic method. By default, an internal connection pool is created on `redis.Redis()` and attached to the `Redis` instance. When calling `Redis.aclose` this internal connection pool closes automatically, which disconnects all connections."
    ]
   },
   {
@@ -48,7 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you create custom `ConnectionPool` for the `Redis` instance to use alone, use the `from_pool` class method to create it.  This will cause the pool to be disconnected along with the Redis instance. Disconnecting the connection pool simply disconnects all connections hosted in the pool."
+    "If you create a custom `ConnectionPool` to be used by a single `Redis` instance, use the `Redis.from_pool` class method. The Redis client will take ownership of the connection pool. This will cause the pool to be disconnected along with the Redis instance. Disconnecting the connection pool simply disconnects all connections hosted in the pool."
    ]
   },
   {
@@ -61,7 +61,7 @@
     "\n",
     "pool = redis.ConnectionPool.from_url(\"redis://localhost\")\n",
     "client = redis.Redis.from_pool(pool)\n",
-    "await client.close()"
+    "await client.aclose()"
    ]
   },
   {
@@ -74,7 +74,7 @@
    },
    "source": [
     "\n",
-    "However, If you supply a `ConnectionPool` that is shared several `Redis` instances, you may want to disconnect the connection pool explicitly. use the `connection_pool` argument in that case."
+    "However, if the `ConnectionPool` is to be shared by several `Redis` instances, you should use the `connection_pool` argument, and you may want to disconnect the connection pool explicitly."
    ]
   },
   {


### PR DESCRIPTION
Clarified wording + one case of deprecated .close() changed to .aclose()