### PR TITLE
Remove typing-extensions from deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 async-timeout>=4.0.2
-typing-extensions; python_version<"3.8"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     author_email="oss@redis.com",
     python_requires=">=3.8",
     install_requires=[
-        'typing-extensions; python_version<"3.8"',
         'async-timeout>=4.0.3',
     ],
     classifiers=[


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Removes typing-extensions from dependencies.
It's not used, and this library requires Python 3.8+.

