### PR TITLE
Ignore TypeError on disconnect (within multiprocess)

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -451,7 +451,7 @@ class AbstractConnection:
         if os.getpid() == self.pid:
             try:
                 conn_sock.shutdown(socket.SHUT_RDWR)
-            except OSError:
+            except (OSError, TypeError):
                 pass
 
         try:


### PR DESCRIPTION
Exception ignored in: <function Redis.\_\_del\_\_ at ...>
Traceback ....
TypeError: 'NoneType' object cannot be interpreted as an integer.

This happens when closing the connection within a spawned Process (multiprocess).

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Adding TypeError to exept..
