### PR TITLE
Support NOVALUES parameter for HSCAN

### DIFF
--- a/redis/_parsers/helpers.py
+++ b/redis/_parsers/helpers.py
@@ -354,7 +354,12 @@ def parse_scan(response, **options):
 
 def parse_hscan(response, **options):
     cursor, r = response
-    return int(cursor), r and pairs_to_dict(r) or {}
+    no_values = options.get("no_values", False)
+    if no_values:
+        payload = r or []
+    else:
+        payload = r and pairs_to_dict(r) or {}
+    return int(cursor), payload
 
 
 def parse_zscan(response, **options):

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3112,8 +3112,7 @@ class ScanCommands(CommandsProtocol):
 
         ``count`` allows for hint the minimum number of returns
 
-        ``no_values`` indicates to return only the keys, without values. The
-        return type in this case is a list of keys.
+        ``no_values`` indicates to return only the keys, without values.
 
         For more information see https://redis.io/commands/hscan
         """
@@ -3284,8 +3283,12 @@ class AsyncScanCommands(ScanCommands):
             cursor, data = await self.hscan(
                 name, cursor=cursor, match=match, count=count, no_values=no_values
             )
-            for it in data.items():
-                yield it
+            if no_values:
+                for it in data:
+                    yield it
+            else:
+                for it in data.items():
+                    yield it
 
     async def zscan_iter(
         self,

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -1349,6 +1349,19 @@ class TestRedisCommands:
         assert dic == {b"a": b"1", b"b": b"2", b"c": b"3"}
         _, dic = await r.hscan("a", match="a")
         assert dic == {b"a": b"1"}
+        _, dic = await r.hscan("a_notset", match="a")
+        assert dic == {}
+
+    @skip_if_server_version_lt("7.4.0")
+    async def test_hscan_novalues(self, r: redis.Redis):
+        await r.hset("a", mapping={"a": 1, "b": 2, "c": 3})
+        cursor, keys = await r.hscan("a", no_values=True)
+        assert cursor == 0
+        assert sorted(keys) == [b"a", b"b", b"c"]
+        _, keys = await r.hscan("a", match="a", no_values=True)
+        assert keys == [b"a"]
+        _, keys = await r.hscan("a_notset", match="a", no_values=True)
+        assert keys == []
 
     @skip_if_server_version_lt("2.8.0")
     async def test_hscan_iter(self, r: redis.Redis):
@@ -1357,6 +1370,18 @@ class TestRedisCommands:
         assert dic == {b"a": b"1", b"b": b"2", b"c": b"3"}
         dic = {k: v async for k, v in r.hscan_iter("a", match="a")}
         assert dic == {b"a": b"1"}
+        dic = {k: v async for k, v in r.hscan_iter("a_notset", match="a")}
+        assert dic == {}
+
+    @skip_if_server_version_lt("7.4.0")
+    async def test_hscan_iter_novalues(self, r: redis.Redis):
+        await r.hset("a", mapping={"a": 1, "b": 2, "c": 3})
+        keys = list([k async for k in r.hscan_iter("a", no_values=True)])
+        assert sorted(keys) == [b"a", b"b", b"c"]
+        keys = list([k async for k in r.hscan_iter("a", match="a", no_values=True)])
+        assert keys == [b"a"]
+        keys = list([k async for k in r.hscan_iter("a", match="a_notset", no_values=True)])
+        assert keys == []
 
     @skip_if_server_version_lt("2.8.0")
     async def test_zscan(self, r: redis.Redis):

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -1380,7 +1380,9 @@ class TestRedisCommands:
         assert sorted(keys) == [b"a", b"b", b"c"]
         keys = list([k async for k in r.hscan_iter("a", match="a", no_values=True)])
         assert keys == [b"a"]
-        keys = list([k async for k in r.hscan_iter("a", match="a_notset", no_values=True)])
+        keys = list(
+            [k async for k in r.hscan_iter("a", match="a_notset", no_values=True)]
+        )
         assert keys == []
 
     @skip_if_server_version_lt("2.8.0")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2162,6 +2162,19 @@ class TestRedisCommands:
         assert dic == {b"a": b"1", b"b": b"2", b"c": b"3"}
         _, dic = r.hscan("a", match="a")
         assert dic == {b"a": b"1"}
+        _, dic = r.hscan("a_notset")
+        assert dic == {}
+
+    @skip_if_server_version_lt("7.4.0")
+    def test_hscan_novalues(self, r):
+        r.hset("a", mapping={"a": 1, "b": 2, "c": 3})
+        cursor, keys = r.hscan("a", no_values=True)
+        assert cursor == 0
+        assert keys == [b"a", b"b", b"c"]
+        _, keys = r.hscan("a", match="a", no_values=True)
+        assert keys == [b"a"]
+        _, keys = r.hscan("a_notset", no_values=True)
+        assert keys == []
 
     @skip_if_server_version_lt("2.8.0")
     def test_hscan_iter(self, r):
@@ -2170,6 +2183,18 @@ class TestRedisCommands:
         assert dic == {b"a": b"1", b"b": b"2", b"c": b"3"}
         dic = dict(r.hscan_iter("a", match="a"))
         assert dic == {b"a": b"1"}
+        dic = dict(r.hscan_iter("a_notset"))
+        assert dic == {}
+
+    @skip_if_server_version_lt("7.4.0")
+    def test_hscan_iter_novalues(self, r):
+        r.hset("a", mapping={"a": 1, "b": 2, "c": 3})
+        keys = list(r.hscan_iter("a", no_values=True))
+        assert keys == [b"a", b"b", b"c"]
+        keys = list(r.hscan_iter("a", match="a", no_values=True))
+        assert keys == [b"a"]
+        keys = list(r.hscan_iter("a_notset", no_values=True))
+        assert keys == []
 
     @skip_if_server_version_lt("2.8.0")
     def test_zscan(self, r):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2170,7 +2170,7 @@ class TestRedisCommands:
         r.hset("a", mapping={"a": 1, "b": 2, "c": 3})
         cursor, keys = r.hscan("a", no_values=True)
         assert cursor == 0
-        assert keys == [b"a", b"b", b"c"]
+        assert sorted(keys) == [b"a", b"b", b"c"]
         _, keys = r.hscan("a", match="a", no_values=True)
         assert keys == [b"a"]
         _, keys = r.hscan("a_notset", no_values=True)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Issue #3153

The NOVALUES parameter instructs HSCAN to only return the hash keys, without values.