### PR TITLE
Make `message` in LockError optional to support backwards compatibility

### DIFF
--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -82,7 +82,7 @@ class LockError(RedisError, ValueError):
     # NOTE: For backwards compatibility, this class derives from ValueError.
     # This was originally chosen to behave like threading.Lock.
 
-    def __init__(self, message, lock_name=None):
+    def __init__(self, message=None, lock_name=None):
         self.message = message
         self.lock_name = lock_name
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
