### PR TITLE
Support the MAXAGE option for CLIENT KILL

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -459,6 +459,7 @@ class ManagementCommands(CommandsProtocol):
         skipme: Union[bool, None] = None,
         laddr: Union[bool, None] = None,
         user: str = None,
+        maxage: Union[int, None] = None,
         **kwargs,
     ) -> ResponseT:
         """
@@ -472,6 +473,7 @@ class ManagementCommands(CommandsProtocol):
         options. If skipme is not provided, the server defaults to skipme=True
         :param laddr: Kills a client by its 'local (bind) address:port'
         :param user: Kills a client for a specific user name
+        :param maxage: Kills clients that are older than the specified age in seconds
         """
         args = []
         if _type is not None:
@@ -494,6 +496,8 @@ class ManagementCommands(CommandsProtocol):
             args.extend((b"LADDR", laddr))
         if user is not None:
             args.extend((b"USER", user))
+        if maxage is not None:
+            args.extend((b"MAXAGE", maxage))
         if not args:
             raise DataError(
                 "CLIENT KILL <filter> <value> ... ... <filter> "

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -707,6 +707,15 @@ class TestRedisCommands:
             assert c["user"] != killuser
         r.acl_deluser(killuser)
 
+    @skip_if_server_version_lt("7.4.0")
+    @skip_if_redis_enterprise()
+    def test_client_kill_filter_by_maxage(self, r, request):
+        _get_client(redis.Redis, request, flushdb=False)
+        time.sleep(4)
+        assert len(r.client_list()) == 2
+        r.client_kill_filter(maxage=2)
+        assert len(r.client_list()) == 1
+
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.9.50")
     @skip_if_redis_enterprise()


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

Issue #3154

The CLIENT KILL command has a new option, called MAXAGE, to kill clients older than a given age. Add support for this new option.
