### PR TITLE
Streamline client side caching API typing

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,6 @@
 click==8.0.4
 black==24.3.0
+cachetools
 flake8==5.0.4
 flake8-isort==6.0.0
 flynt~=0.69.0

--- a/dockers/sentinel.conf
+++ b/dockers/sentinel.conf
@@ -1,4 +1,5 @@
-sentinel monitor redis-py-test 127.0.0.1 6379 2
+sentinel resolve-hostnames yes
+sentinel monitor redis-py-test redis 6379 2
 sentinel down-after-milliseconds redis-py-test 5000
 sentinel failover-timeout redis-py-test 60000
 sentinel parallel-syncs redis-py-test 1

--- a/redis/_cache.py
+++ b/redis/_cache.py
@@ -17,7 +17,7 @@ class EvictionPolicy(Enum):
 
 DEFAULT_EVICTION_POLICY = EvictionPolicy.LRU
 
-DEFAULT_BLACKLIST = [
+DEFAULT_DENY_LIST = [
     "BF.CARD",
     "BF.DEBUG",
     "BF.EXISTS",
@@ -77,7 +77,7 @@ DEFAULT_BLACKLIST = [
     "TTL",
 ]
 
-DEFAULT_WHITELIST = [
+DEFAULT_ALLOW_LIST = [
     "BITCOUNT",
     "BITFIELD_RO",
     "BITPOS",

--- a/redis/_cache.py
+++ b/redis/_cache.py
@@ -167,19 +167,24 @@ class AbstractCache(ABC):
     """
 
     @abstractmethod
-    def set(self, command: str, response: ResponseT, keys_in_command: List[KeyT]):
+    def set(
+        self,
+        command: Union[str, Iterable[str]],
+        response: ResponseT,
+        keys_in_command: List[KeyT],
+    ):
         pass
 
     @abstractmethod
-    def get(self, command: str) -> ResponseT:
+    def get(self, command: Union[str, Iterable[str]]) -> ResponseT:
         pass
 
     @abstractmethod
-    def delete_command(self, command: str):
+    def delete_command(self, command: Union[str, Iterable[str]]):
         pass
 
     @abstractmethod
-    def delete_commands(self, commands):
+    def delete_commands(self, commands: List[Union[str, Iterable[str]]]):
         pass
 
     @abstractmethod

--- a/redis/_cache.py
+++ b/redis/_cache.py
@@ -4,12 +4,11 @@ import time
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
 from enum import Enum
-from typing import List
+from typing import Iterable, List, Union
 
 from redis.typing import KeyT, ResponseT
 
 DEFAULT_EVICTION_POLICY = "lru"
-
 
 DEFAULT_BLACKLIST = [
     "BF.CARD",
@@ -70,7 +69,6 @@ DEFAULT_BLACKLIST = [
     "TOUCH",
     "TTL",
 ]
-
 
 DEFAULT_WHITELIST = [
     "BITCOUNT",
@@ -180,7 +178,7 @@ class AbstractCache(ABC):
         pass
 
     @abstractmethod
-    def delete_many(self, commands):
+    def delete_commands(self, commands):
         pass
 
     @abstractmethod
@@ -215,7 +213,6 @@ class _LocalCache(AbstractCache):
         max_size: int = 10000,
         ttl: int = 0,
         eviction_policy: EvictionPolicy = DEFAULT_EVICTION_POLICY,
-        **kwargs,
     ):
         self.max_size = max_size
         self.ttl = ttl
@@ -224,12 +221,17 @@ class _LocalCache(AbstractCache):
         self.key_commands_map = defaultdict(set)
         self.commands_ttl_list = []
 
-    def set(self, command: str, response: ResponseT, keys_in_command: List[KeyT]):
+    def set(
+        self,
+        command: Union[str, Iterable[str]],
+        response: ResponseT,
+        keys_in_command: List[KeyT],
+    ):
         """
         Set a redis command and its response in the cache.
 
         Args:
-            command (str): The redis command.
+            command (Union[str, Iterable[str]]): The redis command.
             response (ResponseT): The response associated with the command.
             keys_in_command (List[KeyT]): The list of keys used in the command.
         """
@@ -244,12 +246,12 @@ class _LocalCache(AbstractCache):
         self._update_key_commands_map(keys_in_command, command)
         self.commands_ttl_list.append(command)
 
-    def get(self, command: str) -> ResponseT:
+    def get(self, command: Union[str, Iterable[str]]) -> ResponseT:
         """
         Get the response for a redis command from the cache.
 
         Args:
-            command (str): The redis command.
+            command (Union[str, Iterable[str]]): The redis command.
 
         Returns:
             ResponseT: The response associated with the command, or None if the command is not in the cache.  # noqa
@@ -261,12 +263,12 @@ class _LocalCache(AbstractCache):
             self._update_access(command)
             return copy.deepcopy(self.cache[command]["response"])
 
-    def delete_command(self, command: str):
+    def delete_command(self, command: Union[str, Iterable[str]]):
         """
         Delete a redis command and its metadata from the cache.
 
         Args:
-            command (str): The redis command to be deleted.
+            command (Union[str, Iterable[str]]): The redis command to be deleted.
         """
         if command in self.cache:
             keys_in_command = self.cache[command].get("keys")
@@ -274,8 +276,16 @@ class _LocalCache(AbstractCache):
             self.commands_ttl_list.remove(command)
             del self.cache[command]
 
-    def delete_many(self, commands):
-        pass
+    def delete_commands(self, commands: List[Union[str, Iterable[str]]]):
+        """
+        Delete multiple commands and their metadata from the cache.
+
+        Args:
+            commands (List[Union[str, Iterable[str]]]): The list of commands to be
+            deleted.
+        """
+        for command in commands:
+            self.delete_command(command)
 
     def flush(self):
         """Clear the entire cache, removing all redis commands and metadata."""
@@ -283,12 +293,12 @@ class _LocalCache(AbstractCache):
         self.key_commands_map.clear()
         self.commands_ttl_list = []
 
-    def _is_expired(self, command: str) -> bool:
+    def _is_expired(self, command: Union[str, Iterable[str]]) -> bool:
         """
         Check if a redis command has expired based on its time-to-live.
 
         Args:
-            command (str): The redis command.
+            command (Union[str, Iterable[str]]): The redis command.
 
         Returns:
             bool: True if the command has expired, False otherwise.
@@ -297,12 +307,12 @@ class _LocalCache(AbstractCache):
             return False
         return time.monotonic() - self.cache[command]["ctime"] > self.ttl
 
-    def _update_access(self, command: str):
+    def _update_access(self, command: Union[str, Iterable[str]]):
         """
         Update the access information for a redis command based on the eviction policy.
 
         Args:
-            command (str): The redis command.
+            command (Union[str, Iterable[str]]): The redis command.
         """
         if self.eviction_policy == EvictionPolicy.LRU.value:
             self.cache.move_to_end(command)
@@ -329,24 +339,28 @@ class _LocalCache(AbstractCache):
             random_command = random.choice(list(self.cache.keys()))
             self.cache.pop(random_command)
 
-    def _update_key_commands_map(self, keys: List[KeyT], command: str):
+    def _update_key_commands_map(
+        self, keys: List[KeyT], command: Union[str, Iterable[str]]
+    ):
         """
         Update the key_commands_map with command that uses the keys.
 
         Args:
             keys (List[KeyT]): The list of keys used in the command.
-            command (str): The redis command.
+            command (Union[str, Iterable[str]]): The redis command.
         """
         for key in keys:
             self.key_commands_map[key].add(command)
 
-    def _del_key_commands_map(self, keys: List[KeyT], command: str):
+    def _del_key_commands_map(
+        self, keys: List[KeyT], command: Union[str, Iterable[str]]
+    ):
         """
         Remove a redis command from the key_commands_map.
 
         Args:
             keys (List[KeyT]): The list of keys used in the redis command.
-            command (str): The redis command.
+            command (Union[str, Iterable[str]]): The redis command.
         """
         for key in keys:
             self.key_commands_map[key].remove(command)

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -27,9 +27,9 @@ from typing import (
 )
 
 from redis._cache import (
-    DEFAULT_BLACKLIST,
+    DEFAULT_ALLOW_LIST,
+    DEFAULT_DENY_LIST,
     DEFAULT_EVICTION_POLICY,
-    DEFAULT_WHITELIST,
     AbstractCache,
 )
 from redis._parsers.helpers import (
@@ -243,8 +243,8 @@ class Redis(
         cache_max_size: int = 100,
         cache_ttl: int = 0,
         cache_policy: str = DEFAULT_EVICTION_POLICY,
-        cache_blacklist: List[str] = DEFAULT_BLACKLIST,
-        cache_whitelist: List[str] = DEFAULT_WHITELIST,
+        cache_deny_list: List[str] = DEFAULT_DENY_LIST,
+        cache_allow_list: List[str] = DEFAULT_ALLOW_LIST,
     ):
         """
         Initialize a new Redis client.
@@ -299,8 +299,8 @@ class Redis(
                 "cache_max_size": cache_max_size,
                 "cache_ttl": cache_ttl,
                 "cache_policy": cache_policy,
-                "cache_blacklist": cache_blacklist,
-                "cache_whitelist": cache_whitelist,
+                "cache_deny_list": cache_deny_list,
+                "cache_allow_list": cache_allow_list,
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -676,31 +676,22 @@ class Redis(
         return response
 
     def flush_cache(self):
-        try:
-            if self.connection:
-                self.connection.client_cache.flush()
-            else:
-                self.connection_pool.flush_cache()
-        except AttributeError:
-            pass
+        if self.connection:
+            self.connection.flush_cache()
+        else:
+            self.connection_pool.flush_cache()
 
     def delete_command_from_cache(self, command):
-        try:
-            if self.connection:
-                self.connection.client_cache.delete_command(command)
-            else:
-                self.connection_pool.delete_command_from_cache(command)
-        except AttributeError:
-            pass
+        if self.connection:
+            self.connection.delete_command_from_cache(command)
+        else:
+            self.connection_pool.delete_command_from_cache(command)
 
     def invalidate_key_from_cache(self, key):
-        try:
-            if self.connection:
-                self.connection.client_cache.invalidate_key(key)
-            else:
-                self.connection_pool.invalidate_key_from_cache(key)
-        except AttributeError:
-            pass
+        if self.connection:
+            self.connection.invalidate_key_from_cache(key)
+        else:
+            self.connection_pool.invalidate_key_from_cache(key)
 
 
 StrictRedis = Redis

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -640,7 +640,8 @@ class Redis(
                         ),
                         lambda error: self._disconnect_raise(conn, error),
                     )
-                    conn._add_to_local_cache(args, response, keys)
+                    if keys:
+                        conn._add_to_local_cache(args, response, keys)
                     return response
                 finally:
                     if self.single_connection_client:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1075,7 +1075,8 @@ class ClusterNode:
             # Read response
             try:
                 response = await self.parse_response(connection, args[0], **kwargs)
-                connection._add_to_local_cache(args, response, keys)
+                if keys:
+                    connection._add_to_local_cache(args, response, keys)
                 return response
             finally:
                 # Release connection

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -20,9 +20,9 @@ from typing import (
 )
 
 from redis._cache import (
-    DEFAULT_BLACKLIST,
+    DEFAULT_ALLOW_LIST,
+    DEFAULT_DENY_LIST,
     DEFAULT_EVICTION_POLICY,
-    DEFAULT_WHITELIST,
     AbstractCache,
 )
 from redis._parsers import AsyncCommandsParser, Encoder
@@ -280,8 +280,8 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         cache_max_size: int = 100,
         cache_ttl: int = 0,
         cache_policy: str = DEFAULT_EVICTION_POLICY,
-        cache_blacklist: List[str] = DEFAULT_BLACKLIST,
-        cache_whitelist: List[str] = DEFAULT_WHITELIST,
+        cache_deny_list: List[str] = DEFAULT_DENY_LIST,
+        cache_allow_list: List[str] = DEFAULT_ALLOW_LIST,
     ) -> None:
         if db:
             raise RedisClusterException(
@@ -331,8 +331,8 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             "cache_max_size": cache_max_size,
             "cache_ttl": cache_ttl,
             "cache_policy": cache_policy,
-            "cache_blacklist": cache_blacklist,
-            "cache_whitelist": cache_whitelist,
+            "cache_deny_list": cache_deny_list,
+            "cache_allow_list": cache_allow_list,
         }
 
         if ssl:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -936,6 +936,18 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             thread_local=thread_local,
         )
 
+    def flush_cache(self):
+        if self.nodes_manager:
+            self.nodes_manager.flush_cache()
+
+    def delete_command_from_cache(self, command):
+        if self.nodes_manager:
+            self.nodes_manager.delete_command_from_cache(command)
+
+    def invalidate_key_from_cache(self, key):
+        if self.nodes_manager:
+            self.nodes_manager.invalidate_key_from_cache(key)
+
 
 class ClusterNode:
     """
@@ -1106,6 +1118,18 @@ class ClusterNode:
         self._free.append(connection)
 
         return ret
+
+    def flush_cache(self):
+        for connection in self._connections:
+            connection.flush_cache()
+
+    def delete_command_from_cache(self, command):
+        for connection in self._connections:
+            connection.delete_command_from_cache(command)
+
+    def invalidate_key_from_cache(self, key):
+        for connection in self._connections:
+            connection.invalidate_key_from_cache(key)
 
 
 class NodesManager:
@@ -1391,6 +1415,18 @@ class NodesManager:
         if self.address_remap:
             return self.address_remap((host, port))
         return host, port
+
+    def flush_cache(self):
+        for node in self.nodes_cache.values():
+            node.flush_cache()
+
+    def delete_command_from_cache(self, command):
+        for node in self.nodes_cache.values():
+            node.delete_command_from_cache(command)
+
+    def invalidate_key_from_cache(self, key):
+        for node in self.nodes_cache.values():
+            node.invalidate_key_from_cache(key)
 
 
 class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommands):

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -731,25 +731,16 @@ class AbstractConnection:
             self.client_cache.set(command, response, keys)
 
     def flush_cache(self):
-        try:
-            if self.client_cache:
-                self.client_cache.flush()
-        except AttributeError:
-            pass
+        if self.client_cache:
+            self.client_cache.flush()
 
     def delete_command_from_cache(self, command):
-        try:
-            if self.client_cache:
-                self.client_cache.delete_command(command)
-        except AttributeError:
-            pass
+        if self.client_cache:
+            self.client_cache.delete_command(command)
 
     def invalidate_key_from_cache(self, key):
-        try:
-            if self.client_cache:
-                self.client_cache.invalidate_key(key)
-        except AttributeError:
-            pass
+        if self.client_cache:
+            self.client_cache.invalidate_key(key)
 
 
 class Connection(AbstractConnection):

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -696,7 +696,7 @@ class AbstractConnection:
         and the second string is the list of keys to invalidate.
         (if the list of keys is None, then all keys are invalidated)
         """
-        if data[1] is not None:
+        if data[1] is None:
             self.client_cache.flush()
         else:
             for key in data[1]:

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -730,6 +730,27 @@ class AbstractConnection:
         ):
             self.client_cache.set(command, response, keys)
 
+    def flush_cache(self):
+        try:
+            if self.client_cache:
+                self.client_cache.flush()
+        except AttributeError:
+            pass
+
+    def delete_command_from_cache(self, command):
+        try:
+            if self.client_cache:
+                self.client_cache.delete_command(command)
+        except AttributeError:
+            pass
+
+    def invalidate_key_from_cache(self, key):
+        try:
+            if self.client_cache:
+                self.client_cache.invalidate_key(key)
+        except AttributeError:
+            pass
+
 
 class Connection(AbstractConnection):
     "Manages TCP communication to and from a Redis server"
@@ -1252,33 +1273,18 @@ class ConnectionPool:
 
     def flush_cache(self):
         connections = chain(self._available_connections, self._in_use_connections)
-
         for connection in connections:
-            try:
-                connection.client_cache.flush()
-            except AttributeError:
-                # cache is not enabled
-                pass
+            connection.flush_cache()
 
     def delete_command_from_cache(self, command: str):
         connections = chain(self._available_connections, self._in_use_connections)
-
         for connection in connections:
-            try:
-                connection.client_cache.delete_command(command)
-            except AttributeError:
-                # cache is not enabled
-                pass
+            connection.delete_command_from_cache(command)
 
     def invalidate_key_from_cache(self, key: str):
         connections = chain(self._available_connections, self._in_use_connections)
-
         for connection in connections:
-            try:
-                connection.client_cache.invalidate_key(key)
-            except AttributeError:
-                # cache is not enabled
-                pass
+            connection.invalidate_key_from_cache(key)
 
 
 class BlockingConnectionPool(ConnectionPool):

--- a/redis/client.py
+++ b/redis/client.py
@@ -7,9 +7,9 @@ from itertools import chain
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from redis._cache import (
-    DEFAULT_BLACKLIST,
+    DEFAULT_ALLOW_LIST,
+    DEFAULT_DENY_LIST,
     DEFAULT_EVICTION_POLICY,
-    DEFAULT_WHITELIST,
     AbstractCache,
 )
 from redis._parsers.encoders import Encoder
@@ -220,8 +220,8 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         cache_max_size: int = 10000,
         cache_ttl: int = 0,
         cache_policy: str = DEFAULT_EVICTION_POLICY,
-        cache_blacklist: List[str] = DEFAULT_BLACKLIST,
-        cache_whitelist: List[str] = DEFAULT_WHITELIST,
+        cache_deny_list: List[str] = DEFAULT_DENY_LIST,
+        cache_allow_list: List[str] = DEFAULT_ALLOW_LIST,
     ) -> None:
         """
         Initialize a new Redis client.
@@ -278,8 +278,8 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                 "cache_max_size": cache_max_size,
                 "cache_ttl": cache_ttl,
                 "cache_policy": cache_policy,
-                "cache_blacklist": cache_blacklist,
-                "cache_whitelist": cache_whitelist,
+                "cache_deny_list": cache_deny_list,
+                "cache_allow_list": cache_allow_list,
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:

--- a/redis/client.py
+++ b/redis/client.py
@@ -573,7 +573,8 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                     ),
                     lambda error: self._disconnect_raise(conn, error),
                 )
-                conn._add_to_local_cache(args, response, keys)
+                if keys:
+                    conn._add_to_local_cache(args, response, keys)
                 return response
         finally:
             if not self.connection:

--- a/redis/client.py
+++ b/redis/client.py
@@ -601,31 +601,22 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         return response
 
     def flush_cache(self):
-        try:
-            if self.connection:
-                self.connection.client_cache.flush()
-            else:
-                self.connection_pool.flush_cache()
-        except AttributeError:
-            pass
+        if self.connection:
+            self.connection.flush_cache()
+        else:
+            self.connection_pool.flush_cache()
 
     def delete_command_from_cache(self, command):
-        try:
-            if self.connection:
-                self.connection.client_cache.delete_command(command)
-            else:
-                self.connection_pool.delete_command_from_cache(command)
-        except AttributeError:
-            pass
+        if self.connection:
+            self.connection.delete_command_from_cache(command)
+        else:
+            self.connection_pool.delete_command_from_cache(command)
 
     def invalidate_key_from_cache(self, key):
-        try:
-            if self.connection:
-                self.connection.client_cache.invalidate_key(key)
-            else:
-                self.connection_pool.invalidate_key_from_cache(key)
-        except AttributeError:
-            pass
+        if self.connection:
+            self.connection.invalidate_key_from_cache(key)
+        else:
+            self.connection_pool.invalidate_key_from_cache(key)
 
 
 StrictRedis = Redis

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -172,8 +172,8 @@ REDIS_ALLOWED_KEYS = (
     "cache_max_size",
     "cache_ttl",
     "cache_policy",
-    "cache_blacklist",
-    "cache_whitelist",
+    "cache_deny_list",
+    "cache_allow_list",
 )
 KWARGS_DISABLED_KEYS = ("host", "port")
 

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1266,6 +1266,18 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         """
         setattr(self, funcname, func)
 
+    def flush_cache(self):
+        if self.nodes_manager:
+            self.nodes_manager.flush_cache()
+
+    def delete_command_from_cache(self, command):
+        if self.nodes_manager:
+            self.nodes_manager.delete_command_from_cache(command)
+
+    def invalidate_key_from_cache(self, key):
+        if self.nodes_manager:
+            self.nodes_manager.invalidate_key_from_cache(key)
+
 
 class ClusterNode:
     def __init__(self, host, port, server_type=None, redis_connection=None):
@@ -1293,6 +1305,18 @@ class ClusterNode:
     def __del__(self):
         if self.redis_connection is not None:
             self.redis_connection.close()
+
+    def flush_cache(self):
+        if self.redis_connection is not None:
+            self.redis_connection.flush_cache()
+
+    def delete_command_from_cache(self, command):
+        if self.redis_connection is not None:
+            self.redis_connection.delete_command_from_cache(command)
+
+    def invalidate_key_from_cache(self, key):
+        if self.redis_connection is not None:
+            self.redis_connection.invalidate_key_from_cache(key)
 
 
 class LoadBalancer:
@@ -1659,6 +1683,18 @@ class NodesManager:
         if self.address_remap:
             return self.address_remap((host, port))
         return host, port
+
+    def flush_cache(self):
+        for node in self.nodes_cache.values():
+            node.flush_cache()
+
+    def delete_command_from_cache(self, command):
+        for node in self.nodes_cache.values():
+            node.delete_command_from_cache(command)
+
+    def invalidate_key_from_cache(self, key):
+        for node in self.nodes_cache.values():
+            node.invalidate_key_from_cache(key)
 
 
 class ClusterPubSub(PubSub):

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1164,7 +1164,8 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
                         response = self.cluster_response_callbacks[command](
                             response, **kwargs
                         )
-                    connection._add_to_local_cache(args, response, keys)
+                    if keys:
+                        connection._add_to_local_cache(args, response, keys)
                     return response
             except AuthenticationError:
                 raise

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -651,6 +651,27 @@ class AbstractConnection:
         ):
             self.client_cache.set(command, response, keys)
 
+    def flush_cache(self):
+        try:
+            if self.client_cache:
+                self.client_cache.flush()
+        except AttributeError:
+            pass
+
+    def delete_command_from_cache(self, command):
+        try:
+            if self.client_cache:
+                self.client_cache.delete_command(command)
+        except AttributeError:
+            pass
+
+    def invalidate_key_from_cache(self, key):
+        try:
+            if self.client_cache:
+                self.client_cache.invalidate_key(key)
+        except AttributeError:
+            pass
+
 
 class Connection(AbstractConnection):
     "Manages TCP communication to and from a Redis server"

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -9,7 +9,7 @@ from abc import abstractmethod
 from itertools import chain
 from queue import Empty, Full, LifoQueue
 from time import time
-from typing import Any, Callable, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, List, Optional, Sequence, Type, Union
 from urllib.parse import parse_qs, unquote, urlparse
 
 from ._cache import (
@@ -623,7 +623,7 @@ class AbstractConnection:
             for key in data[1]:
                 self.client_cache.invalidate_key(str_if_bytes(key))
 
-    def _get_from_local_cache(self, command: str):
+    def _get_from_local_cache(self, command: Sequence[str]):
         """
         If the command is in the local cache, return the response
         """
@@ -638,7 +638,7 @@ class AbstractConnection:
         return self.client_cache.get(command)
 
     def _add_to_local_cache(
-        self, command: Tuple[str], response: ResponseT, keys: List[KeysT]
+        self, command: Sequence[str], response: ResponseT, keys: List[KeysT]
     ):
         """
         Add the command and response to the local cache if the command
@@ -658,14 +658,14 @@ class AbstractConnection:
         except AttributeError:
             pass
 
-    def delete_command_from_cache(self, command):
+    def delete_command_from_cache(self, command: Union[str, Sequence[str]]):
         try:
             if self.client_cache:
                 self.client_cache.delete_command(command)
         except AttributeError:
             pass
 
-    def invalidate_key_from_cache(self, key):
+    def invalidate_key_from_cache(self, key: KeysT):
         try:
             if self.client_cache:
                 self.client_cache.invalidate_key(key)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -652,25 +652,16 @@ class AbstractConnection:
             self.client_cache.set(command, response, keys)
 
     def flush_cache(self):
-        try:
-            if self.client_cache:
-                self.client_cache.flush()
-        except AttributeError:
-            pass
+        if self.client_cache:
+            self.client_cache.flush()
 
     def delete_command_from_cache(self, command: Union[str, Sequence[str]]):
-        try:
-            if self.client_cache:
-                self.client_cache.delete_command(command)
-        except AttributeError:
-            pass
+        if self.client_cache:
+            self.client_cache.delete_command(command)
 
     def invalidate_key_from_cache(self, key: KeysT):
-        try:
-            if self.client_cache:
-                self.client_cache.invalidate_key(key)
-        except AttributeError:
-            pass
+        if self.client_cache:
+            self.client_cache.invalidate_key(key)
 
 
 class Connection(AbstractConnection):
@@ -1300,37 +1291,22 @@ class ConnectionPool:
         self._checkpid()
         with self._lock:
             connections = chain(self._available_connections, self._in_use_connections)
-
             for connection in connections:
-                try:
-                    connection.client_cache.flush()
-                except AttributeError:
-                    # cache is not enabled
-                    pass
+                connection.flush_cache()
 
     def delete_command_from_cache(self, command: str):
         self._checkpid()
         with self._lock:
             connections = chain(self._available_connections, self._in_use_connections)
-
             for connection in connections:
-                try:
-                    connection.client_cache.delete_command(command)
-                except AttributeError:
-                    # cache is not enabled
-                    pass
+                connection.delete_command_from_cache(command)
 
     def invalidate_key_from_cache(self, key: str):
         self._checkpid()
         with self._lock:
             connections = chain(self._available_connections, self._in_use_connections)
-
             for connection in connections:
-                try:
-                    connection.client_cache.invalidate_key(key)
-                except AttributeError:
-                    # cache is not enabled
-                    pass
+                connection.invalidate_key_from_cache(key)
 
 
 class BlockingConnectionPool(ConnectionPool):

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -13,9 +13,9 @@ from typing import Any, Callable, List, Optional, Tuple, Type, Union
 from urllib.parse import parse_qs, unquote, urlparse
 
 from ._cache import (
-    DEFAULT_BLACKLIST,
+    DEFAULT_ALLOW_LIST,
+    DEFAULT_DENY_LIST,
     DEFAULT_EVICTION_POLICY,
-    DEFAULT_WHITELIST,
     AbstractCache,
     _LocalCache,
 )
@@ -162,8 +162,8 @@ class AbstractConnection:
         cache_max_size: int = 10000,
         cache_ttl: int = 0,
         cache_policy: str = DEFAULT_EVICTION_POLICY,
-        cache_blacklist: List[str] = DEFAULT_BLACKLIST,
-        cache_whitelist: List[str] = DEFAULT_WHITELIST,
+        cache_deny_list: List[str] = DEFAULT_DENY_LIST,
+        cache_allow_list: List[str] = DEFAULT_ALLOW_LIST,
     ):
         """
         Initialize a new Connection.
@@ -239,8 +239,8 @@ class AbstractConnection:
                 raise RedisError(
                     "client caching is only supported with protocol version 3 or higher"
                 )
-            self.cache_blacklist = cache_blacklist
-            self.cache_whitelist = cache_whitelist
+            self.cache_deny_list = cache_deny_list
+            self.cache_allow_list = cache_allow_list
 
     def __repr__(self):
         repr_args = ",".join([f"{k}={v}" for k, v in self.repr_pieces()])
@@ -629,8 +629,8 @@ class AbstractConnection:
         """
         if (
             self.client_cache is None
-            or command[0] in self.cache_blacklist
-            or command[0] not in self.cache_whitelist
+            or command[0] in self.cache_deny_list
+            or command[0] not in self.cache_allow_list
         ):
             return None
         while self.can_read():
@@ -646,8 +646,8 @@ class AbstractConnection:
         """
         if (
             self.client_cache is not None
-            and (self.cache_blacklist == [] or command[0] not in self.cache_blacklist)
-            and (self.cache_whitelist == [] or command[0] in self.cache_whitelist)
+            and (self.cache_deny_list == [] or command[0] not in self.cache_deny_list)
+            and (self.cache_allow_list == [] or command[0] in self.cache_allow_list)
         ):
             self.client_cache.set(command, response, keys)
 

--- a/tests/test_asyncio/conftest.py
+++ b/tests/test_asyncio/conftest.py
@@ -154,7 +154,7 @@ async def sentinel_setup(local_cache, request):
     )
     yield sentinel
     for s in sentinel.sentinels:
-        await s.close()
+        await s.aclose()
 
 
 @pytest_asyncio.fixture()
@@ -162,7 +162,7 @@ async def master(request, sentinel_setup):
     master_service = request.config.getoption("--master-service")
     master = sentinel_setup.master_for(master_service)
     yield master
-    await master.close()
+    await master.aclose()
 
 
 def _gen_cluster_mock_resp(r, response):

--- a/tests/test_asyncio/conftest.py
+++ b/tests/test_asyncio/conftest.py
@@ -7,6 +7,7 @@ import pytest_asyncio
 import redis.asyncio as redis
 from packaging.version import Version
 from redis._parsers import _AsyncHiredisParser, _AsyncRESP2Parser
+from redis.asyncio import Sentinel
 from redis.asyncio.client import Monitor
 from redis.asyncio.connection import Connection, parse_url
 from redis.asyncio.retry import Retry
@@ -134,6 +135,34 @@ async def r2(create_redis):
 @pytest_asyncio.fixture()
 async def decoded_r(create_redis):
     return await create_redis(decode_responses=True)
+
+
+@pytest_asyncio.fixture()
+async def sentinel_setup(local_cache, request):
+    sentinel_ips = request.config.getoption("--sentinels")
+    sentinel_endpoints = [
+        (ip.strip(), int(port.strip()))
+        for ip, port in (endpoint.split(":") for endpoint in sentinel_ips.split(","))
+    ]
+    kwargs = request.param.get("kwargs", {}) if hasattr(request, "param") else {}
+    sentinel = Sentinel(
+        sentinel_endpoints,
+        socket_timeout=0.1,
+        client_cache=local_cache,
+        protocol=3,
+        **kwargs,
+    )
+    yield sentinel
+    for s in sentinel.sentinels:
+        await s.close()
+
+
+@pytest_asyncio.fixture()
+async def master(request, sentinel_setup):
+    master_service = request.config.getoption("--master-service")
+    master = sentinel_setup.master_for(master_service)
+    yield master
+    await master.close()
 
 
 def _gen_cluster_mock_resp(r, response):

--- a/tests/test_asyncio/test_cache.py
+++ b/tests/test_asyncio/test_cache.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 import pytest_asyncio
-from redis._cache import _LocalCache
+from redis._cache import EvictionPolicy, _LocalCache
 from redis.utils import HIREDIS_AVAILABLE
 
 
@@ -41,7 +41,7 @@ class TestLocalCache:
         assert await r.get("foo") == b"barbar"
 
     @pytest.mark.parametrize("r", [{"cache": _LocalCache(max_size=3)}], indirect=True)
-    async def test_cache_max_size(self, r):
+    async def test_cache_lru_eviction(self, r):
         r, cache = r
         # add 3 keys to redis
         await r.set("foo", "bar")
@@ -76,7 +76,9 @@ class TestLocalCache:
         assert cache.get(("GET", "foo")) is None
 
     @pytest.mark.parametrize(
-        "r", [{"cache": _LocalCache(max_size=3, eviction_policy="lfu")}], indirect=True
+        "r",
+        [{"cache": _LocalCache(max_size=3, eviction_policy=EvictionPolicy.LFU)}],
+        indirect=True,
     )
     async def test_cache_lfu_eviction(self, r):
         r, cache = r

--- a/tests/test_asyncio/test_cache.py
+++ b/tests/test_asyncio/test_cache.py
@@ -125,10 +125,10 @@ class TestLocalCache:
 
     @pytest.mark.parametrize(
         "r",
-        [{"cache": _LocalCache(), "kwargs": {"cache_blacklist": ["LLEN"]}}],
+        [{"cache": _LocalCache(), "kwargs": {"cache_deny_list": ["LLEN"]}}],
         indirect=True,
     )
-    async def test_cache_blacklist(self, r):
+    async def test_cache_deny_list(self, r):
         r, cache = r
         # add list to redis
         await r.lpush("mylist", "foo", "bar", "baz")
@@ -139,10 +139,10 @@ class TestLocalCache:
 
     @pytest.mark.parametrize(
         "r",
-        [{"cache": _LocalCache(), "kwargs": {"cache_whitelist": ["LLEN"]}}],
+        [{"cache": _LocalCache(), "kwargs": {"cache_allow_list": ["LLEN"]}}],
         indirect=True,
     )
-    async def test_cache_whitelist(self, r):
+    async def test_cache_allow_list(self, r):
         r, cache = r
         # add list to redis
         await r.lpush("mylist", "foo", "bar", "baz")

--- a/tests/test_asyncio/test_cache.py
+++ b/tests/test_asyncio/test_cache.py
@@ -136,6 +136,20 @@ class TestLocalCache:
         assert cache.get(("LLEN", "mylist")) is None
         assert cache.get(("LINDEX", "mylist", 1)) == b"bar"
 
+    @pytest.mark.parametrize(
+        "r",
+        [{"cache": _LocalCache(), "kwargs": {"cache_whitelist": ["LLEN"]}}],
+        indirect=True,
+    )
+    async def test_cache_whitelist(self, r):
+        r, cache = r
+        # add list to redis
+        await r.lpush("mylist", "foo", "bar", "baz")
+        assert await r.llen("mylist") == 3
+        assert await r.lindex("mylist", 1) == b"bar"
+        assert cache.get(("LLEN", "mylist")) == 3
+        assert cache.get(("LINDEX", "mylist", 1)) is None
+
     @pytest.mark.parametrize("r", [{"cache": _LocalCache()}], indirect=True)
     async def test_cache_return_copy(self, r):
         r, cache = r

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -139,10 +139,10 @@ class TestLocalCache:
 
     @pytest.mark.parametrize(
         "r",
-        [{"cache": _LocalCache(), "kwargs": {"cache_blacklist": ["LLEN"]}}],
+        [{"cache": _LocalCache(), "kwargs": {"cache_deny_list": ["LLEN"]}}],
         indirect=True,
     )
-    def test_cache_blacklist(self, r):
+    def test_cache_deny_list(self, r):
         r, cache = r
         # add list to redis
         r.lpush("mylist", "foo", "bar", "baz")
@@ -153,10 +153,10 @@ class TestLocalCache:
 
     @pytest.mark.parametrize(
         "r",
-        [{"cache": _LocalCache(), "kwargs": {"cache_whitelist": ["LLEN"]}}],
+        [{"cache": _LocalCache(), "kwargs": {"cache_allow_list": ["LLEN"]}}],
         indirect=True,
     )
-    def test_cache_whitelist(self, r):
+    def test_cache_allow_list(self, r):
         r, cache = r
         r.lpush("mylist", "foo", "bar", "baz")
         assert r.llen("mylist") == 3

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,6 @@
 import time
 from collections import defaultdict
-from typing import List
+from typing import Iterable, List, Union
 
 import cachetools
 import pytest
@@ -533,23 +533,28 @@ class TestCustomCache:
             self.keys_to_commands = defaultdict(list)
             self.commands_to_keys = defaultdict(list)
 
-        def set(self, command: str, response: ResponseT, keys_in_command: List[KeyT]):
+        def set(
+            self,
+            command: Union[str, Iterable[str]],
+            response: ResponseT,
+            keys_in_command: List[KeyT],
+        ):
             self.responses[command] = response
             for key in keys_in_command:
                 self.keys_to_commands[key].append(tuple(command))
                 self.commands_to_keys[command].append(tuple(keys_in_command))
 
-        def get(self, command: str) -> ResponseT:
+        def get(self, command: Union[str, Iterable[str]]) -> ResponseT:
             return self.responses.get(command)
 
-        def delete_command(self, command: str):
+        def delete_command(self, command: Union[str, Iterable[str]]):
             self.responses.pop(command, None)
             keys = self.commands_to_keys.pop(command, [])
             for key in keys:
                 if command in self.keys_to_commands[key]:
                     self.keys_to_commands[key].remove(command)
 
-        def delete_commands(self, commands):
+        def delete_commands(self, commands: List[Union[str, Iterable[str]]]):
             for command in commands:
                 self.delete_command(command)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -28,8 +28,8 @@ def local_cache():
 
 
 @pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
+@pytest.mark.onlynoncluster
 class TestLocalCache:
-    @pytest.mark.onlynoncluster
     @pytest.mark.parametrize("r", [{"cache": _LocalCache()}], indirect=True)
     def test_get_from_cache(self, r, r2):
         r, cache = r
@@ -108,7 +108,6 @@ class TestLocalCache:
         assert cache.get(("GET", "foo")) == b"bar"
         assert cache.get(("GET", "foo2")) is None
 
-    @pytest.mark.onlynoncluster
     @pytest.mark.parametrize(
         "r",
         [{"cache": _LocalCache(), "kwargs": {"decode_responses": True}}],
@@ -155,7 +154,6 @@ class TestLocalCache:
         check = cache.get(("LRANGE", "mylist", 0, -1))
         assert check == [b"baz", b"bar", b"foo"]
 
-    @pytest.mark.onlynoncluster
     @pytest.mark.parametrize(
         "r",
         [{"cache": _LocalCache(), "kwargs": {"decode_responses": True}}],
@@ -198,7 +196,6 @@ class TestLocalCache:
         id4 = r.client_id()
         assert id1 == id2 == id3 == id4
 
-    @pytest.mark.onlynoncluster
     @pytest.mark.parametrize(
         "r",
         [{"cache": _LocalCache(), "kwargs": {"decode_responses": True}}],
@@ -219,7 +216,6 @@ class TestLocalCache:
         # get from redis
         assert r.mget("a", "b") == ["2", "1"]
 
-    @pytest.mark.onlynoncluster
     @pytest.mark.parametrize(
         "r",
         [{"cache": _LocalCache(), "kwargs": {"decode_responses": True}}],
@@ -243,7 +239,6 @@ class TestLocalCache:
         assert r.mget("a", "b") == ["1", "1"]
         assert r.get("c") == "1"
 
-    @pytest.mark.onlynoncluster
     @pytest.mark.parametrize(
         "r",
         [{"cache": _LocalCache(), "kwargs": {"decode_responses": True}}],
@@ -267,7 +262,6 @@ class TestLocalCache:
         assert r.mget("a", "b") == ["1", "1"]
         assert r.get("c") == "1"
 
-    @pytest.mark.onlynoncluster
     @pytest.mark.parametrize(
         "r",
         [{"cache": _LocalCache(), "kwargs": {"decode_responses": True}}],
@@ -291,7 +285,6 @@ class TestLocalCache:
         assert r.mget("a", "b") == ["1", "1"]
         assert r.get("c") == "1"
 
-    @pytest.mark.onlynoncluster
     @pytest.mark.parametrize(
         "r",
         [{"cache": _LocalCache(), "kwargs": {"decode_responses": True}}],

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,6 @@
 import time
 from collections import defaultdict
-from typing import Iterable, List, Union
+from typing import List, Sequence, Union
 
 import cachetools
 import pytest
@@ -535,7 +535,7 @@ class TestCustomCache:
 
         def set(
             self,
-            command: Union[str, Iterable[str]],
+            command: Union[str, Sequence[str]],
             response: ResponseT,
             keys_in_command: List[KeyT],
         ):
@@ -544,17 +544,17 @@ class TestCustomCache:
                 self.keys_to_commands[key].append(tuple(command))
                 self.commands_to_keys[command].append(tuple(keys_in_command))
 
-        def get(self, command: Union[str, Iterable[str]]) -> ResponseT:
+        def get(self, command: Union[str, Sequence[str]]) -> ResponseT:
             return self.responses.get(command)
 
-        def delete_command(self, command: Union[str, Iterable[str]]):
+        def delete_command(self, command: Union[str, Sequence[str]]):
             self.responses.pop(command, None)
             keys = self.commands_to_keys.pop(command, [])
             for key in keys:
                 if command in self.keys_to_commands[key]:
                     self.keys_to_commands[key].remove(command)
 
-        def delete_commands(self, commands: List[Union[str, Iterable[str]]]):
+        def delete_commands(self, commands: List[Union[str, Sequence[str]]]):
             for command in commands:
                 self.delete_command(command)
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Streamline the typing of the client side caching API. Some of the methods are defining commands of type `str`, while in reality tuples are being sent for those parameters.

Add client side cache tests for Sentinels. In order to make this work, fix the sentinel configuration in the docker-compose stack.

Add a test for client side caching with a truly custom cache, not just injecting our internal cache structure as custom.

Add a test for client side caching where two different types of commands use the same key, to make sure they invalidate each others cached data.
