### PR TITLE
Feat: raise granular exception types for lock errors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Raise granular exceptions when lock operations fail
     * Allow to control the minimum SSL version
     * Add an optional lock_name attribute to LockError.
     * Fix return types for `get`, `set_path` and `strappend` in JSONCommands

--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -87,6 +87,21 @@ class LockError(RedisError, ValueError):
         self.lock_name = lock_name
 
 
+class LockAquireError(LockError):
+    "Error acquring a lock in a given time"
+    ...
+
+
+class IndefiniteLockError(LockError):
+    "Error whilst trying to adjust lifetime of a lock that is indefinite"
+    ...
+
+
+class LockNotLockedError(LockError):
+    "Error whilst trying to perform an operation on an unlocked lock"
+    ...
+
+
 class LockNotOwnedError(LockError):
     "Error trying to extend or release a lock that is (no longer) owned"
     pass


### PR DESCRIPTION
### Pull Request check-list

- [X] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Is there an example added to the examples folder (if applicable)?
- [X] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This makes the exceptions raised for various `LockError` more granular which enables better handling from the callee if needed. All new exceptions extend `LockError` therefore making this a backwards compatible change.

The following new exceptions have been added:
1. `IndefiniteLockError`
1. `LockAquireError`
1. `LockNotLockedError`
1. `LockNotOwnedError`