### PR TITLE
DOC-3787 add missing code samples for JSON

### DIFF
--- a/doctests/dt_json.py
+++ b/doctests/dt_json.py
@@ -284,7 +284,9 @@ assert res8 == [
 
 # STEP_START filter2
 #  names of bikes made from an alloy
-res9 = r.json().get("bikes:inventory", "$..[?(@.specs.material == 'alloy')].model")
+res9 = r.json().get(
+    "bikes:inventory", "$..[?(@.specs.material == 'alloy')].model"
+)
 print(res9)  # >>> ['Weywot', 'Mimas']
 # STEP_END
 
@@ -293,7 +295,9 @@ assert res9 == ["Weywot", "Mimas"]
 # REMOVE_END
 
 # STEP_START filter3
-res10 = r.json().get("bikes:inventory", "$..[?(@.specs.material =~ '(?i)al')].model")
+res10 = r.json().get(
+    "bikes:inventory", "$..[?(@.specs.material =~ '(?i)al')].model"
+)
 print(res10)  # >>> ['Quaoar', 'Weywot', 'Salacia', 'Mimas']
 # STEP_END
 
@@ -341,7 +345,9 @@ assert res17 == [1920, 2072, 3264, 1475, 3941]
 # REMOVE_END
 
 # STEP_START update_filters1
-res18 = r.json().set("bikes:inventory", "$.inventory.*[?(@.price<2000)].price", 1500)
+res18 = r.json().set(
+    "bikes:inventory", "$.inventory.*[?(@.price<2000)].price", 1500
+)
 res19 = r.json().get("bikes:inventory", "$..price")
 print(res19)  # >>> [1500, 2072, 3264, 1500, 3941]
 # STEP_END

--- a/doctests/dt_json.py
+++ b/doctests/dt_json.py
@@ -154,11 +154,12 @@ inventory_json = {
             {
                 "id": "bike:2",
                 "model": "Quaoar",
-                "description": "Redesigned for the 2020 model year, this bike impressed "
-                "our testers and is the best all-around trail bike we've ever tested. The "
-                "Shimano gear system effectively does away with an external cassette, so "
-                "is super low maintenance in terms of wear and tear. All in all it's an "
-                "impressive package for the price, making it very competitive.",
+                "description": "Redesigned for the 2020 model year, this bike "
+                "impressed our testers and is the best all-around trail bike we've "
+                "ever tested. The Shimano gear system effectively does away with an "
+                "external cassette, so is super low maintenance in terms of wear "
+                "and tear. All in all it's an impressive package for the price, "
+                "making it very competitive.",
                 "price": 2072,
                 "specs": {"material": "aluminium", "weight": 7.9},
                 "colors": ["black", "white"],
@@ -166,11 +167,12 @@ inventory_json = {
             {
                 "id": "bike:3",
                 "model": "Weywot",
-                "description": "This bike gives kids aged six years and older a durable "
-                "and uberlight mountain bike for their first experience on tracks and easy "
-                "cruising through forests and fields. A set of powerful Shimano hydraulic "
-                "disc brakes provide ample stopping ability. If you're after a budget option, "
-                "this is one of the best bikes you could get.",
+                "description": "This bike gives kids aged six years and older "
+                "a durable and uberlight mountain bike for their first experience "
+                "on tracks and easy cruising through forests and fields. A set of "
+                "powerful Shimano hydraulic disc brakes provide ample stopping "
+                "ability. If you're after a budget option, this is one of the best "
+                "bikes you could get.",
                 "price": 3264,
                 "specs": {"material": "alloy", "weight": 13.8},
             },
@@ -179,10 +181,11 @@ inventory_json = {
             {
                 "id": "bike:4",
                 "model": "Salacia",
-                "description": "This bike is a great option for anyone who just wants a "
-                "bike to get about on With a slick-shifting Claris gears from Shimano\u2019s, "
-                "this is a bike which doesn\u2019t break the bank and delivers craved "
-                "performance.  It\u2019s for the rider who wants both efficiency and capability.",
+                "description": "This bike is a great option for anyone who just "
+                "wants a bike to get about on With a slick-shifting Claris gears "
+                "from Shimano\u2019s, this is a bike which doesn\u2019t break the "
+                "bank and delivers craved performance.  It\u2019s for the rider "
+                "who wants both efficiency and capability.",
                 "price": 1475,
                 "specs": {"material": "aluminium", "weight": 16.6},
                 "colors": ["black", "silver"],
@@ -190,13 +193,14 @@ inventory_json = {
             {
                 "id": "bike:5",
                 "model": "Mimas",
-                "description": "A real joy to ride, this bike got very high scores in last "
-                "years Bike of the year report. The carefully crafted 50-34 tooth chainset "
-                "and 11-32 tooth cassette give an easy-on-the-legs bottom gear for climbing, "
-                "and the high-quality Vittoria Zaffiro tires give balance and grip.It includes "
+                "description": "A real joy to ride, this bike got very high "
+                "scores in last years Bike of the year report. The carefully "
+                "crafted 50-34 tooth chainset and 11-32 tooth cassette give an "
+                "easy-on-the-legs bottom gear for climbing, and the high-quality "
+                "Vittoria Zaffiro tires give balance and grip.It includes "
                 "a low-step frame , our memory foam seat, bump-resistant shocks and "
-                "conveniently placed thumb throttle. Put it all together and you get a bike "
-                "that helps redefine what can be done for this price.",
+                "conveniently placed thumb throttle. Put it all together and you "
+                "get a bike that helps redefine what can be done for this price.",
                 "price": 3941,
                 "specs": {"material": "alloy", "weight": 11.6},
             },
@@ -214,7 +218,8 @@ res2 = r.json().get("bikes:inventory", "$.inventory.*")
 print(
     res2
 )
-# >>>    [[{'id': 'bike:1', 'model': 'Phoebe', 'description': 'This is a mid-travel trail slayer...
+# >>>    [[{'id': 'bike:1', 'model': 'Phoebe',
+# >>>       'description': 'This is a mid-travel trail slayer...
 # STEP_END
 
 # STEP_START get_mtnbikes
@@ -259,18 +264,20 @@ res8 = r.json().get(
 )
 print(
     res8
-)  # >>> [{'id': 'bike:2', 'model': 'Quaoar', 'description': "Redesigned for the 2020 model year...
+)  # >>> [{'id': 'bike:2', 'model': 'Quaoar',
+#           'description': "Redesigned for the 2020 model year...
 # STEP_END
 
 # REMOVE_START
 assert res8 == [{
     'id': 'bike:2', 'model': 'Quaoar',
-    'description': "Redesigned for the 2020 model year, this bike impressed our testers "
-    "and is the best all-around trail bike we've ever tested. The Shimano gear system "
-    "effectively does away with an external cassette, so is super low maintenance in terms "
-    "of wear and tear. All in all it's an impressive package for the price, making it very "
-    "competitive.", 
-    'price': 2072, 'specs': {'material': 'aluminium', 'weight': 7.9}, 'colors': ['black', 'white']}]
+    'description': "Redesigned for the 2020 model year, this bike impressed "
+    "our testers and is the best all-around trail bike we've ever tested. "
+    "The Shimano gear system effectively does away with an external cassette, "
+    "so is super low maintenance in terms of wear and tear. All in all it's "
+    "an impressive package for the price, making it very competitive.",
+    'price': 2072, 'specs': {'material': 'aluminium', 'weight': 7.9},
+    'colors': ['black', 'white']}]
 # REMOVE_END
 
 # STEP_START filter2
@@ -297,9 +304,21 @@ assert res10 == ["Quaoar", "Weywot", "Salacia", "Mimas"]
 # REMOVE_END
 
 # STEP_START filter4
-res11 = r.json().set("bikes:inventory", "$.inventory.mountain_bikes[0].regex_pat", "(?i)al")
-res12 = r.json().set("bikes:inventory", "$.inventory.mountain_bikes[1].regex_pat", "(?i)al")
-res13 = r.json().set("bikes:inventory", "$.inventory.mountain_bikes[2].regex_pat", "(?i)al")
+res11 = r.json().set(
+    "bikes:inventory",
+    "$.inventory.mountain_bikes[0].regex_pat",
+    "(?i)al"
+)
+res12 = r.json().set(
+    "bikes:inventory",
+    "$.inventory.mountain_bikes[1].regex_pat",
+    "(?i)al"
+)
+res13 = r.json().set(
+    "bikes:inventory",
+    "$.inventory.mountain_bikes[2].regex_pat",
+    "(?i)al"
+)
 
 res14 = r.json().get(
     "bikes:inventory",
@@ -313,44 +332,46 @@ assert res14 == ['Quaoar', 'Weywot']
 # REMOVE_END
 
 # STEP_START update_bikes
-res11 = r.json().get("bikes:inventory", "$..price")
-print(res11)  # >>> [1920, 2072, 3264, 1475, 3941]
+res15 = r.json().get("bikes:inventory", "$..price")
+print(res15)  # >>> [1920, 2072, 3264, 1475, 3941]
 
-res12 = r.json().numincrby("bikes:inventory", "$..price", -100)
-print(res12)  # >>> [1820, 1972, 3164, 1375, 3841]
+res16 = r.json().numincrby("bikes:inventory", "$..price", -100)
+print(res16)  # >>> [1820, 1972, 3164, 1375, 3841]
 
-res13 = r.json().numincrby("bikes:inventory", "$..price", 100)
-print(res13)  # >>> [1920, 2072, 3264, 1475, 3941]
+res17 = r.json().numincrby("bikes:inventory", "$..price", 100)
+print(res17)  # >>> [1920, 2072, 3264, 1475, 3941]
 # STEP_END
 
 # REMOVE_START
-assert res12 == [1820, 1972, 3164, 1375, 3841]
+assert res15 == [1920, 2072, 3264, 1475, 3941]
+assert res16 == [1820, 1972, 3164, 1375, 3841]
+assert res17 == [1920, 2072, 3264, 1475, 3941]
 # REMOVE_END
 
 # STEP_START update_filters1
-res16 = r.json().set("bikes:inventory", "$.inventory.*[?(@.price<2000)].price", 1500)
-res17 = r.json().get("bikes:inventory", "$..price")
-print(res17)    # >>> [1500, 2072, 3264, 1500, 3941]
+res18 = r.json().set("bikes:inventory", "$.inventory.*[?(@.price<2000)].price", 1500)
+res19 = r.json().get("bikes:inventory", "$..price")
+print(res19)    # >>> [1500, 2072, 3264, 1500, 3941]
 # STEP_END
 
 # REMOVE_START
-assert res17 == [1500, 2072, 3264, 1500, 3941]
+assert res19 == [1500, 2072, 3264, 1500, 3941]
 # REMOVE_END
 
 # STEP_START update_filters2
-res14 = r.json().arrappend(
+res20 = r.json().arrappend(
     "bikes:inventory", "$.inventory.*[?(@.price<2000)].colors", "pink"
 )
-print(res14)  # >>> [3, 3]
+print(res20)  # >>> [3, 3]
 
-res15 = r.json().get("bikes:inventory", "$..[*].colors")
+res21 = r.json().get("bikes:inventory", "$..[*].colors")
 print(
-    res15
+    res21
 )  # >>> [['black', 'silver', 'pink'], ['black', 'white'], ['black', 'silver', 'pink']]
 # STEP_END
 
 # REMOVE_START
-assert res15 == [
+assert res21 == [
     ["black", "silver", "pink"],
     ["black", "white"],
     ["black", "silver", "pink"],

--- a/doctests/dt_json.py
+++ b/doctests/dt_json.py
@@ -1,5 +1,8 @@
 # EXAMPLE: json_tutorial
 # HIDE_START
+"""
+Code samples for JSON doc pages: https://redis.io/docs/latest/develop/data-types/json/
+"""
 import redis
 
 r = redis.Redis(decode_responses=True)
@@ -139,7 +142,11 @@ inventory_json = {
             {
                 "id": "bike:1",
                 "model": "Phoebe",
-                "description": "This is a mid-travel trail slayer that is a fantastic daily driver or one bike quiver. The Shimano Claris 8-speed groupset gives plenty of gear range to tackle hills and there\u2019s room for mudguards and a rack too.  This is the bike for the rider who wants trail manners with low fuss ownership.",
+                "description": "This is a mid-travel trail slayer that is a fantastic "
+                "daily driver or one bike quiver. The Shimano Claris 8-speed groupset "
+                "gives plenty of gear range to tackle hills and there\u2019s room for "
+                "mudguards and a rack too.  This is the bike for the rider who wants "
+                "trail manners with low fuss ownership.",
                 "price": 1920,
                 "specs": {"material": "carbon", "weight": 13.1},
                 "colors": ["black", "silver"],
@@ -147,7 +154,11 @@ inventory_json = {
             {
                 "id": "bike:2",
                 "model": "Quaoar",
-                "description": "Redesigned for the 2020 model year, this bike impressed our testers and is the best all-around trail bike we've ever tested. The Shimano gear system effectively does away with an external cassette, so is super low maintenance in terms of wear and tear. All in all it's an impressive package for the price, making it very competitive.",
+                "description": "Redesigned for the 2020 model year, this bike impressed "
+                "our testers and is the best all-around trail bike we've ever tested. The "
+                "Shimano gear system effectively does away with an external cassette, so "
+                "is super low maintenance in terms of wear and tear. All in all it's an "
+                "impressive package for the price, making it very competitive.",
                 "price": 2072,
                 "specs": {"material": "aluminium", "weight": 7.9},
                 "colors": ["black", "white"],
@@ -155,7 +166,11 @@ inventory_json = {
             {
                 "id": "bike:3",
                 "model": "Weywot",
-                "description": "This bike gives kids aged six years and older a durable and uberlight mountain bike for their first experience on tracks and easy cruising through forests and fields. A set of powerful Shimano hydraulic disc brakes provide ample stopping ability. If you're after a budget option, this is one of the best bikes you could get.",
+                "description": "This bike gives kids aged six years and older a durable "
+                "and uberlight mountain bike for their first experience on tracks and easy "
+                "cruising through forests and fields. A set of powerful Shimano hydraulic "
+                "disc brakes provide ample stopping ability. If you're after a budget option, "
+                "this is one of the best bikes you could get.",
                 "price": 3264,
                 "specs": {"material": "alloy", "weight": 13.8},
             },
@@ -164,7 +179,10 @@ inventory_json = {
             {
                 "id": "bike:4",
                 "model": "Salacia",
-                "description": "This bike is a great option for anyone who just wants a bike to get about on With a slick-shifting Claris gears from Shimano\u2019s, this is a bike which doesn\u2019t break the bank and delivers craved performance.  It\u2019s for the rider who wants both efficiency and capability.",
+                "description": "This bike is a great option for anyone who just wants a "
+                "bike to get about on With a slick-shifting Claris gears from Shimano\u2019s, "
+                "this is a bike which doesn\u2019t break the bank and delivers craved "
+                "performance.  It\u2019s for the rider who wants both efficiency and capability.",
                 "price": 1475,
                 "specs": {"material": "aluminium", "weight": 16.6},
                 "colors": ["black", "silver"],
@@ -172,7 +190,13 @@ inventory_json = {
             {
                 "id": "bike:5",
                 "model": "Mimas",
-                "description": "A real joy to ride, this bike got very high scores in last years Bike of the year report. The carefully crafted 50-34 tooth chainset and 11-32 tooth cassette give an easy-on-the-legs bottom gear for climbing, and the high-quality Vittoria Zaffiro tires give balance and grip.It includes a low-step frame , our memory foam seat, bump-resistant shocks and conveniently placed thumb throttle. Put it all together and you get a bike that helps redefine what can be done for this price.",
+                "description": "A real joy to ride, this bike got very high scores in last "
+                "years Bike of the year report. The carefully crafted 50-34 tooth chainset "
+                "and 11-32 tooth cassette give an easy-on-the-legs bottom gear for climbing, "
+                "and the high-quality Vittoria Zaffiro tires give balance and grip.It includes "
+                "a low-step frame , our memory foam seat, bump-resistant shocks and "
+                "conveniently placed thumb throttle. Put it all together and you get a bike "
+                "that helps redefine what can be done for this price.",
                 "price": 3941,
                 "specs": {"material": "alloy", "weight": 11.6},
             },
@@ -189,7 +213,8 @@ print(res1)  # >>> True
 res2 = r.json().get("bikes:inventory", "$.inventory.*")
 print(
     res2
-)  # >>> [[{'id': 'bike:1', 'model': 'Phoebe', 'description': 'This is a mid-travel trail slayer that is a fantastic daily driver or one bike quiver. The Shimano Claris 8-speed groupset gives plenty of gear range to tackle hills and there’s room for mudguards and a rack too.  This is the bike for the rider who wants trail manners with low fuss ownership.', 'price': 1920, 'specs': {'material': 'carbon', 'weight': 13.1}, 'colors': ['black', 'silver']}, {'id': 'bike:2', 'model': 'Quaoar', 'description': "Redesigned for the 2020 model year, this bike impressed our testers and is the best all-around trail bike we've ever tested. The Shimano gear system effectively does away with an external cassette, so is super low maintenance in terms of wear and tear. All in all it's an impressive package for the price, making it very competitive.", 'price': 2072, 'specs': {'material': 'aluminium', 'weight': 7.9}, 'colors': ['black', 'white']}, {'id': 'bike:3', 'model': 'Weywot', 'description': "This bike gives kids aged six years and older a durable and uberlight mountain bike for their first experience on tracks and easy cruising through forests and fields. A set of powerful Shimano hydraulic disc brakes provide ample stopping ability. If you're after a budget option, this is one of the best bikes you could get.", 'price': 3264, 'specs': {'material': 'alloy', 'weight': 13.8}}], [{'id': 'bike:4', 'model': 'Salacia', 'description': 'This bike is a great option for anyone who just wants a bike to get about on With a slick-shifting Claris gears from Shimano’s, this is a bike which doesn’t break the bank and delivers craved performance.  It’s for the rider who wants both efficiency and capability.', 'price': 1475, 'specs': {'material': 'aluminium', 'weight': 16.6}, 'colors': ['black', 'silver']}, {'id': 'bike:5', 'model': 'Mimas', 'description': 'A real joy to ride, this bike got very high scores in last years Bike of the year report. The carefully crafted 50-34 tooth chainset and 11-32 tooth cassette give an easy-on-the-legs bottom gear for climbing, and the high-quality Vittoria Zaffiro tires give balance and grip.It includes a low-step frame , our memory foam seat, bump-resistant shocks and conveniently placed thumb throttle. Put it all together and you get a bike that helps redefine what can be done for this price.', 'price': 3941, 'specs': {'material': 'alloy', 'weight': 11.6}}]]
+)
+# >>>    [[{'id': 'bike:1', 'model': 'Phoebe', 'description': 'This is a mid-travel trail slayer...
 # STEP_END
 
 # STEP_START get_mtnbikes
@@ -234,11 +259,18 @@ res8 = r.json().get(
 )
 print(
     res8
-)  # >>> [{'id': 'bike:2', 'model': 'Quaoar', 'description': "Redesigned for the 2020 model year, this bike impressed our testers and is the best all-around trail bike we've ever tested. The Shimano gear system effectively does away with an external cassette, so is super low maintenance in terms of wear and tear. All in all it's an impressive package for the price, making it very competitive.", 'price': 2072, 'specs': {'material': 'aluminium', 'weight': 7.9}, 'colors': ['black', 'white']}]
+)  # >>> [{'id': 'bike:2', 'model': 'Quaoar', 'description': "Redesigned for the 2020 model year...
 # STEP_END
 
 # REMOVE_START
-assert res8 == [{'id': 'bike:2', 'model': 'Quaoar', 'description': "Redesigned for the 2020 model year, this bike impressed our testers and is the best all-around trail bike we've ever tested. The Shimano gear system effectively does away with an external cassette, so is super low maintenance in terms of wear and tear. All in all it's an impressive package for the price, making it very competitive.", 'price': 2072, 'specs': {'material': 'aluminium', 'weight': 7.9}, 'colors': ['black', 'white']}]
+assert res8 == [{
+    'id': 'bike:2', 'model': 'Quaoar',
+    'description': "Redesigned for the 2020 model year, this bike impressed our testers "
+    "and is the best all-around trail bike we've ever tested. The Shimano gear system "
+    "effectively does away with an external cassette, so is super low maintenance in terms "
+    "of wear and tear. All in all it's an impressive package for the price, making it very "
+    "competitive.", 
+    'price': 2072, 'specs': {'material': 'aluminium', 'weight': 7.9}, 'colors': ['black', 'white']}]
 # REMOVE_END
 
 # STEP_START filter2
@@ -269,7 +301,10 @@ res11 = r.json().set("bikes:inventory", "$.inventory.mountain_bikes[0].regex_pat
 res12 = r.json().set("bikes:inventory", "$.inventory.mountain_bikes[1].regex_pat", "(?i)al")
 res13 = r.json().set("bikes:inventory", "$.inventory.mountain_bikes[2].regex_pat", "(?i)al")
 
-res14 = r.json().get("bikes:inventory", "$.inventory.mountain_bikes[?(@.specs.material =~ @.regex_pat)].model")
+res14 = r.json().get(
+    "bikes:inventory",
+    "$.inventory.mountain_bikes[?(@.specs.material =~ @.regex_pat)].model"
+)
 print(res14)    # >>> ['Quaoar', 'Weywot']
 # STEP_END
 

--- a/doctests/dt_json.py
+++ b/doctests/dt_json.py
@@ -227,7 +227,7 @@ print(res7)  # >>> [['Phoebe', 'Quaoar']]
 assert res7 == ["Phoebe", "Quaoar"]
 # REMOVE_END
 
-# STEP_START filters
+# STEP_START filter1
 res8 = r.json().get(
     "bikes:inventory",
     "$..mountain_bikes[?(@.price < 3000 && @.specs.weight < 10)]",
@@ -235,13 +235,25 @@ res8 = r.json().get(
 print(
     res8
 )  # >>> [{'id': 'bike:2', 'model': 'Quaoar', 'description': "Redesigned for the 2020 model year, this bike impressed our testers and is the best all-around trail bike we've ever tested. The Shimano gear system effectively does away with an external cassette, so is super low maintenance in terms of wear and tear. All in all it's an impressive package for the price, making it very competitive.", 'price': 2072, 'specs': {'material': 'aluminium', 'weight': 7.9}, 'colors': ['black', 'white']}]
+# STEP_END
 
+# REMOVE_START
+assert res8 == [{'id': 'bike:2', 'model': 'Quaoar', 'description': "Redesigned for the 2020 model year, this bike impressed our testers and is the best all-around trail bike we've ever tested. The Shimano gear system effectively does away with an external cassette, so is super low maintenance in terms of wear and tear. All in all it's an impressive package for the price, making it very competitive.", 'price': 2072, 'specs': {'material': 'aluminium', 'weight': 7.9}, 'colors': ['black', 'white']}]
+# REMOVE_END
+
+# STEP_START filter2
 #  names of bikes made from an alloy
 res9 = r.json().get(
     "bikes:inventory", "$..[?(@.specs.material == 'alloy')].model"
 )
-print(res9)  # >>> [['Weywot', 'Mimas']]
+print(res9)  # >>> ['Weywot', 'Mimas']
+# STEP_END
 
+# REMOVE_START
+assert res9 == ['Weywot', 'Mimas']
+# REMOVE_END
+
+# STEP_START filter3
 res10 = r.json().get(
     "bikes:inventory", "$..[?(@.specs.material =~ '(?i)al')].model"
 )
@@ -250,6 +262,19 @@ print(res10)  # >>> ['Quaoar', 'Weywot', 'Salacia', 'Mimas']
 
 # REMOVE_START
 assert res10 == ["Quaoar", "Weywot", "Salacia", "Mimas"]
+# REMOVE_END
+
+# STEP_START filter4
+res11 = r.json().set("bikes:inventory", "$.inventory.mountain_bikes[0].regex_pat", "(?i)al")
+res12 = r.json().set("bikes:inventory", "$.inventory.mountain_bikes[1].regex_pat", "(?i)al")
+res13 = r.json().set("bikes:inventory", "$.inventory.mountain_bikes[2].regex_pat", "(?i)al")
+
+res14 = r.json().get("bikes:inventory", "$.inventory.mountain_bikes[?(@.specs.material =~ @.regex_pat)].model")
+print(res14)    # >>> ['Quaoar', 'Weywot']
+# STEP_END
+
+# REMOVE_START
+assert res14 == ['Quaoar', 'Weywot']
 # REMOVE_END
 
 # STEP_START update_bikes
@@ -267,7 +292,17 @@ print(res13)  # >>> [1920, 2072, 3264, 1475, 3941]
 assert res12 == [1820, 1972, 3164, 1375, 3841]
 # REMOVE_END
 
-# STEP_START update_filters
+# STEP_START update_filters1
+res16 = r.json().set("bikes:inventory", "$.inventory.*[?(@.price<2000)].price", 1500)
+res17 = r.json().get("bikes:inventory", "$..price")
+print(res17)    # >>> [1500, 2072, 3264, 1500, 3941]
+# STEP_END
+
+# REMOVE_START
+assert res17 == [1500, 2072, 3264, 1500, 3941]
+# REMOVE_END
+
+# STEP_START update_filters2
 res14 = r.json().arrappend(
     "bikes:inventory", "$.inventory.*[?(@.price<2000)].colors", "pink"
 )

--- a/doctests/dt_json.py
+++ b/doctests/dt_json.py
@@ -268,25 +268,23 @@ print(res8)
 # REMOVE_START
 assert res8 == [
     {
-        'id': 'bike:2',
-        'model': 'Quaoar',
-        'description': "Redesigned for the 2020 model year, this bike impressed "
+        "id": "bike:2",
+        "model": "Quaoar",
+        "description": "Redesigned for the 2020 model year, this bike impressed "
         "our testers and is the best all-around trail bike we've ever tested. "
         "The Shimano gear system effectively does away with an external cassette, "
         "so is super low maintenance in terms of wear and tear. All in all it's "
         "an impressive package for the price, making it very competitive.",
-        'price': 2072,
-        'specs': {'material': 'aluminium', 'weight': 7.9},
-        'colors': ['black', 'white']
+        "price": 2072,
+        "specs": {"material": "aluminium", "weight": 7.9},
+        "colors": ["black", "white"],
     }
 ]
 # REMOVE_END
 
 # STEP_START filter2
 #  names of bikes made from an alloy
-res9 = r.json().get(
-    "bikes:inventory", "$..[?(@.specs.material == 'alloy')].model"
-)
+res9 = r.json().get("bikes:inventory", "$..[?(@.specs.material == 'alloy')].model")
 print(res9)  # >>> ['Weywot', 'Mimas']
 # STEP_END
 
@@ -295,9 +293,7 @@ assert res9 == ["Weywot", "Mimas"]
 # REMOVE_END
 
 # STEP_START filter3
-res10 = r.json().get(
-    "bikes:inventory", "$..[?(@.specs.material =~ '(?i)al')].model"
-)
+res10 = r.json().get("bikes:inventory", "$..[?(@.specs.material =~ '(?i)al')].model")
 print(res10)  # >>> ['Quaoar', 'Weywot', 'Salacia', 'Mimas']
 # STEP_END
 
@@ -318,9 +314,9 @@ res13 = r.json().set(
 
 res14 = r.json().get(
     "bikes:inventory",
-    "$.inventory.mountain_bikes[?(@.specs.material =~ @.regex_pat)].model"
+    "$.inventory.mountain_bikes[?(@.specs.material =~ @.regex_pat)].model",
 )
-print(res14)    # >>> ['Quaoar', 'Weywot']
+print(res14)  # >>> ['Quaoar', 'Weywot']
 # STEP_END
 
 # REMOVE_START
@@ -345,11 +341,9 @@ assert res17 == [1920, 2072, 3264, 1475, 3941]
 # REMOVE_END
 
 # STEP_START update_filters1
-res18 = r.json().set(
-    "bikes:inventory", "$.inventory.*[?(@.price<2000)].price", 1500
-)
+res18 = r.json().set("bikes:inventory", "$.inventory.*[?(@.price<2000)].price", 1500)
 res19 = r.json().get("bikes:inventory", "$..price")
-print(res19)    # >>> [1500, 2072, 3264, 1500, 3941]
+print(res19)  # >>> [1500, 2072, 3264, 1500, 3941]
 # STEP_END
 
 # REMOVE_START

--- a/doctests/dt_json.py
+++ b/doctests/dt_json.py
@@ -215,9 +215,7 @@ print(res1)  # >>> True
 
 # STEP_START get_bikes
 res2 = r.json().get("bikes:inventory", "$.inventory.*")
-print(
-    res2
-)
+print(res2)
 # >>>    [[{'id': 'bike:1', 'model': 'Phoebe',
 # >>>       'description': 'This is a mid-travel trail slayer...
 # STEP_END
@@ -262,22 +260,26 @@ res8 = r.json().get(
     "bikes:inventory",
     "$..mountain_bikes[?(@.price < 3000 && @.specs.weight < 10)]",
 )
-print(
-    res8
-)  # >>> [{'id': 'bike:2', 'model': 'Quaoar',
+print(res8)
+# >>> [{'id': 'bike:2', 'model': 'Quaoar',
 #           'description': "Redesigned for the 2020 model year...
 # STEP_END
 
 # REMOVE_START
-assert res8 == [{
-    'id': 'bike:2', 'model': 'Quaoar',
-    'description': "Redesigned for the 2020 model year, this bike impressed "
-    "our testers and is the best all-around trail bike we've ever tested. "
-    "The Shimano gear system effectively does away with an external cassette, "
-    "so is super low maintenance in terms of wear and tear. All in all it's "
-    "an impressive package for the price, making it very competitive.",
-    'price': 2072, 'specs': {'material': 'aluminium', 'weight': 7.9},
-    'colors': ['black', 'white']}]
+assert res8 == [
+    {
+        'id': 'bike:2',
+        'model': 'Quaoar',
+        'description': "Redesigned for the 2020 model year, this bike impressed "
+        "our testers and is the best all-around trail bike we've ever tested. "
+        "The Shimano gear system effectively does away with an external cassette, "
+        "so is super low maintenance in terms of wear and tear. All in all it's "
+        "an impressive package for the price, making it very competitive.",
+        'price': 2072,
+        'specs': {'material': 'aluminium', 'weight': 7.9},
+        'colors': ['black', 'white']
+    }
+]
 # REMOVE_END
 
 # STEP_START filter2
@@ -289,7 +291,7 @@ print(res9)  # >>> ['Weywot', 'Mimas']
 # STEP_END
 
 # REMOVE_START
-assert res9 == ['Weywot', 'Mimas']
+assert res9 == ["Weywot", "Mimas"]
 # REMOVE_END
 
 # STEP_START filter3
@@ -305,19 +307,13 @@ assert res10 == ["Quaoar", "Weywot", "Salacia", "Mimas"]
 
 # STEP_START filter4
 res11 = r.json().set(
-    "bikes:inventory",
-    "$.inventory.mountain_bikes[0].regex_pat",
-    "(?i)al"
+    "bikes:inventory", "$.inventory.mountain_bikes[0].regex_pat", "(?i)al"
 )
 res12 = r.json().set(
-    "bikes:inventory",
-    "$.inventory.mountain_bikes[1].regex_pat",
-    "(?i)al"
+    "bikes:inventory", "$.inventory.mountain_bikes[1].regex_pat", "(?i)al"
 )
 res13 = r.json().set(
-    "bikes:inventory",
-    "$.inventory.mountain_bikes[2].regex_pat",
-    "(?i)al"
+    "bikes:inventory", "$.inventory.mountain_bikes[2].regex_pat", "(?i)al"
 )
 
 res14 = r.json().get(
@@ -328,7 +324,7 @@ print(res14)    # >>> ['Quaoar', 'Weywot']
 # STEP_END
 
 # REMOVE_START
-assert res14 == ['Quaoar', 'Weywot']
+assert res14 == ["Quaoar", "Weywot"]
 # REMOVE_END
 
 # STEP_START update_bikes
@@ -349,7 +345,9 @@ assert res17 == [1920, 2072, 3264, 1475, 3941]
 # REMOVE_END
 
 # STEP_START update_filters1
-res18 = r.json().set("bikes:inventory", "$.inventory.*[?(@.price<2000)].price", 1500)
+res18 = r.json().set(
+    "bikes:inventory", "$.inventory.*[?(@.price<2000)].price", 1500
+)
 res19 = r.json().get("bikes:inventory", "$..price")
 print(res19)    # >>> [1500, 2072, 3264, 1500, 3941]
 # STEP_END


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Python examples for the [JSON datatype page](https://redis.io/docs/latest/develop/data-types/json/) are available in the repo but haven't been added to the page yet. While adding them, I discovered that the Python samples don't match the CLI samples in a few places, so I've updated them.
