### PR TITLE
Ignore RuntimeError in AbstractConnection._close

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -248,7 +248,10 @@ class AbstractConnection:
         Internal method to silently close the connection without waiting
         """
         if self._writer:
-            self._writer.close()
+            try:
+                self._writer.close()
+            except RuntimeError:
+                pass
             self._writer = self._reader = None
 
     def __repr__(self):


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Fixes https://github.com/redis/redis-py/issues/3239 by ignoring a `RuntimeError`