### PR TITLE
Add type annotations for redis-module commands

### DIFF
--- a/redis/commands/redismodules.py
+++ b/redis/commands/redismodules.py
@@ -1,4 +1,13 @@
 from json import JSONDecoder, JSONEncoder
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .json import JSON
+    from .search import Search
+    from .timeseries import TimeSeries
+    from .bf import BFBloom, CMSBloom, TOPKBloom, TDigestBloom, CFBloom
+    from .graph import Graph, AsyncGraph
+    from .search import AsyncSearch
 
 
 class RedisModuleCommands:
@@ -6,7 +15,11 @@ class RedisModuleCommands:
     modules into the command namespace.
     """
 
-    def json(self, encoder=JSONEncoder(), decoder=JSONDecoder()):
+    def json(
+        self,
+        encoder: JSONEncoder = JSONEncoder(),
+        decoder: JSONDecoder = JSONDecoder(),
+    ) -> "JSON":
         """Access the json namespace, providing support for redis json."""
 
         from .json import JSON
@@ -14,7 +27,7 @@ class RedisModuleCommands:
         jj = JSON(client=self, encoder=encoder, decoder=decoder)
         return jj
 
-    def ft(self, index_name="idx"):
+    def ft(self, index_name: str = "idx") -> "Search":
         """Access the search namespace, providing support for redis search."""
 
         from .search import Search
@@ -22,7 +35,7 @@ class RedisModuleCommands:
         s = Search(client=self, index_name=index_name)
         return s
 
-    def ts(self):
+    def ts(self) -> "TimeSeries":
         """Access the timeseries namespace, providing support for
         redis timeseries data.
         """
@@ -32,7 +45,7 @@ class RedisModuleCommands:
         s = TimeSeries(client=self)
         return s
 
-    def bf(self):
+    def bf(self) -> "BFBloom":
         """Access the bloom namespace."""
 
         from .bf import BFBloom
@@ -40,7 +53,7 @@ class RedisModuleCommands:
         bf = BFBloom(client=self)
         return bf
 
-    def cf(self):
+    def cf(self) -> "CFBloom":
         """Access the bloom namespace."""
 
         from .bf import CFBloom
@@ -48,7 +61,7 @@ class RedisModuleCommands:
         cf = CFBloom(client=self)
         return cf
 
-    def cms(self):
+    def cms(self) -> "CMSBloom":
         """Access the bloom namespace."""
 
         from .bf import CMSBloom
@@ -56,7 +69,7 @@ class RedisModuleCommands:
         cms = CMSBloom(client=self)
         return cms
 
-    def topk(self):
+    def topk(self) -> "TOPKBloom":
         """Access the bloom namespace."""
 
         from .bf import TOPKBloom
@@ -64,7 +77,7 @@ class RedisModuleCommands:
         topk = TOPKBloom(client=self)
         return topk
 
-    def tdigest(self):
+    def tdigest(self) -> "TDigestBloom":
         """Access the bloom namespace."""
 
         from .bf import TDigestBloom
@@ -72,7 +85,7 @@ class RedisModuleCommands:
         tdigest = TDigestBloom(client=self)
         return tdigest
 
-    def graph(self, index_name="idx"):
+    def graph(self, index_name: str = "idx") -> "Graph":
         """Access the graph namespace, providing support for
         redis graph data.
         """
@@ -84,7 +97,7 @@ class RedisModuleCommands:
 
 
 class AsyncRedisModuleCommands(RedisModuleCommands):
-    def ft(self, index_name="idx"):
+    def ft(self, index_name: str = "idx") -> "AsyncSearch":
         """Access the search namespace, providing support for redis search."""
 
         from .search import AsyncSearch
@@ -92,7 +105,7 @@ class AsyncRedisModuleCommands(RedisModuleCommands):
         s = AsyncSearch(client=self, index_name=index_name)
         return s
 
-    def graph(self, index_name="idx"):
+    def graph(self, index_name: str = "idx") -> "AsyncGraph":
         """Access the graph namespace, providing support for
         redis graph data.
         """

--- a/redis/commands/redismodules.py
+++ b/redis/commands/redismodules.py
@@ -2,12 +2,11 @@ from json import JSONDecoder, JSONEncoder
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from .bf import BFBloom, CFBloom, CMSBloom, TDigestBloom, TOPKBloom
+    from .graph import AsyncGraph, Graph
     from .json import JSON
-    from .search import Search
+    from .search import AsyncSearch, Search
     from .timeseries import TimeSeries
-    from .bf import BFBloom, CMSBloom, TOPKBloom, TDigestBloom, CFBloom
-    from .graph import Graph, AsyncGraph
-    from .search import AsyncSearch
 
 
 class RedisModuleCommands:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Add missing type annotations for `redismodules.py`, as `redis-py` is packaged with a `py.typed`, so modules should be annotated.
