### PR TITLE
Fix parsing of INFO response

### DIFF
--- a/redis/_parsers/helpers.py
+++ b/redis/_parsers/helpers.py
@@ -38,7 +38,7 @@ def parse_info(response):
     response = str_if_bytes(response)
 
     def get_value(value):
-        if "," not in value or "=" not in value:
+        if "," not in value and "=" not in value:
             try:
                 if "." in value:
                     return float(value)

--- a/tests/test_parsers/test_helpers.py
+++ b/tests/test_parsers/test_helpers.py
@@ -1,0 +1,35 @@
+from redis._parsers.helpers import parse_info
+
+
+def test_parse_info():
+    info_output = """
+# Modules
+module:name=search,ver=999999,api=1,filters=0,usedby=[],using=[ReJSON],options=[handle-io-errors]
+
+# search_fields_statistics
+search_fields_text:Text=3
+search_fields_tag:Tag=2,Sortable=1
+
+# search_version
+search_version:99.99.99
+search_redis_version:7.2.2 - oss
+
+# search_runtime_configurations
+search_query_timeout_ms:500
+    """
+    info = parse_info(info_output)
+
+    assert isinstance(info["modules"], list)
+    assert isinstance(info["modules"][0], dict)
+    assert info["modules"][0]["name"] == "search"
+
+    assert isinstance(info["search_fields_text"], dict)
+    assert info["search_fields_text"]["Text"] == 3
+
+    assert isinstance(info["search_fields_tag"], dict)
+    assert info["search_fields_tag"]["Tag"] == 2
+    assert info["search_fields_tag"]["Sortable"] == 1
+
+    assert info["search_version"] == "99.99.99"
+    assert info["search_redis_version"] == "7.2.2 - oss"
+    assert info["search_query_timeout_ms"] == 500


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

If the INFO response contains a single `a=b` value for any of the keys, that must also be parsed into a dictionary.

Fixes #3262
