### PR TITLE
[#3090] Reduce Command Responses in Redis Connection Process (on_connect)

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -411,8 +411,7 @@ class AbstractConnection:
             if self.client_cache:
                 self.send_command("CLIENT", "TRACKING", "ON")
 
-        # execute the MULTI block
-        try:
+            # execute the MULTI block
             self.send_command('EXEC')
             responses = self._read_exec_responses()
             # check AUTH response if AUTH command was sent

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -414,15 +414,6 @@ class AbstractConnection:
             # execute the MULTI block
             self.send_command('EXEC')
             responses = self._read_exec_responses()
-            # check AUTH response if AUTH command was sent
-            if auth_command_response:
-                # First response should be for AUTH command
-                auth_response = responses[0]
-                if b'ERR' in auth_response:
-                    raise AuthenticationError(
-                        "Authentication failed: %s" % auth_response)
-                responses = responses[1:]  # Remove AUTH response from the list
-
             self._handle_responses(responses, auth_args)
         except (TimeoutError, AuthenticationError, ConnectionError) as e:
             if not self.retry_on_timeout:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -395,29 +395,16 @@ class AbstractConnection:
         # if a client_name is given, set it
         if self.client_name:
             self.send_command("CLIENT", "SETNAME", self.client_name)
-            if str_if_bytes(self.read_response()) != "OK":
-                raise ConnectionError("Error setting client name")
 
-        try:
-            # set the library name and version
-            if self.lib_name:
-                self.send_command("CLIENT", "SETINFO", "LIB-NAME", self.lib_name)
-                self.read_response()
-        except ResponseError:
-            pass
-
-        try:
-            if self.lib_version:
-                self.send_command("CLIENT", "SETINFO", "LIB-VER", self.lib_version)
-                self.read_response()
-        except ResponseError:
-            pass
+        # set the library name and version
+        if self.lib_name:
+            self.send_command("CLIENT", "SETINFO", "LIB-NAME", self.lib_name)
+        if self.lib_version:
+            self.send_command("CLIENT", "SETINFO", "LIB-VER", self.lib_version)
 
         # if a database is specified, switch to it
         if self.db:
             self.send_command("SELECT", self.db)
-            if str_if_bytes(self.read_response()) != "OK":
-                raise ConnectionError("Invalid Database")
 
         # if client caching is enabled, start tracking
         if self.client_cache:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -264,6 +264,58 @@ class TestConnection(TestCase):
         mock_send_command.assert_called()
         mock_read_response.assert_called()
 
+    @patch.object(Connection, 'send_command')
+    @patch.object(Connection, 'read_response')
+    def test_on_connect_auth_with_password_only(
+            self, mock_read_response, mock_send_command):
+        """Test on_connect handling of password-only AUTH for Redis versions below 6.0.0 without HELLO command"""
+        conn = Connection()
+
+        conn._parser = MagicMock()
+        conn._parser.on_connect.return_value = None
+        conn.credential_provider = None
+        conn.username = None
+        conn.password = "password"
+        conn.protocol = 1
+        conn.client_name = "test-client"
+        conn.lib_name = "test"
+        conn.lib_version = "1234"
+        conn.db = 1
+        conn.client_cache = True
+
+        # command response to simulate Redis < 6.0.0 behavior
+        mock_read_response.side_effect = itertools.cycle([
+            Exception("ERR HELLO"),  # HELLO (fails)
+            b'QUEUED',  # MULTI
+            b'QUEUED',  # AUTH
+            b'QUEUED',  # CLIENT SETNAME
+            b'QUEUED',  # CLIENT SETINFO LIB-NAME
+            b'QUEUED',  # CLIENT SETINFO LIB-VER
+            b'QUEUED',  # SELECT
+            b'QUEUED',  # CLIENT TRACKING ON
+            [
+                b'OK',                           # AUTH response
+                b'OK',                           # CLIENT SETNAME response
+                b'OK',                           # CLIENT SETINFO LIB-NAME response
+                b'OK',                           # CLIENT SETINFO LIB-VER response
+                b'OK',                           # SELECT response
+                b'OK'                            # CLIENT TRACKING ON response
+            ]
+        ])
+
+        conn.on_connect()
+
+        mock_send_command.assert_any_call('HELLO', 1, 'AUTH', 'default', 'password'),
+        mock_send_command.assert_any_call('MULTI'),
+        mock_send_command.assert_any_call(
+            'AUTH', 'default', 'password', check_health=False)
+        mock_send_command.assert_any_call('CLIENT', 'SETNAME', 'test-client')
+        mock_send_command.assert_any_call('CLIENT', 'SETINFO', 'LIB-NAME', 'test')
+        mock_send_command.assert_any_call('CLIENT', 'SETINFO', 'LIB-VER', '1234')
+        mock_send_command.assert_any_call('SELECT', 1)
+        mock_send_command.assert_any_call('CLIENT', 'TRACKING', 'ON')
+        mock_send_command.assert_any_call('EXEC')
+        mock_read_response.assert_called()
 
 
 @pytest.mark.onlynoncluster


### PR DESCRIPTION
### Pull Request check-list
#3090 
_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
In this PR, I experimented with using MULTI and EXEC commands to batch multiple Redis commands into a single request. My goal was to reduce the number of network round-trips and improve overall performance by minimizing network latency.

**Observations**
After running the integration tests, I noticed that while the number of network requests decreased, the total execution time actually increased. Here’s what I found:

1. Increased BufferedReader Time

    When we send multiple commands in one MULTI/EXEC block, the server responds with all the results in one go. Reading this large combined response takes longer, which increased the time spent in the BufferedReader.

2. Command Packing Overhead

    Packing multiple commands into a single MULTI request requires additional processing to format the data correctly. This added some overhead to the command preparation phase.

3. Complex Response Parsing

    Parsing the combined response from EXEC also turned out to be more complex and time-consuming. Each individual command’s result had to be handled separately from the large, single response, which added to the total processing time.


**Test Result**
Here are the Integration test results comparing the Original Logic' and the Modified Logic

[ Measuring the time for 1000 Redis connections ]
|Modified Logic|Original Logic|
|------|---|
|0.243718 s|0.168276 s|


```python
class TestRedisIntegration(unittest.TestCase):

    def setUp(self):
        self.client = redis.Redis(host='localhost', port=6379, db=0)
        self.client.set('test_key', 'test_value')
        logger.info(f"value: {self.client.get('test_key').decode('utf-8')}")
        self.client.flushdb()

    def tearDown(self):
        self.client.flushdb()

    def test_on_connect_performance_high_version(self):
        """Test on_connect method performance"""
        conn = Connection()
        conn.username = None
        conn.password = None
        conn.protocol = 2
        conn.client_name = None
        conn.lib_name = 'redis-py'
        conn.lib_version = '99.99.99'
        conn.db = 0
        conn.client_cache = False

        # Recording start time and measuring execution time
        connect_time_thousand = timeit.timeit(conn.on_connect, number=1000)

        logger.info(f"Measuring the time for 1000 Redis connections: {connect_time_thousand:.6f} seconds")
```

![image](https://github.com/redis/redis-py/assets/44468282/a1758b8c-9a4c-4a0e-9ffa-f847336e8d47)


**Conclusion**
While the idea was to reduce network latency by batching commands, the extra time taken to read and parse the larger response offset these gains. It seems that for our case, the increased local processing outweighed the benefits of fewer network requests.

----
I’d love to get your feedback on this. Do you think there are other optimizations we should consider, or is there something I might have missed? Any insights would be greatly appreciated! cc. @chayim 🙇🏻

Thanks!