### PR TITLE
Correct typo in set example

### DIFF
--- a/doctests/dt_set.py
+++ b/doctests/dt_set.py
@@ -39,7 +39,7 @@ res5 = r.sismember("bikes:racing:usa", "bike:1")
 print(res5)  # >>> 1
 
 res6 = r.sismember("bikes:racing:usa", "bike:2")
-print(res6)  # >>> 1
+print(res6)  # >>> 0
 # STEP_END
 
 # REMOVE_START


### PR DESCRIPTION
### Description of change

Modify a comment in doctests/dt_set.py per [this docs issue](https://github.com/redis/docs/issues/308) .
