### PR TITLE
Refactor(Typing): Add and update type annotations for core Redis commands

### DIFF
--- a/redis/typing.py
+++ b/redis/typing.py
@@ -1,11 +1,11 @@
-# from __future__ import annotations
-
 from datetime import datetime, timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
     Awaitable,
     Iterable,
+    List,
+    Literal,
     Mapping,
     Protocol,
     Type,
@@ -32,7 +32,14 @@ KeyT = _StringLikeT  # Main redis key space
 PatternT = _StringLikeT  # Patterns matched against keys, fields etc
 FieldT = EncodableT  # Fields within hash tables, streams and geo commands
 KeysT = Union[KeyT, Iterable[KeyT]]
-ResponseT = Union[Awaitable[Any], Any]
+OldResponseT = Union[Awaitable[Any], Any]  # Deprecated
+AnyResponseT = TypeVar("AnyResponseT", bound=Any)
+ResponseT = Union[AnyResponseT, Awaitable[AnyResponseT]]
+OKT = Literal[True]
+ArrayResponseT = List
+IntegerResponseT = int
+NullResponseT = type(None)
+BulkStringResponseT = str
 ChannelT = _StringLikeT
 GroupT = _StringLikeT  # Consumer group
 ConsumerT = _StringLikeT  # Consumer name
@@ -54,10 +61,10 @@ ExceptionMappingT = Mapping[str, Union[Type[Exception], Mapping[str, Type[Except
 class CommandsProtocol(Protocol):
     connection_pool: Union["AsyncConnectionPool", "ConnectionPool"]
 
-    def execute_command(self, *args, **options): ...
+    def execute_command(self, *args, **options) -> ResponseT[Any]: ...
 
 
 class ClusterCommandsProtocol(CommandsProtocol, Protocol):
     encoder: "Encoder"
 
-    def execute_command(self, *args, **options) -> Union[Any, Awaitable]: ...
+    def execute_command(self, *args, **options) -> ResponseT[Any]: ...


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

## Comprehensive Refactoring of Type Annotations for Redis Core Commands

### Overview
This pull request introduces a comprehensive update and correction of the type annotations 
for all core Redis commands. The primary focus of this effort was to enhance the precision 
and usefulness of the type information based on the official Redis documentation. 
The task involved meticulously revisiting each command's return type to ensure 
accuracy and completeness.

### Key Changes
- **Standardization of Return Types**: Many core commands lacked proper return type 
  annotations.
  some used overly generic types, while others did not accurately reflect 
  all possible return values. This update corrects these issues, providing a clear and 
  reliable type for each function based on the Redis command specifications.
- **Correction of Types**: Adjustments were made to type annotations to 
  accurately include possible `nil` and other replies, addressing previous oversights.
- **Optional Arguments**: Some function arguments were incorrectly marked as non-optional. 
  This has been corrected, ensuring that optional parameters are appropriately typed.
- **Handling Awaitable Types**: Discrepancies in the typing of awaitable and non-awaitable 
  unions in return types have been standardized - some commands mention it and some not, now all commands is handled in the same direction of union sync and async responses.
- **Usage of 'OK' Type**: The 'OK' type annotation was missing in certain commands 
  where it should have been applied. This has now been consistently integrated where applicable.
- **Class Initializations**: Instances of classes being initialized more than once have 
  been corrected.
- **Compatibility Adjustments**: Replaced unsupported below Python 3.8 'list' type usage with 
  'typing.List' to maintain compatibility across supported versions.

### Challenges and Acknowledgements
* The task involved extensive review and application of type annotations one by one 
from the Redis documentation. While I have made effort to ensure accuracy, some types might still need adjustments. This effort significantly improves the clarity and reliability of the codebase, even though some 
minor discrepancies might remain.

* Binary response of 1\0 is marked as integer, need to be corrected after the progression of this PR.

* Async\Sync - Generic way to handle the differences between async commands and sync commands to get correct typing, for now I didn't want to change logic and only change the typing and continue the same type decision as before.

* core.py - 6000+ lines of code made it hard to edit and refactor, different classes of core commands can be separated to multiple files to enhance future code contributions.      