### PR TITLE
Fix xinfo_stream(full) parse error when no entry or no group and parse consumer as well

### DIFF
--- a/redis/_parsers/helpers.py
+++ b/redis/_parsers/helpers.py
@@ -282,7 +282,7 @@ def parse_xinfo_stream(response, **options):
             data["last-entry"] = (last[0], pairs_to_dict(last[1]))
     else:
         data["entries"] = {_id: pairs_to_dict(entry) for _id, entry in data["entries"]}
-        if isinstance(data["groups"][0], list):
+        if len(data["groups"]) > 0 and isinstance(data["groups"][0], list):
             data["groups"] = [
                 pairs_to_dict(group, decode_keys=True) for group in data["groups"]
             ]

--- a/redis/_parsers/helpers.py
+++ b/redis/_parsers/helpers.py
@@ -275,10 +275,10 @@ def parse_xinfo_stream(response, **options):
         data = {str_if_bytes(k): v for k, v in response.items()}
     if not options.get("full", False):
         first = data.get("first-entry")
-        if first is not None:
+        if first is not None and first[0] is not None:
             data["first-entry"] = (first[0], pairs_to_dict(first[1]))
         last = data["last-entry"]
-        if last is not None:
+        if last is not None and last[0] is not None:
             data["last-entry"] = (last[0], pairs_to_dict(last[1]))
     else:
         data["entries"] = {_id: pairs_to_dict(entry) for _id, entry in data["entries"]}

--- a/redis/_parsers/helpers.py
+++ b/redis/_parsers/helpers.py
@@ -286,6 +286,11 @@ def parse_xinfo_stream(response, **options):
             data["groups"] = [
                 pairs_to_dict(group, decode_keys=True) for group in data["groups"]
             ]
+            for g in data["groups"]:
+                if g["consumers"] and g["consumers"][0] is not None:
+                    g["consumers"] = [
+                        pairs_to_dict(c, decode_keys=True) for c in g["consumers"]
+                    ]
         else:
             data["groups"] = [
                 {str_if_bytes(k): v for k, v in group.items()}

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -2922,8 +2922,8 @@ class TestRedisCommands:
         await r.xtrim(stream, 0)
         info = await r.xinfo_stream(stream)
         assert info["length"] == 0
-        assert info["first-entry"] == None
-        assert info["last-entry"] == None
+        assert info["first-entry"] is None
+        assert info["last-entry"] is None
 
     @skip_if_server_version_lt("6.0.0")
     async def test_xinfo_stream_full(self, r: redis.Redis):

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -2919,6 +2919,12 @@ class TestRedisCommands:
         assert info["first-entry"] == await get_stream_message(r, stream, m1)
         assert info["last-entry"] == await get_stream_message(r, stream, m2)
 
+        await r.xtrim(stream, 0)
+        info = await r.xinfo_stream(stream)
+        assert info["length"] == 0
+        assert info["first-entry"] == None
+        assert info["last-entry"] == None
+
     @skip_if_server_version_lt("6.0.0")
     async def test_xinfo_stream_full(self, r: redis.Redis):
         stream = "stream"

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -2921,12 +2921,11 @@ class TestRedisCommands:
 
     @skip_if_server_version_lt("6.0.0")
     async def test_xinfo_stream_full(self, r: redis.Redis):
-
         stream = "stream"
         group = "group"
-        m1 = await r.xadd(stream, {"foo": "bar"})
+
+        await r.xadd(stream, {"foo": "bar"})
         info = await r.xinfo_stream(stream, full=True)
-        print(info)
         assert info["length"] == 1
         assert len(info["groups"]) == 0
 
@@ -2938,7 +2937,6 @@ class TestRedisCommands:
         info = await r.xinfo_stream(stream, full=True)
         consumer = info["groups"][0]["consumers"][0]
         assert isinstance(consumer, dict)
-
 
     @skip_if_server_version_lt("5.0.0")
     async def test_xlen(self, r: redis.Redis):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4455,8 +4455,8 @@ class TestRedisCommands:
         r.xtrim(stream, 0)
         info = r.xinfo_stream(stream)
         assert info["length"] == 0
-        assert info["first-entry"] == None
-        assert info["last-entry"] == None
+        assert info["first-entry"] is None
+        assert info["last-entry"] is None
 
     @skip_if_server_version_lt("6.0.0")
     def test_xinfo_stream_full(self, r):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4457,9 +4457,12 @@ class TestRedisCommands:
         stream = "stream"
         group = "group"
         m1 = r.xadd(stream, {"foo": "bar"})
+        info = r.xinfo_stream(stream, full=True)
+        assert info["length"] == 1
+        assert len(info["groups"]) == 0
+
         r.xgroup_create(stream, group, 0)
         info = r.xinfo_stream(stream, full=True)
-
         assert info["length"] == 1
         assert_resp_response_in(
             r,
@@ -4468,6 +4471,11 @@ class TestRedisCommands:
             info["entries"].keys(),
         )
         assert len(info["groups"]) == 1
+
+        r.xreadgroup(group, "consumer", streams={stream: ">"})
+        info = r.xinfo_stream(stream, full=True)
+        consumer = info["groups"][0]["consumers"][0]
+        assert isinstance(consumer, dict)
 
     @skip_if_server_version_lt("5.0.0")
     def test_xlen(self, r):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4452,6 +4452,12 @@ class TestRedisCommands:
         assert info["entries-added"] == 2
         assert info["recorded-first-entry-id"] == m1
 
+        r.xtrim(stream, 0)
+        info = r.xinfo_stream(stream)
+        assert info["length"] == 0
+        assert info["first-entry"] == None
+        assert info["last-entry"] == None
+
     @skip_if_server_version_lt("6.0.0")
     def test_xinfo_stream_full(self, r):
         stream = "stream"


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._

closes: #3065 

And also fix when there is no group(`data["groups"] == []`) and parse `consumer` by defualt
