### PR TITLE
Fixes CAE-333

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -913,7 +913,6 @@ class UnixDomainSocketConnection(AbstractConnection):
         self.path = path
         self.socket_timeout = socket_timeout
 
-
     def repr_pieces(self):
         pieces = [("path", self.path), ("db", self.db)]
         if self.client_name:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -909,9 +909,10 @@ class UnixDomainSocketConnection(AbstractConnection):
     "Manages UDS communication to and from a Redis server"
 
     def __init__(self, path="", socket_timeout=None, **kwargs):
+        super().__init__(**kwargs)
         self.path = path
         self.socket_timeout = socket_timeout
-        super().__init__(**kwargs)
+
 
     def repr_pieces(self):
         pieces = [("path", self.path), ("db", self.db)]

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -98,10 +98,10 @@ def test_tcp_ssl_tls12_custom_ciphers(tcp_address, ssl_ciphers):
     _assert_connect(conn, tcp_address, certfile=certfile, keyfile=keyfile)
 
 
-'''
+"""
 Addresses bug CAE-333 which uncovered that the init method of the base
 class did override the initialization of the socket_timeout parameter.
-'''
+"""
 
 
 def test_unix_socket_with_timeout():

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -102,6 +102,8 @@ def test_tcp_ssl_tls12_custom_ciphers(tcp_address, ssl_ciphers):
 Addresses bug CAE-333 which uncovered that the init method of the base
 class did override the initialization of the socket_timeout parameter.
 '''
+
+
 def test_unix_socket_with_timeout():
     conn = UnixDomainSocketConnection(socket_timeout=1000)
 
@@ -111,6 +113,7 @@ def test_unix_socket_with_timeout():
     # Verify if the timeout and the path is set correctly.
     assert conn.socket_timeout == 1000
     assert conn.path == ""
+
 
 @pytest.mark.ssl
 @pytest.mark.skipif(not ssl.HAS_TLSv1_3, reason="requires TLSv1.3")

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -98,6 +98,20 @@ def test_tcp_ssl_tls12_custom_ciphers(tcp_address, ssl_ciphers):
     _assert_connect(conn, tcp_address, certfile=certfile, keyfile=keyfile)
 
 
+'''
+Addresses bug CAE-333 which uncovered that the init method of the base
+class did override the initialization of the socket_timeout parameter.
+'''
+def test_unix_socket_with_timeout():
+    conn = UnixDomainSocketConnection(socket_timeout=1000)
+
+    # Check if the base class defaults were taken over.
+    assert conn.db == 0
+
+    # Verify if the timeout and the path is set correctly.
+    assert conn.socket_timeout == 1000
+    assert conn.path == ""
+
 @pytest.mark.ssl
 @pytest.mark.skipif(not ssl.HAS_TLSv1_3, reason="requires TLSv1.3")
 def test_tcp_ssl_version_mismatch(tcp_address):


### PR DESCRIPTION
The bug uncovered that the init method of the base class did override the initialization of the socket_timeout parameter.

This was fixed by moving `super().__init__(**kwargs)` before setting the timeout and path properties.

In addition, a test case was added.