### PR TITLE
Format connection errors in the same way everywhere

### DIFF
--- a/redis/utils.py
+++ b/redis/utils.py
@@ -141,3 +141,15 @@ def get_lib_version():
     except metadata.PackageNotFoundError:
         libver = "99.99.99"
     return libver
+
+
+def format_error_message(host_error: str, exception: BaseException) -> str:
+    if not exception.args:
+        return f"Error connecting to {host_error}."
+    elif len(exception.args) == 1:
+        return f"Error {exception.args[0]} connecting to {host_error}."
+    else:
+        return (
+            f"Error {exception.args[0]} connecting to {host_error}. "
+            f"{exception.args[1]}."
+        )

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -12,7 +12,12 @@ from redis._parsers import (
     _AsyncRESPBase,
 )
 from redis.asyncio import ConnectionPool, Redis
-from redis.asyncio.connection import Connection, UnixDomainSocketConnection, parse_url
+from redis.asyncio.connection import (
+    Connection,
+    SSLConnection,
+    UnixDomainSocketConnection,
+    parse_url,
+)
 from redis.asyncio.retry import Retry
 from redis.backoff import NoBackoff
 from redis.exceptions import ConnectionError, InvalidResponse, TimeoutError
@@ -491,6 +496,59 @@ async def test_connection_garbage_collection(request):
 
     await client.aclose()
     await pool.aclose()
+
+
+@pytest.mark.parametrize(
+    "conn, error, expected_message",
+    [
+        (SSLConnection(), OSError(), "Error connecting to localhost:6379."),
+        (SSLConnection(), OSError(12), "Error 12 connecting to localhost:6379."),
+        (
+            SSLConnection(),
+            OSError(12, "Some Error"),
+            "Error 12 connecting to localhost:6379. Some Error.",
+        ),
+        (
+            UnixDomainSocketConnection(path="unix:///tmp/redis.sock"),
+            OSError(),
+            "Error connecting to unix:///tmp/redis.sock.",
+        ),
+        (
+            UnixDomainSocketConnection(path="unix:///tmp/redis.sock"),
+            OSError(12),
+            "Error 12 connecting to unix:///tmp/redis.sock.",
+        ),
+        (
+            UnixDomainSocketConnection(path="unix:///tmp/redis.sock"),
+            OSError(12, "Some Error"),
+            "Error 12 connecting to unix:///tmp/redis.sock. Some Error.",
+        ),
+    ],
+)
+async def test_format_error_message(conn, error, expected_message):
+    """Test that the _error_message function formats errors correctly"""
+    error_message = conn._error_message(error)
+    assert error_message == expected_message
+
+
+async def test_network_connection_failure():
+    with pytest.raises(ConnectionError) as e:
+        redis = Redis(port=9999)
+        await redis.set("a", "b")
+    assert (
+        str(e.value) == "Error 111 connecting to localhost:9999. "
+        "Connect call failed ('127.0.0.1', 9999)."
+    )
+
+
+async def test_unix_socket_connection_failure():
+    with pytest.raises(ConnectionError) as e:
+        redis = Redis(unix_socket_path="unix:///tmp/a.sock")
+        await redis.set("a", "b")
+    assert (
+        str(e.value)
+        == "Error 2 connecting to unix:///tmp/a.sock. No such file or directory."
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -549,21 +549,3 @@ async def test_unix_socket_connection_failure():
         str(e.value)
         == "Error 2 connecting to unix:///tmp/a.sock. No such file or directory."
     )
-
-
-@pytest.mark.parametrize(
-    "error, expected_message",
-    [
-        (OSError(), "Error connecting to localhost:6379. Connection reset by peer"),
-        (OSError(12), "Error connecting to localhost:6379. 12."),
-        (
-            OSError(12, "Some Error"),
-            "Error 12 connecting to localhost:6379. [Errno 12] Some Error.",
-        ),
-    ],
-)
-async def test_connect_error_message(error, expected_message):
-    """Test that the _error_message function formats errors correctly"""
-    conn = Connection()
-    error_message = conn._error_message(error)
-    assert error_message == expected_message

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -533,10 +533,10 @@ async def test_format_error_message(conn, error, expected_message):
 
 async def test_network_connection_failure():
     with pytest.raises(ConnectionError) as e:
-        redis = Redis(port=9999)
+        redis = Redis(host='127.0.0.1', port=9999)
         await redis.set("a", "b")
     assert (
-        str(e.value) == "Error 111 connecting to localhost:9999. "
+        str(e.value) == "Error 111 connecting to 127.0.0.1:9999. "
         "Connect call failed ('127.0.0.1', 9999)."
     )
 

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -533,12 +533,9 @@ async def test_format_error_message(conn, error, expected_message):
 
 async def test_network_connection_failure():
     with pytest.raises(ConnectionError) as e:
-        redis = Redis(host='127.0.0.1', port=9999)
+        redis = Redis(host="127.0.0.1", port=9999)
         await redis.set("a", "b")
-    assert (
-        str(e.value) == "Error 111 connecting to 127.0.0.1:9999. "
-        "Connect call failed ('127.0.0.1', 9999)."
-    )
+    assert str(e.value).startswith("Error 111 connecting to 127.0.0.1:9999. Connect")
 
 
 async def test_unix_socket_connection_failure():


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Connection errors are formatted in four places, sync and async, network socket and unix socket. Each place has some small differences compared to the others, while they could be, and should be, formatted in an uniform way. Factor out the logic in a helper method and call that method in all four places.

This is a continuation of #3211 
