### PR TITLE
Close Unix sockets if the connection attempt fails

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -64,6 +64,7 @@
     * Make `ClusterCommandsProtocol` an actual Protocol
     * Add `sum` to DUPLICATE_POLICY documentation of `TS.CREATE`, `TS.ADD` and `TS.ALTER`
     * Prevent async ClusterPipeline instances from becoming "false-y" in case of empty command stack (#3061)
+    * Close Unix sockets if the connection attempt fails. This prevents `ResourceWarning`s. (#3314)
 
 * 4.1.3 (Feb 8, 2022)
   * Fix flushdb and flushall (#1926)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -920,7 +920,12 @@ class UnixDomainSocketConnection(AbstractConnection):
         "Create a Unix domain socket connection"
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.settimeout(self.socket_connect_timeout)
-        sock.connect(self.path)
+        try:
+            sock.connect(self.path)
+        except OSError:
+            # Prevent ResourceWarnings for unclosed sockets.
+            sock.close()
+            raise
         sock.settimeout(self.socket_timeout)
         return sock
 


### PR DESCRIPTION
Fixes #3314

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This PR introduces the following change:

* When a call to `.connect()` to a Unix socket raises an exception, the socket instance is immediately closed. This prevents a `ResourceWarning` that would otherwise occur (though Python typically doesn't display this warning).
