### PR TITLE
Suppress `Graph` deprecation warning in test suite

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -13,3 +13,4 @@ asyncio_mode = auto
 timeout = 30
 filterwarnings =
     always
+    ignore:RedisGraph support is deprecated as of Redis Stack 7.2:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,5 @@ markers =
     experimental: run only experimental tests
 asyncio_mode = auto
 timeout = 30
+filterwarnings =
+    always

--- a/tasks.py
+++ b/tasks.py
@@ -55,11 +55,11 @@ def standalone_tests(c, uvloop=False, protocol=2, profile=False):
     profile_arg = "--profile" if profile else ""
     if uvloop:
         run(
-            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_redis.xml -W always -m 'not onlycluster' --uvloop --junit-xml=standalone-uvloop-results.xml"
+            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_redis.xml -m 'not onlycluster' --uvloop --junit-xml=standalone-uvloop-results.xml"
         )
     else:
         run(
-            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_redis.xml -W always -m 'not onlycluster' --junit-xml=standalone-results.xml"
+            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_redis.xml -m 'not onlycluster' --junit-xml=standalone-results.xml"
         )
 
 
@@ -70,11 +70,11 @@ def cluster_tests(c, uvloop=False, protocol=2, profile=False):
     cluster_url = "redis://localhost:16379/0"
     if uvloop:
         run(
-            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_cluster.xml -W always -m 'not onlynoncluster and not redismod' --redis-url={cluster_url} --junit-xml=cluster-uvloop-results.xml --uvloop"
+            f"pytest {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_cluster.xml -m 'not onlynoncluster and not redismod' --redis-url={cluster_url} --junit-xml=cluster-uvloop-results.xml --uvloop"
         )
     else:
         run(
-            f"pytest  {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_clusteclient.xml -W always -m 'not onlynoncluster and not redismod' --redis-url={cluster_url} --junit-xml=cluster-results.xml"
+            f"pytest  {profile_arg} --protocol={protocol} --cov=./ --cov-report=xml:coverage_clusteclient.xml -m 'not onlynoncluster and not redismod' --redis-url={cluster_url} --junit-xml=cluster-results.xml"
         )
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -41,6 +41,15 @@ def test_bulk(client):
 
 
 @pytest.mark.redismod
+def test_graph_creation_throws_deprecation_warning(client):
+    """Verify that a DeprecationWarning is raised when creating a Graph instance."""
+
+    match = "RedisGraph support is deprecated as of Redis Stack 7.2"
+    with pytest.warns(DeprecationWarning, match=match):
+        client.graph()
+
+
+@pytest.mark.redismod
 @skip_if_resp_version(3)
 def test_graph_creation(client):
     graph = client.graph()


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

When the test suite runs in CI, it shows that there are many uncaught `DeprecationWarning` messages ([recent example](https://github.com/redis/redis-py/actions/runs/9900975496/job/27352615257#step:4:289)).

These occur when `Graph` is instantiated and are expected. Therefore, they should be ignored by default, so other issues can be focused on.

This PR introduces the following changes:

* The pytest warnings configuration (currently present as the CLI argument `-W always`) is moved to `pytest.ini`
* The specific `DeprecationWarning` is now ignored by default in `pytest.ini`
* A new test was added to ensure that the `DeprecationWarning` is actually being thrown when `Graph` is instantiated.

If this merges, it will reduce the warning output that pytest displays after running the test suite.