### PR TITLE
Close SSL sockets when connections/validations fail

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,7 @@
     * Add `sum` to DUPLICATE_POLICY documentation of `TS.CREATE`, `TS.ADD` and `TS.ALTER`
     * Prevent async ClusterPipeline instances from becoming "false-y" in case of empty command stack (#3061)
     * Close Unix sockets if the connection attempt fails. This prevents `ResourceWarning`s. (#3314)
+    * Close SSL sockets if the connection attempt fails, or if validations fail. (#3317)
 
 * 4.1.3 (Feb 8, 2022)
   * Fix flushdb and flushall (#1926)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -819,7 +819,7 @@ class SSLConnection(Connection):
         sock = super()._connect()
         try:
             return self._wrap_socket_with_ssl(sock)
-        except OSError:
+        except (OSError, RedisError):
             sock.close()
             raise
 
@@ -854,7 +854,6 @@ class SSLConnection(Connection):
             context.minimum_version = self.ssl_min_version
         if self.ssl_ciphers:
             context.set_ciphers(self.ssl_ciphers)
-        sslsock = context.wrap_socket(sock, server_hostname=self.host)
         if self.ssl_validate_ocsp is True and CRYPTOGRAPHY_AVAILABLE is False:
             raise RedisError("cryptography is not installed.")
 
@@ -863,6 +862,8 @@ class SSLConnection(Connection):
                 "Either an OCSP staple or pure OCSP connection must be validated "
                 "- not both."
             )
+
+        sslsock = context.wrap_socket(sock, server_hostname=self.host)
 
         # validation for the stapled case
         if self.ssl_validate_ocsp_stapled:


### PR DESCRIPTION
Fixes #3317

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?

> [!NOTE]
>
> CI may fail, as it currently does on the `master` branch, but because the SSL sockets are getting closed, the `ResourceWarning` displayed as pytest exits are now resolved.

- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

As noted in #3317, there are two places where SSL sockets might not get closed, and they both stem from a `RedisError` getting raised when either of two validation checks fail. This PR addresses the issue in these ways:

* `RedisError` is now caught in addition to `OSError` so the first open socket can be closed
* The second open socket is only created _after_ two validations have passed.