### PR TITLE
Resolve some docs warnings

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -141,3 +141,4 @@ unicode
 url
 virtualenv
 www
+yaml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,6 @@ html_theme = "furo"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "display_version": True,
     "footer_icons": [
         {
             "name": "GitHub",

--- a/docs/connections.rst
+++ b/docs/connections.rst
@@ -55,7 +55,7 @@ ClusterNode
 Async Client
 ************
 
-See complete example: `here <examples/asyncio_examples.html>`_
+See complete example: `here <examples/asyncio_examples.html>`__
 
 This client is used for communicating with Redis, asynchronously.
 
@@ -88,7 +88,7 @@ ClusterPipeline (Async)
 Connection
 **********
 
-See complete example: `here <examples/connection_examples.html>`_
+See complete example: `here <examples/connection_examples.html>`__
 
 Connection
 ==========
@@ -104,7 +104,7 @@ Connection (Async)
 Connection Pools
 ****************
 
-See complete example: `here <examples/connection_examples.html>`_
+See complete example: `here <examples/connection_examples.html>`__
 
 ConnectionPool
 ==============

--- a/docs/opentelemetry.rst
+++ b/docs/opentelemetry.rst
@@ -125,7 +125,7 @@ Alerting and notifications
 
 Uptrace also allows you to monitor `OpenTelemetry metrics <https://uptrace.dev/opentelemetry/metrics.html>`_ using alerting rules. For example, the following monitor uses the group by node expression to create an alert whenever an individual Redis shard is down:
 
-.. code-block:: python
+.. code-block:: yaml
 
    monitors:
      - name: Redis shard is down
@@ -142,7 +142,7 @@ Uptrace also allows you to monitor `OpenTelemetry metrics <https://uptrace.dev/o
 
 You can also create queries with more complex expressions. For example, the following rule creates an alert when the keyspace hit rate is lower than 75%:
 
-.. code-block:: python
+.. code-block:: yaml
 
    monitors:
      - name: Redis read hit rate < 75%

--- a/docs/opentelemetry.rst
+++ b/docs/opentelemetry.rst
@@ -4,7 +4,7 @@ Integrating OpenTelemetry
 What is OpenTelemetry?
 ----------------------
 
-`OpenTelemetry <https://opentelemetry.io>`_ is an open-source observability framework for traces, metrics, and logs. It is a merger of OpenCensus and OpenTracing projects hosted by Cloud Native Computing Foundation.
+`OpenTelemetry <https://opentelemetry.io>`__ is an open-source observability framework for traces, metrics, and logs. It is a merger of OpenCensus and OpenTracing projects hosted by Cloud Native Computing Foundation.
 
 OpenTelemetry allows developers to collect and export telemetry data in a vendor agnostic way. With OpenTelemetry, you can instrument your application once and then add or change vendors without changing the instrumentation, for example, here is a list of `popular DataDog competitors <https://uptrace.dev/get/compare/datadog-competitors.html>`_ that support OpenTelemetry.
 
@@ -61,7 +61,7 @@ Once the code is patched, you can use redis-py as usually:
 OpenTelemetry API
 -----------------
 
-`OpenTelemetry <https://uptrace.dev/opentelemetry/>`_ API is a programming interface that you can use to instrument code and collect telemetry data such as traces, metrics, and logs.
+`OpenTelemetry API <https://uptrace.dev/opentelemetry/>`__ is a programming interface that you can use to instrument code and collect telemetry data such as traces, metrics, and logs.
 
 You can use OpenTelemetry API to measure important operations:
 

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -79,7 +79,7 @@ class ACLCommands(CommandsProtocol):
 
     def acl_deluser(self, *username: str, **kwargs) -> ResponseT:
         """
-        Delete the ACL for the specified ``username``s
+        Delete the ACL for the specified ``username``\\s
 
         For more information see https://redis.io/commands/acl-deluser
         """
@@ -227,9 +227,10 @@ class ACLCommands(CommandsProtocol):
                       must be prefixed with either a '+' to add the command permission
                       or a '-' to remove the command permission.
             keys: A list of key patterns to grant the user access to. Key patterns allow
-                  '*' to support wildcard matching. For example, '*' grants access to
-                  all keys while 'cache:*' grants access to all keys that are prefixed
-                  with 'cache:'. `keys` should not be prefixed with a '~'.
+                  ``'*'`` to support wildcard matching. For example, ``'*'`` grants
+                  access to all keys while ``'cache:*'`` grants access to all keys that
+                  are prefixed with ``cache:``.
+                  `keys` should not be prefixed with a ``'~'``.
             reset: Indicates whether the user should be fully reset prior to applying
                    the new ACL. Setting this to `True` will remove all existing
                    passwords, flags, and privileges from the user and then apply the
@@ -3369,7 +3370,7 @@ class SetCommands(CommandsProtocol):
         self, numkeys: int, keys: List[str], limit: int = 0
     ) -> Union[Awaitable[int], int]:
         """
-        Return the cardinality of the intersect of multiple sets specified by ``keys`.
+        Return the cardinality of the intersect of multiple sets specified by ``keys``.
 
         When LIMIT provided (defaults to 0 and means unlimited), if the intersection
         cardinality reaches limit partway through the computation, the algorithm will
@@ -3501,9 +3502,11 @@ class StreamCommands(CommandsProtocol):
     def xack(self, name: KeyT, groupname: GroupT, *ids: StreamIdT) -> ResponseT:
         """
         Acknowledges the successful processing of one or more messages.
-        name: name of the stream.
-        groupname: name of the consumer group.
-        *ids: message ids to acknowledge.
+
+        Args:
+            name: name of the stream.
+            groupname: name of the consumer group.
+            *ids: message ids to acknowledge.
 
         For more information see https://redis.io/commands/xack
         """
@@ -3699,8 +3702,10 @@ class StreamCommands(CommandsProtocol):
     def xdel(self, name: KeyT, *ids: StreamIdT) -> ResponseT:
         """
         Deletes one or more messages from a stream.
-        name: name of the stream.
-        *ids: message ids to delete.
+
+        Args:
+            name: name of the stream.
+            *ids: message ids to delete.
 
         For more information see https://redis.io/commands/xdel
         """
@@ -4268,7 +4273,7 @@ class SortedSetCommands(CommandsProtocol):
     ) -> Union[Awaitable[int], int]:
         """
         Return the cardinality of the intersect of multiple sorted sets
-        specified by ``keys`.
+        specified by ``keys``.
         When LIMIT provided (defaults to 0 and means unlimited), if the intersection
         cardinality reaches limit partway through the computation, the algorithm will
         exit and yield limit as the cardinality

--- a/redis/commands/graph/commands.py
+++ b/redis/commands/graph/commands.py
@@ -155,7 +155,7 @@ class GraphCommands:
     def config(self, name, value=None, set=False):
         """
         Retrieve or update a RedisGraph configuration.
-        For more information see `https://redis.io/commands/graph.config-get/>`_. # noqa
+        For more information see `<https://redis.io/commands/graph.config-get/>`__.
 
         Args:
 

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -337,30 +337,30 @@ class SearchCommands:
         """
         Add a single document to the index.
 
-        ### Parameters
+        Args:
 
-        - **doc_id**: the id of the saved document.
-        - **nosave**: if set to true, we just index the document, and don't
+            doc_id: the id of the saved document.
+            nosave: if set to true, we just index the document, and don't
                       save a copy of it. This means that searches will just
                       return ids.
-        - **score**: the document ranking, between 0.0 and 1.0
-        - **payload**: optional inner-index payload we can save for fast
-        i              access in scoring functions
-        - **replace**: if True, and the document already is in the index,
-        we perform an update and reindex the document
-        - **partial**: if True, the fields specified will be added to the
+            score: the document ranking, between 0.0 and 1.0
+            payload: optional inner-index payload we can save for fast
+                     access in scoring functions
+            replace: if True, and the document already is in the index,
+                     we perform an update and reindex the document
+            partial: if True, the fields specified will be added to the
                        existing document.
                        This has the added benefit that any fields specified
                        with `no_index`
                        will not be reindexed again. Implies `replace`
-        - **language**: Specify the language used for document tokenization.
-        - **no_create**: if True, the document is only updated and reindexed
+            language: Specify the language used for document tokenization.
+            no_create: if True, the document is only updated and reindexed
                          if it already exists.
                          If the document does not exist, an error will be
                          returned. Implies `replace`
-        - **fields** kwargs dictionary of the document fields to be saved
-                         and/or indexed.
-                     NOTE: Geo points shoule be encoded as strings of "lon,lat"
+            fields: kwargs dictionary of the document fields to be saved
+                    and/or indexed.
+                    NOTE: Geo points shoule be encoded as strings of "lon,lat"
         """  # noqa
         return self._add_document(
             doc_id,

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -627,13 +627,13 @@ class SearchCommands:
         """
         Issue a spellcheck query
 
-        ### Parameters
+        Args:
 
-        **query**: search query.
-        **distance***: the maximal Levenshtein distance for spelling
+            query: search query.
+            distance: the maximal Levenshtein distance for spelling
                        suggestions (default: 1, max: 4).
-        **include**: specifies an inclusion custom dictionary.
-        **exclude**: specifies an exclusion custom dictionary.
+            include: specifies an inclusion custom dictionary.
+            exclude: specifies an exclusion custom dictionary.
 
         For more information see `FT.SPELLCHECK <https://redis.io/commands/ft.spellcheck>`_.
         """  # noqa


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This PR begins to resolve the many warnings output during documentation builds ([recent example on Read the Docs](https://readthedocs.org/projects/redis-py/builds/23205005/); expand the `python -m sphinx ...` log line to see the warnings and errors).

There are a significant number of rendering issues caused by incorrect Napoleon formatting in docstrings, but this PR is specifically aiming to resolve some warnings and errors. Here's [an example of a rendering issue caused by incorrect Napoleon formatting](https://redis-py.readthedocs.io/en/stable/redismodules.html#redis.commands.search.commands.SearchCommands.profile) that needs to be addressed:

> ![image](https://github.com/user-attachments/assets/7e7c1b6e-3435-4e0e-8e95-0d6872ca9532)
