### PR TITLE
Handle RESP3 sets as Python lists

### DIFF
--- a/doctests/dt_set.py
+++ b/doctests/dt_set.py
@@ -58,11 +58,11 @@ r.sadd("bikes:racing:france", "bike:1", "bike:2", "bike:3")
 r.sadd("bikes:racing:usa", "bike:1", "bike:4")
 # HIDE_END
 res7 = r.sinter("bikes:racing:france", "bikes:racing:usa")
-print(res7)  # >>> {'bike:1'}
+print(res7)  # >>> ['bike:1']
 # STEP_END
 
 # REMOVE_START
-assert res7 == {"bike:1"}
+assert res7 == ["bike:1"]
 # REMOVE_END
 
 # STEP_START scard
@@ -83,12 +83,12 @@ res9 = r.sadd("bikes:racing:france", "bike:1", "bike:2", "bike:3")
 print(res9)  # >>> 3
 
 res10 = r.smembers("bikes:racing:france")
-print(res10)  # >>> {'bike:1', 'bike:2', 'bike:3'}
+print(res10)  # >>> ['bike:1', 'bike:2', 'bike:3']
 # STEP_END
 
 # REMOVE_START
 assert res9 == 3
-assert res10 == {"bike:1", "bike:2", "bike:3"}
+assert res10 == ['bike:1', 'bike:2', 'bike:3']
 # REMOVE_END
 
 # STEP_START smismember
@@ -109,11 +109,11 @@ r.sadd("bikes:racing:france", "bike:1", "bike:2", "bike:3")
 r.sadd("bikes:racing:usa", "bike:1", "bike:4")
 
 res13 = r.sdiff("bikes:racing:france", "bikes:racing:usa")
-print(res13)  # >>> {'bike:2', 'bike:3'}
+print(res13)  # >>> ['bike:2', 'bike:3']
 # STEP_END
 
 # REMOVE_START
-assert res13 == {"bike:2", "bike:3"}
+assert res13 == ['bike:2', 'bike:3']
 r.delete("bikes:racing:france")
 r.delete("bikes:racing:usa")
 # REMOVE_END
@@ -124,27 +124,27 @@ r.sadd("bikes:racing:usa", "bike:1", "bike:4")
 r.sadd("bikes:racing:italy", "bike:1", "bike:2", "bike:3", "bike:4")
 
 res13 = r.sinter("bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy")
-print(res13)  # >>> {'bike:1'}
+print(res13)  # >>> ['bike:1']
 
 res14 = r.sunion("bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy")
-print(res14)  # >>> {'bike:1', 'bike:2', 'bike:3', 'bike:4'}
+print(res14)  # >>> ['bike:1', 'bike:2', 'bike:3', 'bike:4']
 
 res15 = r.sdiff("bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy")
-print(res15)  # >>> set()
+print(res15)  # >>> []
 
 res16 = r.sdiff("bikes:racing:usa", "bikes:racing:france")
-print(res16)  # >>> {'bike:4'}
+print(res16)  # >>> ['bike:4']
 
 res17 = r.sdiff("bikes:racing:france", "bikes:racing:usa")
-print(res17)  # >>> {'bike:2', 'bike:3'}
+print(res17)  # >>> ['bike:2', 'bike:3']
 # STEP_END
 
 # REMOVE_START
-assert res13 == {"bike:1"}
-assert res14 == {"bike:1", "bike:2", "bike:3", "bike:4"}
-assert res15 == set()
-assert res16 == {"bike:4"}
-assert res17 == {"bike:2", "bike:3"}
+assert res13 == ['bike:1']
+assert res14 == ['bike:1', 'bike:2', 'bike:3', 'bike:4']
+assert res15 == []
+assert res16 == ['bike:4']
+assert res17 == ['bike:2', 'bike:3']
 r.delete("bikes:racing:france")
 r.delete("bikes:racing:usa")
 r.delete("bikes:racing:italy")
@@ -160,7 +160,7 @@ res19 = r.spop("bikes:racing:france")
 print(res19)  # >>> bike:3
 
 res20 = r.smembers("bikes:racing:france")
-print(res20)  # >>> {'bike:2', 'bike:4', 'bike:5'}
+print(res20)  # >>> ['bike:2', 'bike:4', 'bike:5']
 
 res21 = r.srandmember("bikes:racing:france")
 print(res21)  # >>> bike:4

--- a/redis/_parsers/helpers.py
+++ b/redis/_parsers/helpers.py
@@ -784,9 +784,6 @@ _RedisCallbacks = {
 
 _RedisCallbacksRESP2 = {
     **string_keys_to_dict(
-        "SDIFF SINTER SMEMBERS SUNION", lambda r: r and set(r) or set()
-    ),
-    **string_keys_to_dict(
         "ZDIFF ZINTER ZPOPMAX ZPOPMIN ZRANGE ZRANGEBYSCORE ZRANK ZREVRANGE "
         "ZREVRANGEBYSCORE ZREVRANK ZUNION",
         zset_score_pairs,

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -88,15 +88,11 @@ class _RESP3Parser(_RESPBase):
         # set response
         elif byte == b"~":
             # redis can return unhashable types (like dict) in a set,
-            # so we need to first convert to a list, and then try to convert it to a set
+            # so we return sets as list, all the time, for predictability
             response = [
                 self._read_response(disable_decoding=disable_decoding)
                 for _ in range(int(response))
             ]
-            try:
-                response = set(response)
-            except TypeError:
-                pass
         # map response
         elif byte == b"%":
             # We cannot use a dict-comprehension to parse stream.

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -229,15 +229,11 @@ class _AsyncRESP3Parser(_AsyncRESPBase):
         # set response
         elif byte == b"~":
             # redis can return unhashable types (like dict) in a set,
-            # so we need to first convert to a list, and then try to convert it to a set
+            # so we always convert to a list, to have predictable return types
             response = [
                 (await self._read_response(disable_decoding=disable_decoding))
                 for _ in range(int(response))
             ]
-            try:
-                response = set(response)
-            except TypeError:
-                pass
         # map response
         elif byte == b"%":
             # We cannot use a dict-comprehension to parse stream.

--- a/redis/commands/bf/commands.py
+++ b/redis/commands/bf/commands.py
@@ -1,6 +1,5 @@
 from redis.client import NEVER_DECODE
-from redis.exceptions import ModuleError
-from redis.utils import HIREDIS_AVAILABLE, deprecated_function
+from redis.utils import deprecated_function
 
 BF_RESERVE = "BF.RESERVE"
 BF_ADD = "BF.ADD"
@@ -139,9 +138,6 @@ class BFCommands:
         This command will return successive (iter, data) pairs until (0, NULL) to indicate completion.
         For more information see `BF.SCANDUMP <https://redis.io/commands/bf.scandump>`_.
         """  # noqa
-        if HIREDIS_AVAILABLE:
-            raise ModuleError("This command cannot be used when hiredis is available.")
-
         params = [key, iter]
         options = {}
         options[NEVER_DECODE] = []

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -7,7 +7,7 @@ try:
     import hiredis  # noqa
 
     # Only support Hiredis >= 3.0:
-    HIREDIS_AVAILABLE = int(hiredis.__version__.split('.')[0]) >= 3
+    HIREDIS_AVAILABLE = int(hiredis.__version__.split(".")[0]) >= 3
     HIREDIS_PACK_AVAILABLE = hasattr(hiredis, "pack_command")
 except ImportError:
     HIREDIS_AVAILABLE = False

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Mapping, Union
 try:
     import hiredis  # noqa
 
-    # Only support Hiredis >= 1.0:
-    HIREDIS_AVAILABLE = not hiredis.__version__.startswith("0.")
+    # Only support Hiredis >= 3.0:
+    HIREDIS_AVAILABLE = int(hiredis.__version__.split('.')[0]) >= 3
     HIREDIS_PACK_AVAILABLE = hasattr(hiredis, "pack_command")
 except ImportError:
     HIREDIS_AVAILABLE = False

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     extras_require={
-        "hiredis": ["hiredis>=1.0.0"],
+        "hiredis": ["hiredis>=3.0.0"],
         "ocsp": ["cryptography>=36.0.1", "pyopenssl==23.2.1", "requests>=2.31.0"],
     },
 )

--- a/tests/test_asyncio/test_bloom.py
+++ b/tests/test_asyncio/test_bloom.py
@@ -3,8 +3,7 @@ from math import inf
 import pytest
 import pytest_asyncio
 import redis.asyncio as redis
-from redis.exceptions import ModuleError, RedisError
-from redis.utils import HIREDIS_AVAILABLE
+from redis.exceptions import RedisError
 from tests.conftest import (
     assert_resp_response,
     is_resp2_connection,

--- a/tests/test_asyncio/test_bloom.py
+++ b/tests/test_asyncio/test_bloom.py
@@ -105,10 +105,6 @@ async def test_bf_scandump_and_loadchunk(decoded_r: redis.Redis):
 
     await do_verify()
     cmds = []
-    if HIREDIS_AVAILABLE:
-        with pytest.raises(ModuleError):
-            cur = await decoded_r.bf().scandump("myBloom", 0)
-        return
 
     cur = await decoded_r.bf().scandump("myBloom", 0)
     first = cur[0]

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -1753,49 +1753,49 @@ class TestClusterRedisCommands:
 
     async def test_cluster_sdiff(self, r: RedisCluster) -> None:
         await r.sadd("{foo}a", "1", "2", "3")
-        assert await r.sdiff("{foo}a", "{foo}b") == {b"1", b"2", b"3"}
+        assert set(await r.sdiff("{foo}a", "{foo}b")) == {b"1", b"2", b"3"}
         await r.sadd("{foo}b", "2", "3")
-        assert await r.sdiff("{foo}a", "{foo}b") == {b"1"}
+        assert await r.sdiff("{foo}a", "{foo}b") == [b"1"]
 
     async def test_cluster_sdiffstore(self, r: RedisCluster) -> None:
         await r.sadd("{foo}a", "1", "2", "3")
         assert await r.sdiffstore("{foo}c", "{foo}a", "{foo}b") == 3
-        assert await r.smembers("{foo}c") == {b"1", b"2", b"3"}
+        assert set(await r.smembers("{foo}c")) == {b"1", b"2", b"3"}
         await r.sadd("{foo}b", "2", "3")
         assert await r.sdiffstore("{foo}c", "{foo}a", "{foo}b") == 1
-        assert await r.smembers("{foo}c") == {b"1"}
+        assert await r.smembers("{foo}c") == [b"1"]
 
     async def test_cluster_sinter(self, r: RedisCluster) -> None:
         await r.sadd("{foo}a", "1", "2", "3")
-        assert await r.sinter("{foo}a", "{foo}b") == set()
+        assert await r.sinter("{foo}a", "{foo}b") == []
         await r.sadd("{foo}b", "2", "3")
-        assert await r.sinter("{foo}a", "{foo}b") == {b"2", b"3"}
+        assert set(await r.sinter("{foo}a", "{foo}b")) == {b"2", b"3"}
 
     async def test_cluster_sinterstore(self, r: RedisCluster) -> None:
         await r.sadd("{foo}a", "1", "2", "3")
         assert await r.sinterstore("{foo}c", "{foo}a", "{foo}b") == 0
-        assert await r.smembers("{foo}c") == set()
+        assert await r.smembers("{foo}c") == []
         await r.sadd("{foo}b", "2", "3")
         assert await r.sinterstore("{foo}c", "{foo}a", "{foo}b") == 2
-        assert await r.smembers("{foo}c") == {b"2", b"3"}
+        assert set(await r.smembers("{foo}c")) == {b"2", b"3"}
 
     async def test_cluster_smove(self, r: RedisCluster) -> None:
         await r.sadd("{foo}a", "a1", "a2")
         await r.sadd("{foo}b", "b1", "b2")
         assert await r.smove("{foo}a", "{foo}b", "a1")
-        assert await r.smembers("{foo}a") == {b"a2"}
-        assert await r.smembers("{foo}b") == {b"b1", b"b2", b"a1"}
+        assert await r.smembers("{foo}a") == [b"a2"]
+        assert set(await r.smembers("{foo}b")) == {b"b1", b"b2", b"a1"}
 
     async def test_cluster_sunion(self, r: RedisCluster) -> None:
         await r.sadd("{foo}a", "1", "2")
         await r.sadd("{foo}b", "2", "3")
-        assert await r.sunion("{foo}a", "{foo}b") == {b"1", b"2", b"3"}
+        assert set(await r.sunion("{foo}a", "{foo}b")) == {b"1", b"2", b"3"}
 
     async def test_cluster_sunionstore(self, r: RedisCluster) -> None:
         await r.sadd("{foo}a", "1", "2")
         await r.sadd("{foo}b", "2", "3")
         assert await r.sunionstore("{foo}c", "{foo}a", "{foo}b") == 3
-        assert await r.smembers("{foo}c") == {b"1", b"2", b"3"}
+        assert set(await r.smembers("{foo}c")) == {b"1", b"2", b"3"}
 
     @skip_if_server_version_lt("6.2.0")
     async def test_cluster_zdiff(self, r: RedisCluster) -> None:

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -862,7 +862,7 @@ async def test_tags(decoded_r: redis.Redis):
         assert 1 == res["total_results"]
 
         q2 = await decoded_r.ft().tagvals("tags")
-        assert set(tags.split(",") + tags2.split(",")) == q2
+        assert set(tags.split(",") + tags2.split(",")) == set(q2)
 
 
 @pytest.mark.redismod
@@ -986,7 +986,7 @@ async def test_dict_operations(decoded_r: redis.Redis):
 
     # Dump dict and inspect content
     res = await decoded_r.ft().dict_dump("custom_dict")
-    assert_resp_response(decoded_r, res, ["item1", "item3"], {"item1", "item3"})
+    assert res == ["item1", "item3"]
 
     # Remove rest of the items before reload
     await decoded_r.ft().dict_del("custom_dict", *res)

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -24,7 +24,6 @@ from redis.commands.search.query import GeoFilter, NumericFilter, Query
 from redis.commands.search.result import Result
 from redis.commands.search.suggestion import Suggestion
 from tests.conftest import (
-    assert_resp_response,
     is_resp2_connection,
     skip_if_redis_enterprise,
     skip_if_resp_version,

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -745,9 +745,7 @@ async def test_query_index(decoded_r: redis.Redis):
     await decoded_r.ts().create(2, labels={"Test": "This", "Taste": "That"})
     assert 2 == len(await decoded_r.ts().queryindex(["Test=This"]))
     assert 1 == len(await decoded_r.ts().queryindex(["Taste=That"]))
-    assert_resp_response(
-        decoded_r, await decoded_r.ts().queryindex(["Taste=That"]), [2], {"2"}
-    )
+    assert ["2"] == await decoded_r.ts().queryindex(["Taste=That"])
 
 
 @pytest.mark.redismod

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -745,7 +745,9 @@ async def test_query_index(decoded_r: redis.Redis):
     await decoded_r.ts().create(2, labels={"Test": "This", "Taste": "That"})
     assert 2 == len(await decoded_r.ts().queryindex(["Test=This"]))
     assert 1 == len(await decoded_r.ts().queryindex(["Taste=That"]))
-    assert ["2"] == await decoded_r.ts().queryindex(["Taste=That"])
+    assert_resp_response(
+        decoded_r, await decoded_r.ts().queryindex(["Taste=That"]), [2], ["2"]
+    )
 
 
 @pytest.mark.redismod

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -136,10 +136,6 @@ def test_bf_scandump_and_loadchunk(client):
 
     do_verify()
     cmds = []
-    if HIREDIS_AVAILABLE:
-        with pytest.raises(ModuleError):
-            cur = client.bf().scandump("myBloom", 0)
-        return
 
     cur = client.bf().scandump("myBloom", 0)
     first = cur[0]

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -2,8 +2,7 @@ from math import inf
 
 import pytest
 import redis.commands.bf
-from redis.exceptions import ModuleError, RedisError
-from redis.utils import HIREDIS_AVAILABLE
+from redis.exceptions import RedisError
 
 from .conftest import (
     _get_client,

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1868,49 +1868,49 @@ class TestClusterRedisCommands:
 
     def test_cluster_sdiff(self, r):
         r.sadd("{foo}a", "1", "2", "3")
-        assert r.sdiff("{foo}a", "{foo}b") == {b"1", b"2", b"3"}
+        assert set(r.sdiff("{foo}a", "{foo}b")) == {b"1", b"2", b"3"}
         r.sadd("{foo}b", "2", "3")
-        assert r.sdiff("{foo}a", "{foo}b") == {b"1"}
+        assert r.sdiff("{foo}a", "{foo}b") == [b"1"]
 
     def test_cluster_sdiffstore(self, r):
         r.sadd("{foo}a", "1", "2", "3")
         assert r.sdiffstore("{foo}c", "{foo}a", "{foo}b") == 3
-        assert r.smembers("{foo}c") == {b"1", b"2", b"3"}
+        assert set(r.smembers("{foo}c")) == {b"1", b"2", b"3"}
         r.sadd("{foo}b", "2", "3")
         assert r.sdiffstore("{foo}c", "{foo}a", "{foo}b") == 1
-        assert r.smembers("{foo}c") == {b"1"}
+        assert r.smembers("{foo}c") == [b"1"]
 
     def test_cluster_sinter(self, r):
         r.sadd("{foo}a", "1", "2", "3")
-        assert r.sinter("{foo}a", "{foo}b") == set()
+        assert r.sinter("{foo}a", "{foo}b") == []
         r.sadd("{foo}b", "2", "3")
-        assert r.sinter("{foo}a", "{foo}b") == {b"2", b"3"}
+        assert set(r.sinter("{foo}a", "{foo}b")) == {b"2", b"3"}
 
     def test_cluster_sinterstore(self, r):
         r.sadd("{foo}a", "1", "2", "3")
         assert r.sinterstore("{foo}c", "{foo}a", "{foo}b") == 0
-        assert r.smembers("{foo}c") == set()
+        assert r.smembers("{foo}c") == []
         r.sadd("{foo}b", "2", "3")
         assert r.sinterstore("{foo}c", "{foo}a", "{foo}b") == 2
-        assert r.smembers("{foo}c") == {b"2", b"3"}
+        assert set(r.smembers("{foo}c")) == {b"2", b"3"}
 
     def test_cluster_smove(self, r):
         r.sadd("{foo}a", "a1", "a2")
         r.sadd("{foo}b", "b1", "b2")
         assert r.smove("{foo}a", "{foo}b", "a1")
-        assert r.smembers("{foo}a") == {b"a2"}
-        assert r.smembers("{foo}b") == {b"b1", b"b2", b"a1"}
+        assert r.smembers("{foo}a") == [b"a2"]
+        assert set(r.smembers("{foo}b")) == {b"b1", b"b2", b"a1"}
 
     def test_cluster_sunion(self, r):
         r.sadd("{foo}a", "1", "2")
         r.sadd("{foo}b", "2", "3")
-        assert r.sunion("{foo}a", "{foo}b") == {b"1", b"2", b"3"}
+        assert set(r.sunion("{foo}a", "{foo}b")) == {b"1", b"2", b"3"}
 
     def test_cluster_sunionstore(self, r):
         r.sadd("{foo}a", "1", "2")
         r.sadd("{foo}b", "2", "3")
         assert r.sunionstore("{foo}c", "{foo}a", "{foo}b") == 3
-        assert r.smembers("{foo}c") == {b"1", b"2", b"3"}
+        assert set(r.smembers("{foo}c")) == {b"1", b"2", b"3"}
 
     @skip_if_server_version_lt("6.2.0")
     def test_cluster_zdiff(self, r):

--- a/tests/test_command_parser.py
+++ b/tests/test_command_parser.py
@@ -1,6 +1,5 @@
 import pytest
 from redis._parsers import CommandsParser
-from redis.utils import HIREDIS_AVAILABLE
 
 from .conftest import (
     assert_resp_response,
@@ -9,9 +8,6 @@ from .conftest import (
 )
 
 
-# The response to COMMAND contains maps inside sets, which are not handled
-# by the hiredis-py parser (see https://github.com/redis/hiredis-py/issues/188)
-@pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 class TestCommandsParser:
     def test_init_commands(self, r):
         commands_parser = CommandsParser(r)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -68,7 +68,7 @@ class TestFunction:
                 b"library_name": b"mylib",
                 b"engine": b"LUA",
                 b"functions": [
-                    {b"name": b"myfunc", b"description": None, b"flags": {b"no-writes"}}
+                    {b"name": b"myfunc", b"description": None, b"flags": [b"no-writes"]}
                 ],
             }
         ]
@@ -98,7 +98,7 @@ class TestFunction:
                 b"library_name": b"mylib",
                 b"engine": b"LUA",
                 b"functions": [
-                    {b"name": b"myfunc", b"description": None, b"flags": {b"no-writes"}}
+                    {b"name": b"myfunc", b"description": None, b"flags": [b"no-writes"]}
                 ],
             }
         ]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -27,7 +27,6 @@ from redis.commands.search.suggestion import Suggestion
 
 from .conftest import (
     _get_client,
-    assert_resp_response,
     is_resp2_connection,
     skip_if_redis_enterprise,
     skip_if_resp_version,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -893,7 +893,7 @@ def test_dict_operations(client):
 
     # Dump dict and inspect content
     res = client.ft().dict_dump("custom_dict")
-    assert_resp_response(client, res, ["item1", "item3"], {"item1", "item3"})
+    assert res == ["item1", "item3"]
 
     # Remove rest of the items before reload
     client.ft().dict_del("custom_dict", *res)

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -988,7 +988,7 @@ def test_query_index(client):
     client.ts().create(2, labels={"Test": "This", "Taste": "That"})
     assert 2 == len(client.ts().queryindex(["Test=This"]))
     assert 1 == len(client.ts().queryindex(["Taste=That"]))
-    assert ["2"] == client.ts().queryindex(["Taste=That"])
+    assert_resp_response(client, client.ts().queryindex(["Taste=That"]), [2], ["2"])
 
 
 @pytest.mark.redismod

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -988,7 +988,7 @@ def test_query_index(client):
     client.ts().create(2, labels={"Test": "This", "Taste": "That"})
     assert 2 == len(client.ts().queryindex(["Test=This"]))
     assert 1 == len(client.ts().queryindex(["Taste=That"]))
-    assert_resp_response(client, client.ts().queryindex(["Taste=That"]), [2], {"2"})
+    assert ["2"] == client.ts().queryindex(["Taste=That"])
 
 
 @pytest.mark.redismod


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Although the RESP3 protocol defines the set data structure, sometimes the responses from the Redis server contain sets with nested maps, which cannot be represented in Python as sets with nested dicts, because dicts are not hashable.

Versions of HIREDIS before 3.0.0 would cause segmentation fault when parsing such responses. Starting with version 3.0.0 the problem was fixed, with the compromise that RESP3 sets are represented as Python lists.

The embedded RESP3 parser was so far trying to represent RESP3 sets as Python sets, if possible. Only when this was not possible it would switch to the list representation. Arguably this is not the best user experience, not knowing when you will get back a set or a list.

Upgrade the required hiredis-py version to be at least 3.0.0, and change the embedded parser to always represent RESP3 sets as lists. This way we get a consistent experience in all cases.

This is a breaking change.

Fixes #3074 and #3145 