### PR TITLE
More docs fixes

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -579,10 +579,12 @@ class Redis(
         """
         Closes Redis client connection
 
-        :param close_connection_pool: decides whether to close the connection pool used
-        by this Redis client, overriding Redis.auto_close_connection_pool. By default,
-        let Redis.auto_close_connection_pool decide whether to close the connection
-        pool.
+        Args:
+            close_connection_pool:
+                decides whether to close the connection pool used by this Redis client,
+                overriding Redis.auto_close_connection_pool.
+                By default, let Redis.auto_close_connection_pool decide
+                whether to close the connection pool.
         """
         conn = self.connection
         if conn:

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -46,8 +46,8 @@ from redis.typing import (
 from .helpers import list_or_args
 
 if TYPE_CHECKING:
-    from redis.asyncio.client import Redis as AsyncRedis
-    from redis.client import Redis
+    import redis.asyncio.client
+    import redis.client
 
 
 class ACLCommands(CommandsProtocol):
@@ -1442,7 +1442,7 @@ class BitFieldOperation:
 
     def __init__(
         self,
-        client: Union["Redis", "AsyncRedis"],
+        client: Union["redis.client.Redis", "redis.asyncio.client.Redis"],
         key: str,
         default_overflow: Union[str, None] = None,
     ):
@@ -1586,7 +1586,7 @@ class BasicKeyCommands(CommandsProtocol):
         return self.execute_command("BITCOUNT", *params, keys=[key])
 
     def bitfield(
-        self: Union["Redis", "AsyncRedis"],
+        self: Union["redis.client.Redis", "redis.asyncio.client.Redis"],
         key: KeyT,
         default_overflow: Union[str, None] = None,
     ) -> BitFieldOperation:
@@ -1599,7 +1599,7 @@ class BasicKeyCommands(CommandsProtocol):
         return BitFieldOperation(self, key, default_overflow=default_overflow)
 
     def bitfield_ro(
-        self: Union["Redis", "AsyncRedis"],
+        self: Union["redis.client.Redis", "redis.asyncio.client.Redis"],
         key: KeyT,
         encoding: str,
         offset: BitfieldOffsetT,
@@ -5467,7 +5467,7 @@ class Script:
     An executable Lua script object returned by ``register_script``
     """
 
-    def __init__(self, registered_client: "Redis", script: ScriptTextT):
+    def __init__(self, registered_client: "redis.client.Redis", script: ScriptTextT):
         self.registered_client = registered_client
         self.script = script
         # Precalculate and store the SHA1 hex digest of the script.
@@ -5487,7 +5487,7 @@ class Script:
         self,
         keys: Union[Sequence[KeyT], None] = None,
         args: Union[Iterable[EncodableT], None] = None,
-        client: Union["Redis", None] = None,
+        client: Union["redis.client.Redis", None] = None,
     ):
         """Execute the script, passing any required ``args``"""
         keys = keys or []
@@ -5516,7 +5516,11 @@ class AsyncScript:
     An executable Lua script object returned by ``register_script``
     """
 
-    def __init__(self, registered_client: "AsyncRedis", script: ScriptTextT):
+    def __init__(
+        self,
+        registered_client: "redis.asyncio.client.Redis",
+        script: ScriptTextT,
+    ):
         self.registered_client = registered_client
         self.script = script
         # Precalculate and store the SHA1 hex digest of the script.
@@ -5536,7 +5540,7 @@ class AsyncScript:
         self,
         keys: Union[Sequence[KeyT], None] = None,
         args: Union[Iterable[EncodableT], None] = None,
-        client: Union["AsyncRedis", None] = None,
+        client: Union["redis.asyncio.client.Redis", None] = None,
     ):
         """Execute the script, passing any required ``args``"""
         keys = keys or []
@@ -5761,7 +5765,7 @@ class ScriptCommands(CommandsProtocol):
         """
         return self.execute_command("SCRIPT LOAD", script)
 
-    def register_script(self: "Redis", script: ScriptTextT) -> Script:
+    def register_script(self: "redis.client.Redis", script: ScriptTextT) -> Script:
         """
         Register a Lua ``script`` specifying the ``keys`` it will touch.
         Returns a Script object that is callable and hides the complexity of
@@ -5775,7 +5779,10 @@ class AsyncScriptCommands(ScriptCommands):
     async def script_debug(self, *args) -> None:
         return super().script_debug()
 
-    def register_script(self: "AsyncRedis", script: ScriptTextT) -> AsyncScript:
+    def register_script(
+        self: "redis.asyncio.client.Redis",
+        script: ScriptTextT,
+    ) -> AsyncScript:
         """
         Register a Lua ``script`` specifying the ``keys`` it will touch.
         Returns a Script object that is callable and hides the complexity of

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -731,16 +731,19 @@ class ManagementCommands(CommandsProtocol):
 
         For more information see https://redis.io/commands/client-pause
 
-        :param timeout: milliseconds to pause clients
-        :param all: If true (default) all client commands are blocked.
-        otherwise, clients are only blocked if they attempt to execute
-        a write command.
+        Args:
+            timeout: milliseconds to pause clients
+            all: If true (default) all client commands are blocked.
+                 otherwise, clients are only blocked if they attempt to execute
+                 a write command.
+
         For the WRITE mode, some commands have special behavior:
-        EVAL/EVALSHA: Will block client for all scripts.
-        PUBLISH: Will block client.
-        PFCOUNT: Will block client.
-        WAIT: Acknowledgments will be delayed, so this command will
-        appear blocked.
+
+        * EVAL/EVALSHA: Will block client for all scripts.
+        * PUBLISH: Will block client.
+        * PFCOUNT: Will block client.
+        * WAIT: Acknowledgments will be delayed, so this command will
+            appear blocked.
         """
         args = ["CLIENT PAUSE", str(timeout)]
         if not isinstance(timeout, int):

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -6415,9 +6415,12 @@ class FunctionCommands:
     ) -> Union[Awaitable[List], List]:
         """
         Return information about the functions and libraries.
-        :param library: pecify a pattern for matching library names
-        :param withcode: cause the server to include the libraries source
-         implementation in the reply
+
+        Args:
+
+            library: specify a pattern for matching library names
+            withcode: cause the server to include the libraries source implementation
+                in the reply
         """
         args = ["LIBRARYNAME", library]
         if withcode:

--- a/redis/commands/timeseries/commands.py
+++ b/redis/commands/timeseries/commands.py
@@ -60,17 +60,17 @@ class TimeSeriesCommands:
             duplicate_policy:
                 Policy for handling multiple samples with identical timestamps. Can be
                 one of:
-                    - 'block': An error will occur and the new value will be ignored.
-                    - 'first': Ignore the new value.
-                    - 'last': Override with the latest value.
-                    - 'min': Only override if the value is lower than the existing
-                      value.
-                    - 'max': Only override if the value is higher than the existing
-                      value.
-                    - 'sum': If a previous sample exists, add the new sample to it so
-                      that the updated value is equal to (previous + new). If no
-                      previous sample exists, set the updated value equal to the new
-                      value.
+
+                - 'block': An error will occur and the new value will be ignored.
+                - 'first': Ignore the new value.
+                - 'last': Override with the latest value.
+                - 'min': Only override if the value is lower than the existing value.
+                - 'max': Only override if the value is higher than the existing value.
+                - 'sum': If a previous sample exists, add the new sample to it so
+                  that the updated value is equal to (previous + new). If no
+                  previous sample exists, set the updated value equal to the new
+                  value.
+
             ignore_max_time_diff:
                 A non-negative integer value, in milliseconds, that sets an ignore
                 threshold for added timestamps. If the difference between the last
@@ -130,17 +130,17 @@ class TimeSeriesCommands:
             duplicate_policy:
                 Policy for handling multiple samples with identical timestamps. Can be
                 one of:
-                    - 'block': An error will occur and the new value will be ignored.
-                    - 'first': Ignore the new value.
-                    - 'last': Override with the latest value.
-                    - 'min': Only override if the value is lower than the existing
-                      value.
-                    - 'max': Only override if the value is higher than the existing
-                      value.
-                    - 'sum': If a previous sample exists, add the new sample to it so
-                      that the updated value is equal to (previous + new). If no
-                      previous sample exists, set the updated value equal to the new
-                      value.
+
+                - 'block': An error will occur and the new value will be ignored.
+                - 'first': Ignore the new value.
+                - 'last': Override with the latest value.
+                - 'min': Only override if the value is lower than the existing value.
+                - 'max': Only override if the value is higher than the existing value.
+                - 'sum': If a previous sample exists, add the new sample to it so
+                  that the updated value is equal to (previous + new). If no
+                  previous sample exists, set the updated value equal to the new
+                  value.
+
             ignore_max_time_diff:
                 A non-negative integer value, in milliseconds, that sets an ignore
                 threshold for added timestamps. If the difference between the last
@@ -210,17 +210,17 @@ class TimeSeriesCommands:
             duplicate_policy:
                 Policy for handling multiple samples with identical timestamps. Can be
                 one of:
-                    - 'block': An error will occur and the new value will be ignored.
-                    - 'first': Ignore the new value.
-                    - 'last': Override with the latest value.
-                    - 'min': Only override if the value is lower than the existing
-                      value.
-                    - 'max': Only override if the value is higher than the existing
-                      value.
-                    - 'sum': If a previous sample exists, add the new sample to it so
-                      that the updated value is equal to (previous + new). If no
-                      previous sample exists, set the updated value equal to the new
-                      value.
+
+                - 'block': An error will occur and the new value will be ignored.
+                - 'first': Ignore the new value.
+                - 'last': Override with the latest value.
+                - 'min': Only override if the value is lower than the existing value.
+                - 'max': Only override if the value is higher than the existing value.
+                - 'sum': If a previous sample exists, add the new sample to it so
+                  that the updated value is equal to (previous + new). If no
+                  previous sample exists, set the updated value equal to the new
+                  value.
+
             ignore_max_time_diff:
                 A non-negative integer value, in milliseconds, that sets an ignore
                 threshold for added timestamps. If the difference between the last
@@ -331,17 +331,17 @@ class TimeSeriesCommands:
             duplicate_policy:
                 Policy for handling multiple samples with identical timestamps. Can be
                 one of:
-                    - 'block': An error will occur and the new value will be ignored.
-                    - 'first': Ignore the new value.
-                    - 'last': Override with the latest value.
-                    - 'min': Only override if the value is lower than the existing
-                      value.
-                    - 'max': Only override if the value is higher than the existing
-                      value.
-                    - 'sum': If a previous sample exists, add the new sample to it so
-                      that the updated value is equal to (previous + new). If no
-                      previous sample exists, set the updated value equal to the new
-                      value.
+
+                - 'block': An error will occur and the new value will be ignored.
+                - 'first': Ignore the new value.
+                - 'last': Override with the latest value.
+                - 'min': Only override if the value is lower than the existing value.
+                - 'max': Only override if the value is higher than the existing value.
+                - 'sum': If a previous sample exists, add the new sample to it so
+                  that the updated value is equal to (previous + new). If no
+                  previous sample exists, set the updated value equal to the new
+                  value.
+
             ignore_max_time_diff:
                 A non-negative integer value, in milliseconds, that sets an ignore
                 threshold for added timestamps. If the difference between the last
@@ -423,17 +423,17 @@ class TimeSeriesCommands:
             duplicate_policy:
                 Policy for handling multiple samples with identical timestamps. Can be
                 one of:
-                    - 'block': An error will occur and the new value will be ignored.
-                    - 'first': Ignore the new value.
-                    - 'last': Override with the latest value.
-                    - 'min': Only override if the value is lower than the existing
-                      value.
-                    - 'max': Only override if the value is higher than the existing
-                      value.
-                    - 'sum': If a previous sample exists, add the new sample to it so
-                      that the updated value is equal to (previous + new). If no
-                      previous sample exists, set the updated value equal to the new
-                      value.
+
+                - 'block': An error will occur and the new value will be ignored.
+                - 'first': Ignore the new value.
+                - 'last': Override with the latest value.
+                - 'min': Only override if the value is lower than the existing value.
+                - 'max': Only override if the value is higher than the existing value.
+                - 'sum': If a previous sample exists, add the new sample to it so
+                  that the updated value is equal to (previous + new). If no
+                  previous sample exists, set the updated value equal to the new
+                  value.
+
             ignore_max_time_diff:
                 A non-negative integer value, in milliseconds, that sets an ignore
                 threshold for added timestamps. If the difference between the last


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This PR resolves three classes of warnings and errors that Sphinx reports when building the documentation ([recent example](https://readthedocs.org/projects/redis-py/builds/23205005/); click the `python -m sphinx` accordion to see the details):

* "Unexpected indentation"
* "Unexpected unindent"
* "more than one target for cross-reference 'Redis'"
