### PR TITLE
Ignore a coverage warning re: sysmon on Pythons < 3.12

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,5 @@ timeout = 30
 filterwarnings =
     always
     ignore:RedisGraph support is deprecated as of Redis Stack 7.2:DeprecationWarning
+    # Ignore a coverage warning when COVERAGE_CORE=sysmon for Pythons < 3.12.
+    ignore:sys.monitoring isn't available:coverage.exceptions.CoverageWarning


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Coverage currently emits a warning in CI when running on Pythons < 3.12 because `COVERAGE_CORE=sysmon` regardless of Python version. [Recent example](https://github.com/kurtmckee/pr-redis-py/actions/runs/10058841871/job/27802800159#step:4:297) on Python 3.8:

```
../../../../../opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/coverage/collector.py:156
  /opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/coverage/collector.py:156: CoverageWarning: sys.monitoring isn't available, using default core (no-sysmon)
    self.warn("sys.monitoring isn't available, using default core", slug="no-sysmon")
```

This PR configures pytest to ignore the warning.