### PR TITLE
Catch a known `DeprecationWarning` when calling `.close()`

### DIFF
--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -313,7 +313,8 @@ class TestRedisClusterObj:
             called += 1
 
         with mock.patch.object(cluster, "aclose", mock_aclose):
-            await cluster.close()
+            with pytest.warns(DeprecationWarning, match=r"Use aclose\(\) instead"):
+                await cluster.close()
             assert called == 1
         await cluster.aclose()
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

When running the test suite, an expected `DeprecationWarning` is not caught. [Recent example](https://github.com/redis/redis-py/actions/runs/10051119769/job/27780178155#step:4:292):

```
tests/test_asyncio/test_cluster.py::TestRedisClusterObj::test_close_is_aclose
  /home/runner/work/redis-py/redis-py/tests/test_asyncio/test_cluster.py:316: DeprecationWarning: Call to deprecated close. (Use aclose() instead) -- Deprecated since version 5.0.0.
    await cluster.close()
```

As this is expected behavior, this PR adds a `pytest.warns()` context manager to verify that this warning is issued and has an expected message.