### PR TITLE
Allows cluster mode connections to wait for free connection when at max.

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1,5 +1,4 @@
 import asyncio
-import collections
 import random
 import socket
 import ssl
@@ -7,7 +6,6 @@ import warnings
 from typing import (
     Any,
     Callable,
-    Deque,
     Dict,
     Generator,
     List,
@@ -65,9 +63,9 @@ from redis.exceptions import (
     RedisClusterException,
     ResponseError,
     SlotNotCoveredError,
-    TryAgainError,
 )
 from redis.exceptions import TimeoutError as RedisTimeoutError
+from redis.exceptions import TryAgainError
 from redis.typing import AnyKeyT, EncodableT, KeyT
 from redis.utils import (
     deprecated_function,
@@ -1001,7 +999,7 @@ class ClusterNode:
         self.connection_class = connection_class
         self.connection_kwargs = connection_kwargs
         self.response_callbacks = connection_kwargs.pop("response_callbacks", {})
-        self.acquire_connection_timeout = connection_kwargs.get('socket_timeout', 30)
+        self.acquire_connection_timeout = connection_kwargs.get("socket_timeout", 30)
 
         self._connections: List[Connection] = []
         self._free: asyncio.Queue[Connection] = asyncio.Queue()
@@ -1057,12 +1055,13 @@ class ClusterNode:
             elif self.wait_for_connections:
                 try:
                     connection = await asyncio.wait_for(
-                        self._free.get(),
-                        self.acquire_connection_timeout
+                        self._free.get(), self.acquire_connection_timeout
                     )
                     return connection
                 except TimeoutError:
-                    raise RedisTimeoutError("Timeout reached waiting for a free connection")
+                    raise RedisTimeoutError(
+                        "Timeout reached waiting for a free connection"
+                    )
 
             raise MaxConnectionsError()
 

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -468,9 +468,7 @@ class TestRedisClusterObj:
         self, create_redis: Callable[..., RedisCluster]
     ) -> None:
         rc = await create_redis(
-            cls=RedisCluster, 
-            max_connections=10,
-            wait_for_connections=True
+            cls=RedisCluster, max_connections=10, wait_for_connections=True
         )
         for node in rc.get_nodes():
             assert node.max_connections == 10
@@ -483,12 +481,8 @@ class TestRedisClusterObj:
             read_response.side_effect = read_response_mocked
 
             await asyncio.gather(
-                *(
-                    rc.ping(target_nodes=RedisCluster.DEFAULT_NODE)
-                    for _ in range(20)
-                )
+                *(rc.ping(target_nodes=RedisCluster.DEFAULT_NODE) for _ in range(20))
             )
-        
         assert len(rc.get_default_node()._connections) == 10
         await rc.aclose()
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ x] Is the new or changed code fully tested?
- [x ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This change adds a flag to the cluster client which is propagated down to the cluster node object called 'wait_for_connections'. This helps in highly distributed high throughput environments where redis connections need to be capped to avoid running into connection limits, but also we want the request to make it through eventually in the event of some sort of stampede.
