### PR TITLE
Fix parsing of the is_master attribute in the URL

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -956,6 +956,7 @@ URL_QUERY_ARGUMENT_PARSERS = {
     "health_check_interval": int,
     "ssl_check_hostname": to_bool,
     "timeout": float,
+    "is_master": to_bool,
 }
 
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
Fixed the parsing of the is_master attribute in the Redis URL. 
When the Redis URL is 'redis://redis-master/1?is_master=0', it is supposed to find the slave node of redis-master for read operations. However, since is_master was parsed as '0' and not correctly interpreted as False, it failed to use the slave node.
 I encountered this issue when trying to implement read-write separation using SentinelConnectionPool.
