### PR TITLE
Fix sentinel connections

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -67,6 +67,7 @@
     * Close Unix sockets if the connection attempt fails. This prevents `ResourceWarning`s. (#3314)
     * Close SSL sockets if the connection attempt fails, or if validations fail. (#3317)
     * Eliminate mutable default arguments in the `redis.commands.core.Script` class. (#3332)
+    * Fix passing arguments to Redis() when forming Sentinel connections.
 
 * 4.1.3 (Feb 8, 2022)
   * Fix flushdb and flushall (#1926)

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -240,7 +240,7 @@ class Sentinel(SentinelCommands):
         self.sentinel_kwargs = sentinel_kwargs
 
         self.sentinels = [
-            Redis(hostname, port, **self.sentinel_kwargs)
+            Redis(hostname, port, **connection_kwargs)
             for hostname, port in sentinels
         ]
         self.min_other_sentinels = min_other_sentinels


### PR DESCRIPTION
When passing args to Redis(), using the connection_kwargs args allows us to use authentication and other connection features.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Modified the arguments passed to Redis() when forming Sentinel connections