### PR TITLE
there is no pyopenssl 23.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
     ],
     extras_require={
         "hiredis": ["hiredis>=3.0.0"],
-        "ocsp": ["cryptography>=36.0.1", "pyopenssl==23.2.1", "requests>=2.31.0"],
+        "ocsp": ["cryptography>=36.0.1", "pyopenssl>=24.2.1", "requests>=2.31.0"],
     },
 )


### PR DESCRIPTION
since #2979 this project pins to a version of pyopenssl that does not exist

per https://pypi.org/project/pyOpenSSL/#history, the latest version at time of that commit - as today - is 24.2.2

I've also removed the exact pin, this just invites conflicts with other projects.

While I have not tested this at all except to install it, I suppose that is more than anyone else has done!

