### PR TITLE
Add `command_timeout` to async client

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -233,7 +233,7 @@ class Redis(
         redis_connect_func=None,
         credential_provider: Optional[CredentialProvider] = None,
         protocol: Optional[int] = 2,
-        default_command_timeout: Optional[float] = None,
+        command_timeout: Optional[float] = None,
     ):
         """
         Initialize a new Redis client.
@@ -283,7 +283,7 @@ class Redis(
                 "lib_version": lib_version,
                 "redis_connect_func": redis_connect_func,
                 "protocol": protocol,
-                "default_command_timeout": default_command_timeout,
+                "command_timeout": command_timeout,
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -233,6 +233,7 @@ class Redis(
         redis_connect_func=None,
         credential_provider: Optional[CredentialProvider] = None,
         protocol: Optional[int] = 2,
+        default_command_timeout: Optional[float] = None,
     ):
         """
         Initialize a new Redis client.
@@ -282,6 +283,7 @@ class Redis(
                 "lib_version": lib_version,
                 "redis_connect_func": redis_connect_func,
                 "protocol": protocol,
+                "default_command_timeout": default_command_timeout,
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -270,7 +270,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         ssl_ciphers: Optional[str] = None,
         protocol: Optional[int] = 2,
         address_remap: Optional[Callable[[Tuple[str, int]], Tuple[str, int]]] = None,
-        default_command_timeout: Optional[float] = None,
+        command_timeout: Optional[float] = None,
     ) -> None:
         if db:
             raise RedisClusterException(
@@ -312,7 +312,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             "socket_keepalive": socket_keepalive,
             "socket_keepalive_options": socket_keepalive_options,
             "socket_timeout": socket_timeout,
-            "default_command_timeout": default_command_timeout,
+            "command_timeout": command_timeout,
             "retry": retry,
             "protocol": protocol,
         }

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -270,6 +270,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         ssl_ciphers: Optional[str] = None,
         protocol: Optional[int] = 2,
         address_remap: Optional[Callable[[Tuple[str, int]], Tuple[str, int]]] = None,
+        default_command_timeout: Optional[float] = None,
     ) -> None:
         if db:
             raise RedisClusterException(
@@ -311,6 +312,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             "socket_keepalive": socket_keepalive,
             "socket_keepalive_options": socket_keepalive_options,
             "socket_timeout": socket_timeout,
+            "default_command_timeout": default_command_timeout,
             "retry": retry,
             "protocol": protocol,
         }

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -104,7 +104,7 @@ class AbstractConnection:
         "credential_provider",
         "password",
         "socket_timeout",
-        "default_command_timeout",
+        "command_timeout",
         "socket_connect_timeout",
         "redis_connect_func",
         "retry_on_timeout",
@@ -149,7 +149,7 @@ class AbstractConnection:
         encoder_class: Type[Encoder] = Encoder,
         credential_provider: Optional[CredentialProvider] = None,
         protocol: Optional[int] = 2,
-        default_command_timeout: Optional[float] = None,
+        command_timeout: Optional[float] = None,
     ):
         if (username or password) and credential_provider is not None:
             raise DataError(
@@ -169,7 +169,7 @@ class AbstractConnection:
         if socket_connect_timeout is None:
             socket_connect_timeout = socket_timeout
         self.socket_connect_timeout = socket_connect_timeout
-        self.default_command_timeout = default_command_timeout
+        self.command_timeout = command_timeout
         self.retry_on_timeout = retry_on_timeout
         if retry_on_error is SENTINEL:
             retry_on_error = []
@@ -212,8 +212,8 @@ class AbstractConnection:
     def _get_command_timeout(self, timeout: Optional[float] = None):
         if timeout is not None:
             return timeout
-        if self.default_command_timeout is not None:
-            return self.default_command_timeout
+        if self.command_timeout is not None:
+            return self.command_timeout
         return self.socket_timeout
 
     def __del__(self, _warnings: Any = warnings):

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -140,7 +140,7 @@ REDIS_ALLOWED_KEYS = (
     "credential_provider",
     "db",
     "decode_responses",
-    "default_command_timeout",
+    "command_timeout",
     "encoding",
     "encoding_errors",
     "errors",

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -140,6 +140,7 @@ REDIS_ALLOWED_KEYS = (
     "credential_provider",
     "db",
     "decode_responses",
+    "default_command_timeout",
     "encoding",
     "encoding_errors",
     "errors",


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Currently, `socket_timeout` is used as both the socket timeout and an asyncio-level timeout. However, if networking is unreliable, it may be preferable to set a shorter `socket_timeout` than the asyncio timeout - this would allow for the command to fail fast if socket is not receiving any data, but keep the command running if the connection is simply slow, or the amount of data is large.
