### PR TITLE
Fixing randomly failing test

### DIFF
--- a/tests/test_asyncio/test_hash.py
+++ b/tests/test_asyncio/test_hash.py
@@ -129,9 +129,9 @@ async def test_hpexpire_multiple_fields(r):
 async def test_hexpireat_basic(r):
     await r.delete("test:hash")
     await r.hset("test:hash", mapping={"field1": "value1", "field2": "value2"})
-    exp_time = int((datetime.now() + timedelta(seconds=1)).timestamp())
+    exp_time = math.ceil((datetime.now() + timedelta(seconds=1)).timestamp())
     assert await r.hexpireat("test:hash", exp_time, "field1") == [1]
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(2.1)
     assert await r.hexists("test:hash", "field1") is False
     assert await r.hexists("test:hash", "field2") is True
 
@@ -140,9 +140,9 @@ async def test_hexpireat_basic(r):
 async def test_hexpireat_with_datetime(r):
     await r.delete("test:hash")
     await r.hset("test:hash", mapping={"field1": "value1", "field2": "value2"})
-    exp_time = datetime.now() + timedelta(seconds=1)
+    exp_time = (datetime.now() + timedelta(seconds=2)).replace(microsecond=0)
     assert await r.hexpireat("test:hash", exp_time, "field1") == [1]
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(2.1)
     assert await r.hexists("test:hash", "field1") is False
     assert await r.hexists("test:hash", "field2") is True
 

--- a/tests/test_asyncio/test_hash.py
+++ b/tests/test_asyncio/test_hash.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 from datetime import datetime, timedelta
 
 from tests.conftest import skip_if_server_version_lt
@@ -175,9 +176,9 @@ async def test_hexpireat_multiple_fields(r):
         "test:hash",
         mapping={"field1": "value1", "field2": "value2", "field3": "value3"},
     )
-    exp_time = int((datetime.now() + timedelta(seconds=1)).timestamp())
+    exp_time = math.ceil((datetime.now() + timedelta(seconds=1)).timestamp())
     assert await r.hexpireat("test:hash", exp_time, "field1", "field2") == [1, 1]
-    await asyncio.sleep(1.5)
+    await asyncio.sleep(2.1)
     assert await r.hexists("test:hash", "field1") is False
     assert await r.hexists("test:hash", "field2") is False
     assert await r.hexists("test:hash", "field3") is True

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,3 +1,4 @@
+import math
 import time
 from datetime import datetime, timedelta
 
@@ -147,9 +148,9 @@ def test_hpexpire_multiple_condition_flags_error(r):
 def test_hexpireat_basic(r):
     r.delete("test:hash")
     r.hset("test:hash", mapping={"field1": "value1", "field2": "value2"})
-    exp_time = int((datetime.now() + timedelta(seconds=1)).timestamp())
+    exp_time = math.ceil((datetime.now() + timedelta(seconds=1)).timestamp())
     assert r.hexpireat("test:hash", exp_time, "field1") == [1]
-    time.sleep(1.1)
+    time.sleep(2.1)
     assert r.hexists("test:hash", "field1") is False
     assert r.hexists("test:hash", "field2") is True
 
@@ -158,9 +159,9 @@ def test_hexpireat_basic(r):
 def test_hexpireat_with_datetime(r):
     r.delete("test:hash")
     r.hset("test:hash", mapping={"field1": "value1", "field2": "value2"})
-    exp_time = datetime.now() + timedelta(seconds=1)
+    exp_time = (datetime.now() + timedelta(seconds=2)).replace(microsecond=0)
     assert r.hexpireat("test:hash", exp_time, "field1") == [1]
-    time.sleep(1.1)
+    time.sleep(2.1)
     assert r.hexists("test:hash", "field1") is False
     assert r.hexists("test:hash", "field2") is True
 
@@ -194,9 +195,9 @@ def test_hexpireat_multiple_fields(r):
         "test:hash",
         mapping={"field1": "value1", "field2": "value2", "field3": "value3"},
     )
-    exp_time = int((datetime.now() + timedelta(seconds=1)).timestamp())
+    exp_time = math.ceil((datetime.now() + timedelta(seconds=1)).timestamp())
     assert r.hexpireat("test:hash", exp_time, "field1", "field2") == [1, 1]
-    time.sleep(1.1)
+    time.sleep(2.1)
     assert r.hexists("test:hash", "field1") is False
     assert r.hexists("test:hash", "field2") is False
     assert r.hexists("test:hash", "field3") is True


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This test fails randomly depending on whether it runs close to the end of the second or not.

For example, if the test runs at `1527800400.999999`, then the integer value of the timestamp + timedelta of 1 seconds = 1527800401. This way when we call `r.hexpireat` with that value, the combination of the time spent in the python code and the network delay adds enough time to cause the expiration timestamp to be in the past when received by the server.
As a result, the result value of the `hexpireat` is 2 (timestamp in the past) instead of 1. 
```

```
