### PR TITLE
Allow multi-node commands in async pipeline

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1567,6 +1567,8 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
                     if name_exc:
                         name, exc = name_exc
                         command = " ".join(map(safe_str, cmd.args))
+                        # Note: this will only raise the first exception, but that is
+                        # consistent with RedisCluster.execute_command.
                         msg = (
                             f"Command # {cmd.position + 1} ({command}) of pipeline "
                             f"caused error on node {name}: "
@@ -1635,7 +1637,7 @@ class PipelineCommand:
 
     def unwrap_result(
         self,
-    ) -> Optional[Union[Union[Any, Exception], Dict[str, Union[Any, Exception]]]]:
+    ) -> Optional[Union[Any, Exception, Dict[str, Union[Any, Exception]]]]:
         if len(self.result) == 0:
             return None
         if len(self.result) == 1:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

While `RedisCluster.execute_command` supports multi-node commands (and returns a dictionary of `{node.name: result}`), `ClusterPipeline` did not allow for it. This PR adds support for multi-node commands in `ClusterPipeline`. The results of those commands will be put into the returned list in format consistent with `RedisCluster.execute_command`.
