### PR TITLE
Expand type for EncodedT

### DIFF
--- a/redis/typing.py
+++ b/redis/typing.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 Number = Union[int, float]
-EncodedT = Union[bytes, memoryview]
+EncodedT = Union[bytes, bytearray, memoryview]
 DecodedT = Union[str, int, float]
 EncodableT = Union[EncodedT, DecodedT]
 AbsExpiryT = Union[int, datetime]


### PR DESCRIPTION
As of PEP 688, type checkers will no longer implicitly consider bytearray to be compatible with bytes