### PR TITLE
Moved self._lock initialisation to Pool constructor

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1378,6 +1378,7 @@ class ConnectionPool:
         # will notice the first thread already did the work and simply
         # release the lock.
         self._fork_lock = threading.Lock()
+        self._lock = threading.Lock()
         self.reset()
 
     def __repr__(self) -> (str, str):
@@ -1395,7 +1396,6 @@ class ConnectionPool:
         return self.connection_kwargs.get("protocol", None)
 
     def reset(self) -> None:
-        self._lock = threading.Lock()
         self._created_connections = 0
         self._available_connections = []
         self._in_use_connections = set()

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -9,9 +9,14 @@ import pytest
 import redis
 from redis.cache import CacheConfig
 from redis.connection import CacheProxyConnection, Connection, to_bool
-from redis.utils import SSL_AVAILABLE
+from redis.utils import HIREDIS_AVAILABLE, SSL_AVAILABLE
 
-from .conftest import _get_client, skip_if_redis_enterprise, skip_if_server_version_lt
+from .conftest import (
+    _get_client,
+    skip_if_redis_enterprise,
+    skip_if_resp_version,
+    skip_if_server_version_lt,
+)
 from .test_pubsub import wait_for_message
 
 
@@ -197,6 +202,10 @@ class TestBlockingConnectionPool:
         expected = "path=abc,db=0,client_name=test-client"
         assert expected in repr(pool)
 
+    @pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
+    @pytest.mark.onlynoncluster
+    @skip_if_resp_version(2)
+    @skip_if_server_version_lt("7.4.0")
     def test_initialise_pool_with_cache(self, master_host):
         pool = redis.BlockingConnectionPool(
             connection_class=Connection,

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -8,7 +8,7 @@ from unittest import mock
 import pytest
 import redis
 from redis.cache import CacheConfig
-from redis.connection import to_bool, CacheProxyConnection, Connection
+from redis.connection import CacheProxyConnection, Connection, to_bool
 from redis.utils import SSL_AVAILABLE
 
 from .conftest import _get_client, skip_if_redis_enterprise, skip_if_server_version_lt

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -7,7 +7,8 @@ from unittest import mock
 
 import pytest
 import redis
-from redis.connection import to_bool
+from redis.cache import CacheConfig
+from redis.connection import to_bool, CacheProxyConnection, Connection
 from redis.utils import SSL_AVAILABLE
 
 from .conftest import _get_client, skip_if_redis_enterprise, skip_if_server_version_lt
@@ -195,6 +196,16 @@ class TestBlockingConnectionPool:
         )
         expected = "path=abc,db=0,client_name=test-client"
         assert expected in repr(pool)
+
+    def test_initialise_pool_with_cache(self, master_host):
+        pool = redis.BlockingConnectionPool(
+            connection_class=Connection,
+            host=master_host[0],
+            port=master_host[1],
+            protocol=3,
+            cache_config=CacheConfig(),
+        )
+        assert isinstance(pool.get_connection("_"), CacheProxyConnection)
 
 
 class TestConnectionPoolURLParsing:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Because property initialised outside of constructor, it cannot be re-used in child class without calling another method

Closes #3459 
