### PR TITLE
Moved ClusterParser exceptions to BaseParser class

### DIFF
--- a/docs/clustering.rst
+++ b/docs/clustering.rst
@@ -17,8 +17,8 @@ Nodes <#specifying-target-nodes>`__ \| `Multi-key
 Commands <#multi-key-commands>`__ \| `Known PubSub
 Limitations <#known-pubsub-limitations>`__
 
-Creating clusters
------------------
+Connecting to cluster
+---------------------
 
 Connecting redis-py to a Redis Cluster instance(s) requires at a minimum
 a single node for cluster discovery. There are multiple ways in which a

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -20,7 +20,7 @@ from ..exceptions import (
     OutOfMemoryError,
     ReadOnlyError,
     RedisError,
-    ResponseError,
+    ResponseError, AskError, TryAgainError, MovedError, ClusterDownError, ClusterCrossSlotError, MasterDownError,
 )
 from ..typing import EncodableT
 from .encoders import Encoder
@@ -72,6 +72,12 @@ class BaseParser(ABC):
         "READONLY": ReadOnlyError,
         "NOAUTH": AuthenticationError,
         "NOPERM": NoPermissionError,
+        "ASK": AskError,
+        "TRYAGAIN": TryAgainError,
+        "MOVED": MovedError,
+        "CLUSTERDOWN": ClusterDownError,
+        "CROSSSLOT": ClusterCrossSlotError,
+        "MASTERDOWN": MasterDownError,
     }
 
     @classmethod

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -9,18 +9,24 @@ else:
     from async_timeout import timeout as async_timeout
 
 from ..exceptions import (
+    AskError,
     AuthenticationError,
     AuthenticationWrongNumberOfArgsError,
     BusyLoadingError,
+    ClusterCrossSlotError,
+    ClusterDownError,
     ConnectionError,
     ExecAbortError,
+    MasterDownError,
     ModuleError,
+    MovedError,
     NoPermissionError,
     NoScriptError,
     OutOfMemoryError,
     ReadOnlyError,
     RedisError,
-    ResponseError, AskError, TryAgainError, MovedError, ClusterDownError, ClusterCrossSlotError, MasterDownError,
+    ResponseError,
+    TryAgainError,
 )
 from ..typing import EncodableT
 from .encoders import Encoder

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -64,12 +64,7 @@ from redis.exceptions import (
     TryAgainError,
 )
 from redis.typing import AnyKeyT, EncodableT, KeyT
-from redis.utils import (
-    deprecated_function,
-    get_lib_version,
-    safe_str,
-    str_if_bytes,
-)
+from redis.utils import deprecated_function, get_lib_version, safe_str, str_if_bytes
 
 TargetNodesT = TypeVar(
     "TargetNodesT", str, "ClusterNode", List["ClusterNode"], Dict[Any, "ClusterNode"]

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -26,7 +26,7 @@ from redis._parsers.helpers import (
     _RedisCallbacksRESP3,
 )
 from redis.asyncio.client import ResponseCallbackT
-from redis.asyncio.connection import Connection, DefaultParser, SSLConnection, parse_url
+from redis.asyncio.connection import Connection, SSLConnection, parse_url
 from redis.asyncio.lock import Lock
 from redis.asyncio.retry import Retry
 from redis.auth.token import TokenInterface
@@ -50,12 +50,10 @@ from redis.event import AfterAsyncClusterInstantiationEvent, EventDispatcher
 from redis.exceptions import (
     AskError,
     BusyLoadingError,
-    ClusterCrossSlotError,
     ClusterDownError,
     ClusterError,
     ConnectionError,
     DataError,
-    MasterDownError,
     MaxConnectionsError,
     MovedError,
     RedisClusterException,
@@ -68,7 +66,6 @@ from redis.exceptions import (
 from redis.typing import AnyKeyT, EncodableT, KeyT
 from redis.utils import (
     deprecated_function,
-    dict_merge,
     get_lib_version,
     safe_str,
     str_if_bytes,

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -79,20 +79,6 @@ TargetNodesT = TypeVar(
 )
 
 
-class ClusterParser(DefaultParser):
-    EXCEPTION_CLASSES = dict_merge(
-        DefaultParser.EXCEPTION_CLASSES,
-        {
-            "ASK": AskError,
-            "CLUSTERDOWN": ClusterDownError,
-            "CROSSSLOT": ClusterCrossSlotError,
-            "MASTERDOWN": MasterDownError,
-            "MOVED": MovedError,
-            "TRYAGAIN": TryAgainError,
-        },
-    )
-
-
 class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommands):
     """
     Create a new RedisCluster client.
@@ -297,7 +283,6 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         kwargs: Dict[str, Any] = {
             "max_connections": max_connections,
             "connection_class": Connection,
-            "parser_class": ClusterParser,
             # Client related kwargs
             "credential_provider": credential_provider,
             "username": username,

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -193,20 +193,6 @@ def cleanup_kwargs(**kwargs):
     return connection_kwargs
 
 
-class ClusterParser(DefaultParser):
-    EXCEPTION_CLASSES = dict_merge(
-        DefaultParser.EXCEPTION_CLASSES,
-        {
-            "ASK": AskError,
-            "TRYAGAIN": TryAgainError,
-            "MOVED": MovedError,
-            "CLUSTERDOWN": ClusterDownError,
-            "CROSSSLOT": ClusterCrossSlotError,
-            "MASTERDOWN": MasterDownError,
-        },
-    )
-
-
 class AbstractRedisCluster:
     RedisClusterRequestTTL = 16
 
@@ -692,7 +678,6 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         Initialize the connection, authenticate and select a database and send
          READONLY if it is set during object initialization.
         """
-        connection.set_parser(ClusterParser)
         connection.on_connect()
 
         if self.read_from_replicas:

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -13,7 +13,7 @@ from redis.cache import CacheConfig, CacheFactory, CacheFactoryInterface, CacheI
 from redis.client import CaseInsensitiveDict, PubSub, Redis
 from redis.commands import READ_COMMANDS, RedisClusterCommands
 from redis.commands.helpers import list_or_args
-from redis.connection import ConnectionPool, DefaultParser, parse_url
+from redis.connection import ConnectionPool, parse_url
 from redis.crc import REDIS_CLUSTER_HASH_SLOTS, key_slot
 from redis.event import (
     AfterPooledConnectionsInstantiationEvent,
@@ -24,12 +24,10 @@ from redis.event import (
 from redis.exceptions import (
     AskError,
     AuthenticationError,
-    ClusterCrossSlotError,
     ClusterDownError,
     ClusterError,
     ConnectionError,
     DataError,
-    MasterDownError,
     MovedError,
     RedisClusterException,
     RedisError,


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

If RESP3 is enabled, the ClusterParser becomes immediately overridden with _RESP3Parser which leads to the fact that all additional exceptions isn't handled by cluster implementation.

ClusterParser class shouldn't exist and inherit other parsers just to extend a list of exceptions that should be associated with given error codes. Parsing errors and associate them to exception classes is a responsibility of parsers itself regardless of server topology, potentially you could get any error code as a response from server and parser should be aware of it.
