### PR TITLE
Fix invalid return type annotation

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -672,7 +672,7 @@ class AbstractConnection(ConnectionInterface):
             output.append(SYM_EMPTY.join(pieces))
         return output
 
-    def get_protocol(self) -> int or str:
+    def get_protocol(self) -> Union[int, str]:
         return self.protocol
 
     @property


### PR DESCRIPTION
`or` cannot be used in type annotations, `Union[]` or `|` should be used instead depending on the python version