### PR TITLE
DOC-4796 fixed capped lists example

### DIFF
--- a/doctests/dt_list.py
+++ b/doctests/dt_list.py
@@ -165,20 +165,20 @@ assert res26 is None
 # REMOVE_END
 
 # STEP_START ltrim
-res27 = r.lpush("bikes:repairs", "bike:1", "bike:2", "bike:3", "bike:4", "bike:5")
+res27 = r.rpush("bikes:repairs", "bike:1", "bike:2", "bike:3", "bike:4", "bike:5")
 print(res27)  # >>> 5
 
 res28 = r.ltrim("bikes:repairs", 0, 2)
 print(res28)  # >>> True
 
 res29 = r.lrange("bikes:repairs", 0, -1)
-print(res29)  # >>> ['bike:5', 'bike:4', 'bike:3']
+print(res29)  # >>> ['bike:1', 'bike:2', 'bike:3']
 # STEP_END
 
 # REMOVE_START
 assert res27 == 5
 assert res28 is True
-assert res29 == ["bike:5", "bike:4", "bike:3"]
+assert res29 == ["bike:1", "bike:2", "bike:3"]
 r.delete("bikes:repairs")
 # REMOVE_END
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

[DOC-4796](https://redislabs.atlassian.net/browse/DOC-4796)

Fix the [capped lists](https://redis.io/docs/latest/develop/data-types/lists/#capped-lists) example to use `RPUSH`, like the CLI version.


[DOC-4796]: https://redislabs.atlassian.net/browse/DOC-4796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ