### PR TITLE
Add return type to `close` functions

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -550,7 +550,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
     def __del__(self):
         self.close()
 
-    def close(self):
+    def close(self) -> None:
         # In case a connection property does not yet exist
         # (due to a crash earlier in the Redis() constructor), return
         # immediately as there is nothing to clean-up.
@@ -1551,7 +1551,6 @@ class Pipeline(Redis):
             conn.retry_on_error is None
             or isinstance(error, tuple(conn.retry_on_error)) is False
         ):
-
             self.reset()
             raise error
 

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1227,7 +1227,7 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
 
         raise ClusterError("TTL exhausted.")
 
-    def close(self):
+    def close(self) -> None:
         try:
             with self._lock:
                 if self.nodes_manager:
@@ -1669,7 +1669,7 @@ class NodesManager:
         # If initialize was called after a MovedError, clear it
         self._moved_exception = None
 
-    def close(self):
+    def close(self) -> None:
         self.default_node = None
         for node in self.nodes_cache.values():
             if node.redis_connection:


### PR DESCRIPTION
Another one 😊

I'm doing these PRs so people using strict mypy don't get this error:

```
error: Call to untyped function "from_url" of "ConnectionPool" in typed context  [no-untyped-call]
```