### PR TITLE
Adding deprecation messages for the exposed in search module commands: FT.INFO, just for async client: FT.CONFIG GET and FT.CONFIG SET

### DIFF
--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -442,6 +442,10 @@ class SearchCommands:
 
         return self.execute_command(MGET_CMD, self.index_name, *ids)
 
+    @deprecated_function(
+        version="8.0.0",
+        reason="deprecated since Redis 8.0, call info from core module instead",
+    )
     def info(self):
         """
         Get info an stats about the the current index, including the number of
@@ -912,6 +916,10 @@ class SearchCommands:
 
 
 class AsyncSearchCommands(SearchCommands):
+    @deprecated_function(
+        version="8.0.0",
+        reason="deprecated since Redis 8.0, call info from core module instead",
+    )
     async def info(self):
         """
         Get info an stats about the the current index, including the number of
@@ -1015,6 +1023,10 @@ class AsyncSearchCommands(SearchCommands):
 
         return self._parse_results(SPELLCHECK_CMD, res)
 
+    @deprecated_function(
+        version="8.0.0",
+        reason="deprecated since Redis 8.0, call config_set from core module instead",
+    )
     async def config_set(self, option: str, value: str) -> bool:
         """Set runtime configuration option.
 
@@ -1029,6 +1041,10 @@ class AsyncSearchCommands(SearchCommands):
         raw = await self.execute_command(*cmd)
         return raw == "OK"
 
+    @deprecated_function(
+        version="8.0.0",
+        reason="deprecated since Redis 8.0, call config_get from core module instead",
+    )
     async def config_get(self, option: str) -> str:
         """Get runtime configuration option value.
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Adding deprecation messages for the exposed in search module commands: FT.INFO, just for async client: FT.CONFIG GET and FT.CONFIG SET
