### PR TITLE
Replacing the redis and redis-stack-server images with redis-libs-tests image in test infrastructure

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Setup Test environment
       env:
         REDIS_VERSION: ${{ inputs.redis-version }}
-        CLIENT_LIBS_TEST_IMAGE: "redislabs/client-libs-test:${{ inputs.redis-version }}"
+        CLIENT_LIBS_TEST_IMAGE_TAG: ${{ inputs.redis-version }}
       run: |
         set -e
                 
@@ -55,13 +55,13 @@ runs:
         
           # Mapping of redis version to stack version  
           declare -A redis_stack_version_mapping=(
-            ["7.4.2"]="7.4.0-v2"
-            ["7.2.7"]="7.2.0-v14"
-            ["6.2.17"]="6.2.6-v18"
+            ["7.4.2"]="rs-7.4.0-v2"
+            ["7.2.7"]="rs-7.2.0-v14"
+            ["6.2.17"]="rs-6.2.6-v18"
           )
                   
           if [[ -v redis_stack_version_mapping[$REDIS_VERSION] ]]; then
-            export REDIS_STACK_IMAGE="redis/redis-stack-server:${redis_stack_version_mapping[$REDIS_VERSION]}"
+            export CLIENT_LIBS_TEST_STACK_IMAGE_TAG=${redis_stack_version_mapping[$REDIS_VERSION]}
             echo "REDIS_MOD_URL=redis://127.0.0.1:6479/0" >> $GITHUB_ENV
           else
             echo "Version not found in the mapping."

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -31,14 +31,9 @@ runs:
     - name: Setup Test environment
       env:
         REDIS_VERSION: ${{ inputs.redis-version }}
-        REDIS_IMAGE: "redis:${{ inputs.redis-version }}"
         CLIENT_LIBS_TEST_IMAGE: "redislabs/client-libs-test:${{ inputs.redis-version }}"
       run: |
         set -e
-        
-        if [ "${{inputs.redis-version}}" == "8.0-M04-pre" ]; then
-          export REDIS_IMAGE=redis:8.0-M03
-        fi
                 
         echo "::group::Installing dependencies"
         pip install -U setuptools wheel

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,7 +27,7 @@ env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   # this speeds up coverage with Python 3.12: https://github.com/nedbat/coveragepy/issues/1665
   COVERAGE_CORE: sysmon
-  REDIS_STACK_IMAGE: redis/redis-stack-server:latest
+  CLIENT_LIBS_TEST_STACK_IMAGE_TAG: 'rs-7.4.0-v2'
   CURRENT_REDIS_VERSION: '7.4.2'
 
 jobs:
@@ -180,7 +180,7 @@ jobs:
       - name: Run installed unit tests
         env:
           REDIS_VERSION: ${{ env.CURRENT_REDIS_VERSION }}
-          CLIENT_LIBS_TEST_IMAGE: "redislabs/client-libs-test:${{ env.CURRENT_REDIS_VERSION }}"
+          CLIENT_LIBS_TEST_IMAGE_TAG: ${{ env.CURRENT_REDIS_VERSION }}
         run: |
           bash .github/workflows/install_and_test.sh ${{ matrix.extension }}
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,7 +27,6 @@ env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   # this speeds up coverage with Python 3.12: https://github.com/nedbat/coveragepy/issues/1665
   COVERAGE_CORE: sysmon
-  REDIS_IMAGE: redis:latest
   REDIS_STACK_IMAGE: redis/redis-stack-server:latest
   CURRENT_REDIS_VERSION: '7.4.2'
 
@@ -181,7 +180,6 @@ jobs:
       - name: Run installed unit tests
         env:
           REDIS_VERSION: ${{ env.CURRENT_REDIS_VERSION }}
-          REDIS_IMAGE: "redis:${{ env.CURRENT_REDIS_VERSION }}"
           CLIENT_LIBS_TEST_IMAGE: "redislabs/client-libs-test:${{ env.CURRENT_REDIS_VERSION }}"
         run: |
           bash .github/workflows/install_and_test.sh ${{ matrix.extension }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -179,7 +179,6 @@ jobs:
           python-version: 3.9
       - name: Run installed unit tests
         env:
-          REDIS_VERSION: ${{ env.CURRENT_REDIS_VERSION }}
           CLIENT_LIBS_TEST_IMAGE_TAG: ${{ env.CURRENT_REDIS_VERSION }}
           CLIENT_LIBS_TEST_STACK_IMAGE_TAG: ${{ env.CURRENT_CLIENT_LIBS_TEST_STACK_IMAGE_TAG }}
         run: |

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,7 +27,7 @@ env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   # this speeds up coverage with Python 3.12: https://github.com/nedbat/coveragepy/issues/1665
   COVERAGE_CORE: sysmon
-  CLIENT_LIBS_TEST_STACK_IMAGE_TAG: 'rs-7.4.0-v2'
+  CURRENT_CLIENT_LIBS_TEST_STACK_IMAGE_TAG: 'rs-7.4.0-v2'
   CURRENT_REDIS_VERSION: '7.4.2'
 
 jobs:
@@ -181,6 +181,7 @@ jobs:
         env:
           REDIS_VERSION: ${{ env.CURRENT_REDIS_VERSION }}
           CLIENT_LIBS_TEST_IMAGE_TAG: ${{ env.CURRENT_REDIS_VERSION }}
+          CLIENT_LIBS_TEST_STACK_IMAGE_TAG: ${{ env.CURRENT_CLIENT_LIBS_TEST_STACK_IMAGE_TAG }}
         run: |
           bash .github/workflows/install_and_test.sh ${{ matrix.extension }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ docker/stunnel/keys
 /dockers/cluster/
 /dockers/replica/
 /dockers/sentinel/
+/dockers/redis-stack/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ docker/stunnel/keys
 /dockers/*/tls/*
 /dockers/standalone/
 /dockers/cluster/
+/dockers/replica/
+/dockers/sentinel/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,13 +24,19 @@ services:
       - all
 
   replica:
-    image: ${REDIS_IMAGE:-redis:7.4.1}
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:7.4.1}
     container_name: redis-replica
     depends_on:
       - redis
-    command: redis-server --replicaof redis 6379 --protected-mode no --save ""
+    environment:
+      - TLS_ENABLED=no
+      - REDIS_CLUSTER=no
+      - PORT=6380
+    command: ${REDIS_EXTRA_ARGS:---enable-debug-command yes --replicaof redis 6379 --protected-mode no --save ""}
     ports:
-      - 6380:6379
+      - 6380:6380
+    volumes:
+      - "./dockers/replica:/redis/work"
     profiles:
       - replica
       - all-stack
@@ -58,45 +64,22 @@ services:
       - all
 
   sentinel:
-    image: ${REDIS_IMAGE:-redis:7.4.1}
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:7.4.1}
     container_name: redis-sentinel
     depends_on:
       - redis
-    entrypoint: "redis-sentinel /redis.conf --port 26379"
+    environment:
+      - REDIS_CLUSTER=no
+      - NODES=3
+      - PORT=26379
+    command: ${REDIS_EXTRA_ARGS:---sentinel}
     ports:
       - 26379:26379
-    volumes:
-      - "./dockers/sentinel.conf:/redis.conf"
-    profiles:
-      - sentinel
-      - all-stack
-      - all
-
-  sentinel2:
-    image: ${REDIS_IMAGE:-redis:7.4.1}
-    container_name: redis-sentinel2
-    depends_on:
-      - redis
-    entrypoint: "redis-sentinel /redis.conf --port 26380"
-    ports:
       - 26380:26380
-    volumes:
-      - "./dockers/sentinel.conf:/redis.conf"
-    profiles:
-      - sentinel
-      - all-stack
-      - all
-
-  sentinel3:
-    image: ${REDIS_IMAGE:-redis:7.4.1}
-    container_name: redis-sentinel3
-    depends_on:
-      - redis
-    entrypoint: "redis-sentinel /redis.conf --port 26381"
-    ports:
       - 26381:26381
     volumes:
-      - "./dockers/sentinel.conf:/redis.conf"
+      - "./dockers/sentinel.conf:/redis/config-default/redis.conf"
+      - "./dockers/sentinel:/redis/work"
     profiles:
       - sentinel
       - all-stack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
 ---
+x-client-libs-stack-image: &client-libs-stack-image
+  image: "redislabs/client-libs-test:${CLIENT_LIBS_TEST_STACK_IMAGE_TAG:-rs-7.4.0-v2}"
+
+x-client-libs-image: &client-libs-image
+  image: "redislabs/client-libs-test:${CLIENT_LIBS_TEST_IMAGE_TAG:-7.4.2}"
 
 services:
 
   redis:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:7.4.1}
+    <<: *client-libs-image
     container_name: redis-standalone
     environment:
       - TLS_ENABLED=yes
@@ -24,7 +29,7 @@ services:
       - all
 
   replica:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:7.4.1}
+    <<: *client-libs-image
     container_name: redis-replica
     depends_on:
       - redis
@@ -43,7 +48,7 @@ services:
       - all
 
   cluster:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:7.4.1}
+    <<: *client-libs-image
     container_name: redis-cluster
     environment:
       - REDIS_CLUSTER=yes
@@ -64,7 +69,7 @@ services:
       - all
 
   sentinel:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:7.4.1}
+    <<: *client-libs-image
     container_name: redis-sentinel
     depends_on:
       - redis
@@ -86,12 +91,16 @@ services:
       - all
 
   redis-stack:
-    image: ${REDIS_STACK_IMAGE:-redis/redis-stack-server:latest}
+    <<: *client-libs-stack-image
     container_name: redis-stack
+    environment:
+      - REDIS_CLUSTER=no
+      - PORT=6379
+    command: ${REDIS_EXTRA_ARGS:---enable-debug-command yes --enable-module-command yes --save ""}
     ports:
       - 6479:6379
-    environment:
-      - "REDIS_ARGS=${REDIS_STACK_EXTRA_ARGS:---enable-debug-command yes --enable-module-command yes --save ''}"
+    volumes:
+      - "./dockers/redis-stack:/redis/work"
     profiles:
       - standalone
       - all-stack

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords=["Redis", "key-value store", "database"],
     license="MIT",
-    version="5.1.1",
+    version="5.3.0",
     packages=find_packages(
         include=[
             "redis",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords=["Redis", "key-value store", "database"],
     license="MIT",
-    version="5.3.0",
+    version="5.2.1",
     packages=find_packages(
         include=[
             "redis",


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

* Replacing the `redis` and `redis-stack-server` images with the `redis-libs-tests` image in test infrastructure - change affects docker containers for redis-stack, replica and sentinel.
* Updating the version in setup.py to the current stable version (5.2.1)