### PR TITLE
Fix #3130 TimeoutError during ClusterPipeline makes the client unrecoverable

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -2185,7 +2185,7 @@ class ClusterPipeline(RedisCluster):
                     redis_node = self.get_redis_connection(node)
                     try:
                         connection = get_connection(redis_node, c.args)
-                    except ConnectionError:
+                    except (ConnectionError, TimeoutError):
                         for n in nodes.values():
                             n.connection_pool.release(n.connection)
                         # Connection retries are being handled in the node's


### PR DESCRIPTION
Fix https://github.com/redis/redis-py/issues/3130 by reinitializing the node slot table on TimeoutError while getting a connection inside a pipeline.