### PR TITLE
Add valid Exception type to Except in ClusterPipeline

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -2120,7 +2120,7 @@ class ClusterPipeline(RedisCluster):
                     raise_on_error=raise_on_error,
                     allow_redirections=allow_redirections,
                 )
-            except (ClusterDownError, ConnectionError) as e:
+            except RedisCluster.ERRORS_ALLOW_RETRY as e:
                 if retry_attempts > 0:
                     # Try again with the new cluster setup. All other errors
                     # should be raised.


### PR DESCRIPTION
First, thank you for the repo.

In a recent change in `ClusterPipeline`, `TimeoutError` has been added to reinitialize the nodes.
https://github.com/redis/redis-py/blob/799716c1c65dff90db2d36eb7ee185cbe51eb56a/redis/cluster.py#L2188
However, it's a nested `try-except` and the upper `except` should also contain `TimeoutError` in order to respect `cluster_error_retry_attempts`.
https://github.com/redis/redis-py/blob/799716c1c65dff90db2d36eb7ee185cbe51eb56a/redis/cluster.py#L2115
