### PR TITLE
WIP Harden the replicas check

### DIFF
--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -352,7 +352,9 @@ class TestRedisClusterObj:
         Test command execution with nodes flag PRIMARIES
         """
         primaries = r.get_primaries()
+        assert primaries
         replicas = r.get_replicas()
+        assert replicas
         mock_all_nodes_resp(r, "PONG")
         assert r.ping(target_nodes=RedisCluster.PRIMARIES) is True
         for primary in primaries:
@@ -1345,6 +1347,7 @@ class TestClusterRedisCommands:
     def test_cluster_replicate(self, r):
         node = r.get_random_node()
         all_replicas = r.get_replicas()
+        assert all_replicas
         mock_all_nodes_resp(r, "OK")
         assert r.cluster_replicate(node, "c8253bae761cb61857d") is True
         results = r.cluster_replicate(all_replicas, "c8253bae761cb61857d")


### PR DESCRIPTION
Harden the checks

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

On MacOS in the `get_replicas()` call returns empty list, even though the `cluster_nodes()` returns primaries and replicas and `RedisCluster` was created after the replicas negotiated with masters. This PR attempts to harden the checks, to make sure that replicas exist.
