### PR TITLE
Add force_master_ip support to async Sentinel client

### DIFF
--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -198,6 +198,7 @@ class Sentinel(AsyncSentinelCommands):
         sentinels,
         min_other_sentinels=0,
         sentinel_kwargs=None,
+        force_master_ip=None,
         **connection_kwargs,
     ):
         # if sentinel_kwargs isn't defined, use the socket_* options from
@@ -214,6 +215,7 @@ class Sentinel(AsyncSentinelCommands):
         ]
         self.min_other_sentinels = min_other_sentinels
         self.connection_kwargs = connection_kwargs
+        self._force_master_ip = force_master_ip
 
     async def execute_command(self, *args, **kwargs):
         """
@@ -277,7 +279,13 @@ class Sentinel(AsyncSentinelCommands):
                     sentinel,
                     self.sentinels[0],
                 )
-                return state["ip"], state["port"]
+
+                ip = (
+                    self._force_master_ip
+                    if self._force_master_ip is not None
+                    else state["ip"]
+                )
+                return ip, state["port"]
 
         error_info = ""
         if len(collected_errors) > 0:

--- a/tests/test_asyncio/conftest.py
+++ b/tests/test_asyncio/conftest.py
@@ -152,8 +152,10 @@ async def sentinel_setup(local_cache, request):
         for ip, port in (endpoint.split(":") for endpoint in sentinel_ips.split(","))
     ]
     kwargs = request.param.get("kwargs", {}) if hasattr(request, "param") else {}
+    force_master_ip = request.param.get("force_master_ip", None)
     sentinel = Sentinel(
         sentinel_endpoints,
+        force_master_ip=force_master_ip,
         socket_timeout=0.1,
         client_cache=local_cache,
         protocol=3,


### PR DESCRIPTION
### Description:

This PR adds support for the `force_master_ip` parameter to the async Sentinel client, mirroring the functionality available in the synchronous version. This allows users to override the master IP address returned by Sentinel, which is useful for local development or specific deployment scenarios.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
