### PR TITLE
feat: adds option not to raise exception when leaving context manager after lock expiration

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -478,6 +478,7 @@ class Redis(
         blocking_timeout: Optional[float] = None,
         lock_class: Optional[Type[Lock]] = None,
         thread_local: bool = True,
+        raise_on_release_error: bool = True,
     ) -> Lock:
         """
         Return a new Lock object using key ``name`` that mimics
@@ -524,6 +525,11 @@ class Redis(
                      thread-1 would see the token value as "xyz" and would be
                      able to successfully release the thread-2's lock.
 
+        ``raise_on_release_error`` indicates whether to raise an exception when
+        the lock is no longer owned when exiting the context manager. By default,
+        this is True, meaning an exception will be raised. If False, the warning
+        will be logged and the exception will be suppressed.
+
         In some use cases it's necessary to disable thread local storage. For
         example, if you have code where one thread acquires a lock and passes
         that lock instance to a worker thread to release later. If thread
@@ -541,6 +547,7 @@ class Redis(
             blocking=blocking,
             blocking_timeout=blocking_timeout,
             thread_local=thread_local,
+            raise_on_release_error=raise_on_release_error,
         )
 
     def pubsub(self, **kwargs) -> "PubSub":

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -839,6 +839,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         blocking_timeout: Optional[float] = None,
         lock_class: Optional[Type[Lock]] = None,
         thread_local: bool = True,
+        raise_on_release_error: bool = True,
     ) -> Lock:
         """
         Return a new Lock object using key ``name`` that mimics
@@ -885,6 +886,11 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
                      thread-1 would see the token value as "xyz" and would be
                      able to successfully release the thread-2's lock.
 
+        ``raise_on_release_error`` indicates whether to raise an exception when
+        the lock is no longer owned when exiting the context manager. By default,
+        this is True, meaning an exception will be raised. If False, the warning
+        will be logged and the exception will be suppressed.
+
         In some use cases it's necessary to disable thread local storage. For
         example, if you have code where one thread acquires a lock and passes
         that lock instance to a worker thread to release later. If thread
@@ -902,6 +908,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             blocking=blocking,
             blocking_timeout=blocking_timeout,
             thread_local=thread_local,
+            raise_on_release_error=raise_on_release_error,
         )
 
 

--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -178,7 +178,9 @@ class Lock:
         except LockError:
             if self.raise_on_release_error:
                 raise
-            logger.warning("Lock was unlocked or no longer owned when exiting context manager.")
+            logger.warning(
+                "Lock was unlocked or no longer owned when exiting context manager."
+            )
 
     async def acquire(
         self,

--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -179,6 +179,10 @@ class Lock:
             if self.raise_on_release_error:
                 raise
             logger.warning("Lock was no longer owned when exiting context manager.")
+        except LockError:
+            if self.raise_on_release_error:
+                raise
+            logger.warning("Lock was unlocked when exiting context manager.")
 
     async def acquire(
         self,

--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 import uuid
+import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Awaitable, Optional, Union
 
@@ -9,6 +10,8 @@ from redis.typing import Number
 
 if TYPE_CHECKING:
     from redis.asyncio import Redis, RedisCluster
+
+logger = logging.getLogger(__name__)
 
 
 class Lock:
@@ -85,6 +88,7 @@ class Lock:
         blocking: bool = True,
         blocking_timeout: Optional[Number] = None,
         thread_local: bool = True,
+        raise_on_release_error: bool = True,
     ):
         """
         Create a new Lock instance named ``name`` using the Redis client
@@ -127,6 +131,11 @@ class Lock:
                      token is *not* stored in thread local storage, then
                      thread-1 would see the token value as "xyz" and would be
                      able to successfully release the thread-2's lock.
+        
+        ``raise_on_release_error`` indicates whether to raise an exception when
+        the lock is no longer owned when exiting the context manager. By default,
+        this is True, meaning an exception will be raised. If False, the warning
+        will be logged and the exception will be suppressed.
 
         In some use cases it's necessary to disable thread local storage. For
         example, if you have code where one thread acquires a lock and passes
@@ -144,6 +153,7 @@ class Lock:
         self.blocking_timeout = blocking_timeout
         self.thread_local = bool(thread_local)
         self.local = threading.local() if self.thread_local else SimpleNamespace()
+        self.raise_on_release_error = raise_on_release_error
         self.local.token = None
         self.register_scripts()
 
@@ -163,7 +173,13 @@ class Lock:
         raise LockError("Unable to acquire lock within the time specified")
 
     async def __aexit__(self, exc_type, exc_value, traceback):
-        await self.release()
+        try:
+            await self.release()
+        except LockNotOwnedError as e:
+            if self.raise_on_release_error:
+                raise e
+            logger.warning("Lock was no longer owned when exiting context manager.")
+
 
     async def acquire(
         self,

--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -177,7 +177,7 @@ class Lock:
             await self.release()
         except LockNotOwnedError as e:
             if self.raise_on_release_error:
-                raise e
+                raise
             logger.warning("Lock was no longer owned when exiting context manager.")
 
 

--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -175,14 +175,10 @@ class Lock:
     async def __aexit__(self, exc_type, exc_value, traceback):
         try:
             await self.release()
-        except LockNotOwnedError:
-            if self.raise_on_release_error:
-                raise
-            logger.warning("Lock was no longer owned when exiting context manager.")
         except LockError:
             if self.raise_on_release_error:
                 raise
-            logger.warning("Lock was unlocked when exiting context manager.")
+            logger.warning("Lock was unlocked or no longer owned when exiting context manager.")
 
     async def acquire(
         self,

--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -1,7 +1,7 @@
 import asyncio
+import logging
 import threading
 import uuid
-import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Awaitable, Optional, Union
 

--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -131,7 +131,7 @@ class Lock:
                      token is *not* stored in thread local storage, then
                      thread-1 would see the token value as "xyz" and would be
                      able to successfully release the thread-2's lock.
-        
+
         ``raise_on_release_error`` indicates whether to raise an exception when
         the lock is no longer owned when exiting the context manager. By default,
         this is True, meaning an exception will be raised. If False, the warning
@@ -175,11 +175,10 @@ class Lock:
     async def __aexit__(self, exc_type, exc_value, traceback):
         try:
             await self.release()
-        except LockNotOwnedError as e:
+        except LockNotOwnedError:
             if self.raise_on_release_error:
                 raise
             logger.warning("Lock was no longer owned when exiting context manager.")
-
 
     async def acquire(
         self,

--- a/redis/client.py
+++ b/redis/client.py
@@ -473,6 +473,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         blocking_timeout: Optional[float] = None,
         lock_class: Union[None, Any] = None,
         thread_local: bool = True,
+        raise_on_release_error: bool = True,
     ):
         """
         Return a new Lock object using key ``name`` that mimics
@@ -519,6 +520,11 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                      thread-1 would see the token value as "xyz" and would be
                      able to successfully release the thread-2's lock.
 
+        ``raise_on_release_error`` indicates whether to raise an exception when
+        the lock is no longer owned when exiting the context manager. By default,
+        this is True, meaning an exception will be raised. If False, the warning
+        will be logged and the exception will be suppressed.
+
         In some use cases it's necessary to disable thread local storage. For
         example, if you have code where one thread acquires a lock and passes
         that lock instance to a worker thread to release later. If thread
@@ -536,6 +542,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             blocking=blocking,
             blocking_timeout=blocking_timeout,
             thread_local=thread_local,
+            raise_on_release_error=raise_on_release_error,
         )
 
     def pubsub(self, **kwargs):

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -822,6 +822,7 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
         blocking_timeout=None,
         lock_class=None,
         thread_local=True,
+        raise_on_release_error: bool = True,
     ):
         """
         Return a new Lock object using key ``name`` that mimics
@@ -868,6 +869,11 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
                      thread-1 would see the token value as "xyz" and would be
                      able to successfully release the thread-2's lock.
 
+        ``raise_on_release_error`` indicates whether to raise an exception when
+        the lock is no longer owned when exiting the context manager. By default,
+        this is True, meaning an exception will be raised. If False, the warning
+        will be logged and the exception will be suppressed.
+
         In some use cases it's necessary to disable thread local storage. For
         example, if you have code where one thread acquires a lock and passes
         that lock instance to a worker thread to release later. If thread
@@ -885,6 +891,7 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
             blocking=blocking,
             blocking_timeout=blocking_timeout,
             thread_local=thread_local,
+            raise_on_release_error=raise_on_release_error,
         )
 
     def set_response_callback(self, command, callback):

--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -89,7 +89,7 @@ class LockError(RedisError, ValueError):
 
 
 class LockNotOwnedError(LockError):
-    "Error trying to extend or release a lock that is (no longer) owned"
+    "Error trying to extend or release a lock that is not owned (anymore)"
 
     pass
 

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -184,6 +184,10 @@ class Lock:
             if self.raise_on_release_error:
                 raise
             logger.warning("Lock was no longer owned when exiting context manager.")
+        except LockError:
+            if self.raise_on_release_error:
+                raise
+            logger.warning("Lock was unlocked when exiting context manager.")
 
     def acquire(
         self,

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -183,7 +183,9 @@ class Lock:
         except LockError:
             if self.raise_on_release_error:
                 raise
-            logger.warning("Lock was unlocked or no longer owned when exiting context manager.")
+            logger.warning(
+                "Lock was unlocked or no longer owned when exiting context manager."
+            )
 
     def acquire(
         self,

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -1,11 +1,14 @@
 import threading
 import time as mod_time
 import uuid
+import logging
 from types import SimpleNamespace, TracebackType
 from typing import Optional, Type
 
 from redis.exceptions import LockError, LockNotOwnedError
 from redis.typing import Number
+
+logger = logging.getLogger(__name__)
 
 
 class Lock:
@@ -82,6 +85,7 @@ class Lock:
         blocking: bool = True,
         blocking_timeout: Optional[Number] = None,
         thread_local: bool = True,
+        raise_on_release_error: bool = True,
     ):
         """
         Create a new Lock instance named ``name`` using the Redis client
@@ -125,6 +129,11 @@ class Lock:
                      thread-1 would see the token value as "xyz" and would be
                      able to successfully release the thread-2's lock.
 
+        ``raise_on_release_error`` indicates whether to raise an exception when
+        the lock is no longer owned when exiting the context manager. By default,
+        this is True, meaning an exception will be raised. If False, the warning
+        will be logged and the exception will be suppressed.
+
         In some use cases it's necessary to disable thread local storage. For
         example, if you have code where one thread acquires a lock and passes
         that lock instance to a worker thread to release later. If thread
@@ -140,6 +149,7 @@ class Lock:
         self.blocking = blocking
         self.blocking_timeout = blocking_timeout
         self.thread_local = bool(thread_local)
+        self.raise_on_release_error = raise_on_release_error
         self.local = threading.local() if self.thread_local else SimpleNamespace()
         self.local.token = None
         self.register_scripts()
@@ -168,7 +178,12 @@ class Lock:
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:
-        self.release()
+        try:
+            self.release()
+        except LockNotOwnedError as e:
+            if self.raise_on_release_error:
+                raise e
+            logger.warning("Lock was no longer owned when exiting context manager.")
 
     def acquire(
         self,

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -180,9 +180,9 @@ class Lock:
     ) -> None:
         try:
             self.release()
-        except LockNotOwnedError as e:
+        except LockNotOwnedError:
             if self.raise_on_release_error:
-                raise e
+                raise
             logger.warning("Lock was no longer owned when exiting context manager.")
 
     def acquire(

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -180,14 +180,10 @@ class Lock:
     ) -> None:
         try:
             self.release()
-        except LockNotOwnedError:
-            if self.raise_on_release_error:
-                raise
-            logger.warning("Lock was no longer owned when exiting context manager.")
         except LockError:
             if self.raise_on_release_error:
                 raise
-            logger.warning("Lock was unlocked when exiting context manager.")
+            logger.warning("Lock was unlocked or no longer owned when exiting context manager.")
 
     def acquire(
         self,

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -1,7 +1,7 @@
+import logging
 import threading
 import time as mod_time
 import uuid
-import logging
 from types import SimpleNamespace, TracebackType
 from typing import Optional, Type
 

--- a/tests/test_asyncio/test_lock.py
+++ b/tests/test_asyncio/test_lock.py
@@ -129,7 +129,7 @@ class TestLock:
             async with self.get_lock(r, "foo", blocking_timeout=0.1):
                 pass
 
-    async def test_context_manager_not_raise_on_release_error(self, r):
+    async def test_context_manager_not_raise_on_release_lock_not_owned_error(self, r):
         try:
             async with self.get_lock(
                 r, "foo", timeout=0.1, raise_on_release_error=False
@@ -143,6 +143,21 @@ class TestLock:
                 r, "foo", timeout=0.1, raise_on_release_error=True
             ):
                 await asyncio.sleep(0.15)
+
+    async def test_context_manager_not_raise_on_release_lock_error(self, r):
+        try:
+            async with self.get_lock(
+                r, "foo", timeout=0.1, raise_on_release_error=False
+            ) as lock:
+                lock.release()
+        except LockError:
+            pytest.fail("LockError should not have been raised")
+
+        with pytest.raises(LockError):
+            async with self.get_lock(
+                r, "foo", timeout=0.1, raise_on_release_error=True
+            ) as lock:
+                lock.release()
 
     async def test_high_sleep_small_blocking_timeout(self, r):
         lock1 = self.get_lock(r, "foo")

--- a/tests/test_asyncio/test_lock.py
+++ b/tests/test_asyncio/test_lock.py
@@ -129,6 +129,21 @@ class TestLock:
             async with self.get_lock(r, "foo", blocking_timeout=0.1):
                 pass
 
+    async def test_context_manager_not_raise_on_release_error(self, r):
+        try:
+            async with self.get_lock(
+                r, "foo", timeout=0.1, raise_on_release_error=False
+            ):
+                await asyncio.sleep(0.15)
+        except LockNotOwnedError:
+            pytest.fail("LockNotOwnedError should not have been raised")
+
+        with pytest.raises(LockNotOwnedError):
+            async with self.get_lock(
+                r, "foo", timeout=0.1, raise_on_release_error=True
+            ):
+                await asyncio.sleep(0.15)
+
     async def test_high_sleep_small_blocking_timeout(self, r):
         lock1 = self.get_lock(r, "foo")
         assert await lock1.acquire(blocking=False)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -133,6 +133,21 @@ class TestLock:
             with self.get_lock(r, "foo", blocking_timeout=0.1):
                 pass
 
+    def test_context_manager_not_raise_on_release_error(self, r):
+        try:
+            with self.get_lock(
+                r, "foo", timeout=0.1, raise_on_release_error=False
+            ):
+                time.sleep(0.15)
+        except LockNotOwnedError:
+            pytest.fail("LockNotOwnedError should not have been raised")
+
+        with pytest.raises(LockNotOwnedError):
+            with self.get_lock(
+                r, "foo", timeout=0.1, raise_on_release_error=True
+            ):
+                time.sleep(0.15)
+
     def test_high_sleep_small_blocking_timeout(self, r):
         lock1 = self.get_lock(r, "foo")
         assert lock1.acquire(blocking=False)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -135,17 +135,13 @@ class TestLock:
 
     def test_context_manager_not_raise_on_release_error(self, r):
         try:
-            with self.get_lock(
-                r, "foo", timeout=0.1, raise_on_release_error=False
-            ):
+            with self.get_lock(r, "foo", timeout=0.1, raise_on_release_error=False):
                 time.sleep(0.15)
         except LockNotOwnedError:
             pytest.fail("LockNotOwnedError should not have been raised")
 
         with pytest.raises(LockNotOwnedError):
-            with self.get_lock(
-                r, "foo", timeout=0.1, raise_on_release_error=True
-            ):
+            with self.get_lock(r, "foo", timeout=0.1, raise_on_release_error=True):
                 time.sleep(0.15)
 
     def test_high_sleep_small_blocking_timeout(self, r):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -133,7 +133,7 @@ class TestLock:
             with self.get_lock(r, "foo", blocking_timeout=0.1):
                 pass
 
-    def test_context_manager_not_raise_on_release_error(self, r):
+    def test_context_manager_not_raise_on_release_lock_not_owned_error(self, r):
         try:
             with self.get_lock(r, "foo", timeout=0.1, raise_on_release_error=False):
                 time.sleep(0.15)
@@ -143,6 +143,21 @@ class TestLock:
         with pytest.raises(LockNotOwnedError):
             with self.get_lock(r, "foo", timeout=0.1, raise_on_release_error=True):
                 time.sleep(0.15)
+
+    def test_context_manager_not_raise_on_release_lock_error(self, r):
+        try:
+            with self.get_lock(
+                r, "foo", timeout=0.1, raise_on_release_error=False
+            ) as lock:
+                lock.release()
+        except LockError:
+            pytest.fail("LockError should not have been raised")
+
+        with pytest.raises(LockError):
+            with self.get_lock(
+                r, "foo", timeout=0.1, raise_on_release_error=True
+            ) as lock:
+                lock.release()
 
     def test_high_sleep_small_blocking_timeout(self, r):
         lock1 = self.get_lock(r, "foo")


### PR DESCRIPTION
Fixes: #3532 

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

I was having trouble using async locks with the context manager because it was failing when exiting the context manager after timeout had expired (even if my code executed successfully).

I would really like not to raise a `LockNotOwnedError` in the exit of the context manager (if I try to release a lock and it was already "released" then great!).

I understand just changing the behavior would be critical, so I added an option to just behave this way when desired instead.

Issue: #3532 