### PR TITLE
Got rid of `time.time()` everywhere

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -950,7 +950,7 @@ class PubSub:
                 "did you forget to call subscribe() or psubscribe()?"
             )
 
-        if conn.health_check_interval and time.time() > conn.next_health_check:
+        if conn.health_check_interval and time.monotonic() > conn.next_health_check:
             conn.send_command("PING", self.HEALTH_CHECK_MESSAGE, check_health=False)
             self.health_check_response_counter += 1
 
@@ -1100,12 +1100,12 @@ class PubSub:
         """
         if not self.subscribed:
             # Wait for subscription
-            start_time = time.time()
+            start_time = time.monotonic()
             if self.subscribed_event.wait(timeout) is True:
                 # The connection was subscribed during the timeout time frame.
                 # The timeout should be adjusted based on the time spent
                 # waiting for the subscription
-                time_spent = time.time() - start_time
+                time_spent = time.monotonic() - start_time
                 timeout = max(0.0, timeout - time_spent)
             else:
                 # The connection isn't subscribed to any channels or patterns,

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -500,7 +500,7 @@ class SearchCommands:
         For more information see `FT.SEARCH <https://redis.io/commands/ft.search>`_.
         """  # noqa
         args, query = self._mk_query_args(query, query_params=query_params)
-        st = time.time()
+        st = time.monotonic()
 
         options = {}
         if get_protocol_version(self.client) not in ["3", 3]:
@@ -512,7 +512,7 @@ class SearchCommands:
             return res
 
         return self._parse_results(
-            SEARCH_CMD, res, query=query, duration=(time.time() - st) * 1000.0
+            SEARCH_CMD, res, query=query, duration=(time.monotonic() - st) * 1000.0
         )
 
     def explain(
@@ -602,7 +602,7 @@ class SearchCommands:
         Each parameter has a name and a value.
 
         """
-        st = time.time()
+        st = time.monotonic()
         cmd = [PROFILE_CMD, self.index_name, ""]
         if limited:
             cmd.append("LIMITED")
@@ -621,7 +621,7 @@ class SearchCommands:
         res = self.execute_command(*cmd)
 
         return self._parse_results(
-            PROFILE_CMD, res, query=query, duration=(time.time() - st) * 1000.0
+            PROFILE_CMD, res, query=query, duration=(time.monotonic() - st) * 1000.0
         )
 
     def spellcheck(self, query, distance=None, include=None, exclude=None):
@@ -940,7 +940,7 @@ class AsyncSearchCommands(SearchCommands):
         For more information see `FT.SEARCH <https://redis.io/commands/ft.search>`_.
         """  # noqa
         args, query = self._mk_query_args(query, query_params=query_params)
-        st = time.time()
+        st = time.monotonic()
 
         options = {}
         if get_protocol_version(self.client) not in ["3", 3]:
@@ -952,7 +952,7 @@ class AsyncSearchCommands(SearchCommands):
             return res
 
         return self._parse_results(
-            SEARCH_CMD, res, query=query, duration=(time.time() - st) * 1000.0
+            SEARCH_CMD, res, query=query, duration=(time.monotonic() - st) * 1000.0
         )
 
     async def aggregate(

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -4,11 +4,11 @@ import socket
 import ssl
 import sys
 import threading
+import time
 import weakref
 from abc import abstractmethod
 from itertools import chain
 from queue import Empty, Full, LifoQueue
-from time import time
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 from urllib.parse import parse_qs, unquote, urlparse
 
@@ -542,7 +542,7 @@ class AbstractConnection(ConnectionInterface):
 
     def check_health(self):
         """Check the health of the connection with a PING/PONG"""
-        if self.health_check_interval and time() > self.next_health_check:
+        if self.health_check_interval and time.monotonic() > self.next_health_check:
             self.retry.call_with_retry(self._send_ping, self._ping_failed)
 
     def send_packed_command(self, command, check_health=True):
@@ -632,7 +632,7 @@ class AbstractConnection(ConnectionInterface):
             raise
 
         if self.health_check_interval:
-            self.next_health_check = time() + self.health_check_interval
+            self.next_health_check = time.monotonic() + self.health_check_interval
 
         if isinstance(response, ResponseError):
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,7 +237,7 @@ def wait_for_cluster_creation(redis_url, cluster_nodes, timeout=60):
     :param cluster_nodes: The number of nodes in the cluster
     :param timeout: the amount of time to wait (in seconds)
     """
-    now = time.time()
+    now = time.monotonic()
     end_time = now + timeout
     client = None
     print(f"Waiting for {cluster_nodes} cluster nodes to become available")
@@ -250,7 +250,7 @@ def wait_for_cluster_creation(redis_url, cluster_nodes, timeout=60):
         except RedisClusterException:
             pass
         time.sleep(1)
-        now = time.time()
+        now = time.monotonic()
     if now >= end_time:
         available_nodes = 0 if client is None else len(client.get_nodes())
         raise RedisClusterException(

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -23,7 +23,7 @@ from .conftest import (
 def wait_for_message(
     pubsub, timeout=0.5, ignore_subscribe_messages=False, node=None, func=None
 ):
-    now = time.time()
+    now = time.monotonic()
     timeout = now + timeout
     while now < timeout:
         if node:
@@ -39,7 +39,7 @@ def wait_for_message(
         if message is not None:
             return message
         time.sleep(0.01)
-        now = time.time()
+        now = time.monotonic()
     return None
 
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Made time calculations more stable, in library itself and in tests as well.