### PR TITLE
Increasing the operations-per-run for stale issues GH action

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -21,5 +21,5 @@ jobs:
         days-before-close: 30
         stale-issue-label: "Stale"
         stale-pr-label: "Stale"
-        operations-per-run: 10
+        operations-per-run: 20
         remove-stale-when-updated: true


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Current configuration is able to cover the following issues and PRs:
Processed items: 132
├── Processed issues: 95
└── Processed PRs   : 37

As a result lots of issues marked as stale are not closed by the automated actions.
We can still increase a lot more, but as a start, I prefer to double the ops per run and check if it will be enough  (Github API rate used: 10
Github API rate remaining: 14989)