### PR TITLE
Fixing search module dropindex function not to send invalid third parameter. Updating pipeline infra

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -74,7 +74,7 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
-        redis-version: ['8.0-M04-pre', '${{ needs.redis_version.outputs.CURRENT }}', '7.2.7', '6.2.17']
+        redis-version: ['8.0-M05-pre', '${{ needs.redis_version.outputs.CURRENT }}', '7.2.7', '6.2.17']
         python-version: ['3.8', '3.13']
         parser-backend: ['plain']
         event-loop: ['asyncio']

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -255,8 +255,14 @@ class SearchCommands:
 
         For more information see `FT.DROPINDEX <https://redis.io/commands/ft.dropindex>`_.
         """  # noqa
-        delete_str = "DD" if delete_documents else ""
-        return self.execute_command(DROPINDEX_CMD, self.index_name, delete_str)
+        args = [DROPINDEX_CMD, self.index_name]
+
+        delete_str = "DD" if delete_documents == True else ""
+
+        if delete_str:
+            args.append(delete_str)
+
+        return self.execute_command(*args)
 
     def _add_document(
         self,

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -257,7 +257,11 @@ class SearchCommands:
         """  # noqa
         args = [DROPINDEX_CMD, self.index_name]
 
-        delete_str = "DD" if delete_documents == True else ""
+        delete_str = (
+            "DD"
+            if isinstance(delete_documents, bool) and delete_documents is True
+            else ""
+        )
 
         if delete_str:
             args.append(delete_str)

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -1603,14 +1603,14 @@ async def test_withsuffixtrie(decoded_r: redis.Redis):
     if is_resp2_connection(decoded_r):
         info = await decoded_r.ft().info()
         assert "WITHSUFFIXTRIE" not in info["attributes"][0]
-        assert await decoded_r.ft().dropindex("idx")
+        assert await decoded_r.ft().dropindex()
 
         # create withsuffixtrie index (text field)
         assert await decoded_r.ft().create_index(TextField("t", withsuffixtrie=True))
         await waitForIndex(decoded_r, getattr(decoded_r.ft(), "index_name", "idx"))
         info = await decoded_r.ft().info()
         assert "WITHSUFFIXTRIE" in info["attributes"][0]
-        assert await decoded_r.ft().dropindex("idx")
+        assert await decoded_r.ft().dropindex()
 
         # create withsuffixtrie index (tag field)
         assert await decoded_r.ft().create_index(TagField("t", withsuffixtrie=True))
@@ -1620,14 +1620,14 @@ async def test_withsuffixtrie(decoded_r: redis.Redis):
     else:
         info = await decoded_r.ft().info()
         assert "WITHSUFFIXTRIE" not in info["attributes"][0]["flags"]
-        assert await decoded_r.ft().dropindex("idx")
+        assert await decoded_r.ft().dropindex()
 
         # create withsuffixtrie index (text fields)
         assert await decoded_r.ft().create_index(TextField("t", withsuffixtrie=True))
         await waitForIndex(decoded_r, getattr(decoded_r.ft(), "index_name", "idx"))
         info = await decoded_r.ft().info()
         assert "WITHSUFFIXTRIE" in info["attributes"][0]["flags"]
-        assert await decoded_r.ft().dropindex("idx")
+        assert await decoded_r.ft().dropindex()
 
         # create withsuffixtrie index (tag field)
         assert await decoded_r.ft().create_index(TagField("t", withsuffixtrie=True))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1711,7 +1711,7 @@ def test_max_text_fields(client):
     with pytest.raises(redis.ResponseError):
         client.ft().alter_schema_add((TextField(f"f{x}"),))
 
-    client.ft().dropindex("idx")
+    client.ft().dropindex()
     # Creating the index definition
     client.ft().create_index((TextField("f0"),), max_text_fields=True)
     # Fill the index with fields
@@ -2575,14 +2575,14 @@ def test_withsuffixtrie(client: redis.Redis):
     if is_resp2_connection(client):
         info = client.ft().info()
         assert "WITHSUFFIXTRIE" not in info["attributes"][0]
-        assert client.ft().dropindex("idx")
+        assert client.ft().dropindex()
 
         # create withsuffixtrie index (text fields)
         assert client.ft().create_index(TextField("t", withsuffixtrie=True))
         waitForIndex(client, getattr(client.ft(), "index_name", "idx"))
         info = client.ft().info()
         assert "WITHSUFFIXTRIE" in info["attributes"][0]
-        assert client.ft().dropindex("idx")
+        assert client.ft().dropindex()
 
         # create withsuffixtrie index (tag field)
         assert client.ft().create_index(TagField("t", withsuffixtrie=True))
@@ -2592,14 +2592,14 @@ def test_withsuffixtrie(client: redis.Redis):
     else:
         info = client.ft().info()
         assert "WITHSUFFIXTRIE" not in info["attributes"][0]["flags"]
-        assert client.ft().dropindex("idx")
+        assert client.ft().dropindex()
 
         # create withsuffixtrie index (text fields)
         assert client.ft().create_index(TextField("t", withsuffixtrie=True))
         waitForIndex(client, getattr(client.ft(), "index_name", "idx"))
         info = client.ft().info()
         assert "WITHSUFFIXTRIE" in info["attributes"][0]["flags"]
-        assert client.ft().dropindex("idx")
+        assert client.ft().dropindex()
 
         # create withsuffixtrie index (tag field)
         assert client.ft().create_index(TagField("t", withsuffixtrie=True))


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

- 8.0 image tag is updated for pipeline actions
- Search module's dropindex function is fixed to send a third parameter only when valid True boolean is provided for the "delete_documents" argument.
- dropindex tests are fixed not to set index name as an input to dropindex function - the expected type of the function's argument is boolean.
