### PR TITLE
Improvement: Use `shutdown()` Before `close()` in connection.py

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -767,7 +767,7 @@ class Connection(AbstractConnection):
                     try:
                         sock.shutdown(socket.SHUT_RDWR)  # ensure a clean close
                     except OSError:
-                        pass  
+                        pass
                     sock.close()
 
         if err is not None:
@@ -1187,7 +1187,6 @@ class UnixDomainSocketConnection(AbstractConnection):
                 sock.shutdown(socket.SHUT_RDWR)  # ensure a clean close
             except OSError:
                 pass
-
             sock.close()
             raise
         sock.settimeout(self.socket_timeout)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -764,6 +764,10 @@ class Connection(AbstractConnection):
             except OSError as _:
                 err = _
                 if sock is not None:
+                    try:
+                        sock.shutdown(socket.SHUT_RDWR)  # ensure a clean close
+                    except:
+                        pass  
                     sock.close()
 
         if err is not None:
@@ -1179,6 +1183,11 @@ class UnixDomainSocketConnection(AbstractConnection):
             sock.connect(self.path)
         except OSError:
             # Prevent ResourceWarnings for unclosed sockets.
+            try:
+                sock.shutdown(socket.SHUT_RDWR)  # ensure a clean close
+            except:
+                pass
+
             sock.close()
             raise
         sock.settimeout(self.socket_timeout)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -766,7 +766,7 @@ class Connection(AbstractConnection):
                 if sock is not None:
                     try:
                         sock.shutdown(socket.SHUT_RDWR)  # ensure a clean close
-                    except:
+                    except OSError:
                         pass  
                     sock.close()
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1185,7 +1185,7 @@ class UnixDomainSocketConnection(AbstractConnection):
             # Prevent ResourceWarnings for unclosed sockets.
             try:
                 sock.shutdown(socket.SHUT_RDWR)  # ensure a clean close
-            except:
+            except OSError:
                 pass
 
             sock.close()


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

### Description of change

This PR improves socket resource management by implementing the recommended shutdown-then-close pattern in error handling scenarios.

#### Benefits

1. Ensures proper connection termination – shutdown() initiates the TCP termination sequence before releasing resources.
2. Prevents potential resource leaks – Reduces the risk of lingering sockets in edge cases.
3. Enhances network reliability – Ensures pending data is handled correctly before closing.
4. Aligns with Python best practices – Follows Python’s official socket documentation recommendations.

#### Technical Details
The Python documentation explicitly states:

> "close() releases the resource associated with a connection but does not necessarily close the connection immediately. If you want to close the connection in a timely fashion, call shutdown() before close()."
[Python socket documentation](https://docs.python.org/3/library/socket.html#socket.socket.close)

This change introduces properly exception-handled shutdown() calls before close() to ensure sockets are gracefully terminated, even when exceptions occur.

#### Impact
This is a low-risk change that improves resource cleanup and robustness. The modification is minimal but aligns the codebase with networking best practices, ensuring better socket lifecycle management.
