### PR TITLE
Adding new hash commands with expiration options - HGETDEL, HGETEX, HSETEX

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -4959,6 +4959,9 @@ class HashCommands(CommandsProtocol):
         Available since Redis 8.0
         For more information see https://redis.io/commands/hgetdel
         """
+        if len(keys) == 0:
+            raise DataError("'hgetdel' should have at least one key provided")
+
         return self.execute_command("HGETDEL", name, "FIELDS", len(keys), *keys)
 
     def hgetex(
@@ -4990,6 +4993,10 @@ class HashCommands(CommandsProtocol):
         Available since Redis 8.0
         For more information see https://redis.io/commands/hgetex
         """
+
+        if len(keys) == 0:
+            raise DataError("'hgetex' should have at least one key provided")
+
         opset = {ex, px, exat, pxat}
         if len(opset) > 2 or len(opset) > 1 and persist:
             raise DataError(
@@ -5060,8 +5067,10 @@ class HashCommands(CommandsProtocol):
 
         For more information see https://redis.io/commands/hset
         """
+
         if key is None and not mapping and not items:
             raise DataError("'hset' with no key value pairs")
+
         pieces = []
         if items:
             pieces.extend(items)
@@ -5122,6 +5131,12 @@ class HashCommands(CommandsProtocol):
         """
         if key is None and not mapping and not items:
             raise DataError("'hsetex' with no key value pairs")
+
+        if items and len(items) % 2 != 0:
+            raise DataError(
+                "'hsetex' with odd number of items. "
+                "'items' must contain a list of key/value pairs."
+            )
 
         opset = {ex, px, exat, pxat}
         if len(opset) > 2 or len(opset) > 1 and keepttl:

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -4980,8 +4980,7 @@ class HashCommands(CommandsProtocol):
     def hgetex(
         self,
         name: KeyT,
-        key: Optional[str] = None,
-        keys: Optional[list] = None,
+        *keys: str,
         ex: Optional[ExpiryT] = None,
         px: Optional[ExpiryT] = None,
         exat: Optional[AbsExpiryT] = None,
@@ -5009,7 +5008,7 @@ class HashCommands(CommandsProtocol):
         Available since Redis 8.0
         For more information see https://redis.io/commands/hgetex
         """
-        if key is None and not keys:
+        if not keys:
             raise DataError("'hgetex' should have at least one key provided")
 
         opset = {ex, px, exat, pxat}
@@ -5018,11 +5017,6 @@ class HashCommands(CommandsProtocol):
                 "``ex``, ``px``, ``exat``, ``pxat``, "
                 "and ``persist`` are mutually exclusive."
             )
-        keys_to_request = []
-        if key is not None:
-            keys_to_request.append(key)
-        if keys:
-            keys_to_request.extend(keys)
 
         exp_options: list[EncodableT] = extract_expire_flags(ex, px, exat, pxat)
 
@@ -5034,8 +5028,8 @@ class HashCommands(CommandsProtocol):
             name,
             *exp_options,
             "FIELDS",
-            len(keys_to_request),
-            *keys_to_request,
+            len(keys),
+            *keys,
         )
 
     def hincrby(

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -31,6 +31,7 @@ from tests.conftest import (
     skip_if_server_version_lt,
     skip_unless_arch_bits,
 )
+from tests.test_asyncio.test_utils import redis_server_time
 
 if sys.version_info >= (3, 11, 3):
     from asyncio import timeout as async_timeout
@@ -75,12 +76,6 @@ async def slowlog(r: redis.Redis):
 
     await r.config_set("slowlog-log-slower-than", old_slower_than_value)
     await r.config_set("slowlog-max-len", old_max_legnth_value)
-
-
-async def redis_server_time(client: redis.Redis):
-    seconds, milliseconds = await client.time()
-    timestamp = float(f"{seconds}.{milliseconds}")
-    return datetime.datetime.fromtimestamp(timestamp)
 
 
 async def get_stream_message(client: redis.Redis, stream: str, message_id: str):
@@ -2328,12 +2323,8 @@ class TestRedisCommands:
         assert await r.hmget("a", "a", "b", "c") == [b"1", b"2", b"3"]
 
     async def test_hmset(self, r: redis.Redis):
-        warning_message = (
-            r"^Redis(?:Cluster)*\.hmset\(\) is deprecated\. "
-            r"Use Redis(?:Cluster)*\.hset\(\) instead\.$"
-        )
         h = {b"a": b"1", b"b": b"2", b"c": b"3"}
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(DeprecationWarning):
             assert await r.hmset("a", h)
         assert await r.hgetall("a") == h
 

--- a/tests/test_asyncio/test_hash.py
+++ b/tests/test_asyncio/test_hash.py
@@ -316,6 +316,9 @@ async def test_hgetdel(r):
     assert await r.hgetdel("test:hash", "foo", "1") == [None, None]
     assert await r.hget("test:hash", "2") == b"2"
 
+    with pytest.raises(exceptions.DataError):
+        await r.hgetdel("test:hash")
+
 
 @skip_if_server_version_lt("7.9.0")
 async def test_hgetex_no_expiration(r):
@@ -395,6 +398,9 @@ async def test_hgetex_invalid_inputs(r):
 
     with pytest.raises(exceptions.DataError):
         await r.hgetex("b", "foo", "1", "3", ex=10, px=6000)
+
+    with pytest.raises(exceptions.DataError):
+        await r.hgetex("b", ex=10)
 
 
 @skip_if_server_version_lt("7.9.0")
@@ -544,6 +550,9 @@ async def test_hsetex_invalid_inputs(r):
 
     with pytest.raises(exceptions.DataError):
         await r.hsetex("b", None, None)
+
+    with pytest.raises(exceptions.DataError):
+        await r.hsetex("b", "foo", "bar", items=["i1", 11, "i2"], px=6000)
 
     with pytest.raises(exceptions.DataError):
         await r.hsetex("b", "foo", "bar", ex=10, keepttl=True)

--- a/tests/test_asyncio/test_utils.py
+++ b/tests/test_asyncio/test_utils.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+import redis
+
+
+async def redis_server_time(client: redis.Redis):
+    seconds, milliseconds = await client.time()
+    timestamp = float(f"{seconds}.{milliseconds}")
+    return datetime.fromtimestamp(timestamp)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -21,6 +21,7 @@ from redis.client import EMPTY_RESPONSE, NEVER_DECODE
 from redis.commands.json.path import Path
 from redis.commands.search.field import TextField
 from redis.commands.search.query import Query
+from tests.test_utils import redis_server_time
 
 from .conftest import (
     _get_client,
@@ -48,12 +49,6 @@ def slowlog(request, r):
 
     r.config_set("slowlog-log-slower-than", 0)
     r.config_set("slowlog-max-len", 128)
-
-
-def redis_server_time(client):
-    seconds, milliseconds = client.time()
-    timestamp = float(f"{seconds}.{milliseconds}")
-    return datetime.datetime.fromtimestamp(timestamp)
 
 
 def get_stream_message(client, stream, message_id):
@@ -3393,13 +3388,8 @@ class TestRedisCommands:
         assert r.hmget("a", "a", "b", "c") == [b"1", b"2", b"3"]
 
     def test_hmset(self, r):
-        redis_class = type(r).__name__
-        warning_message = (
-            r"^{0}\.hmset\(\) is deprecated\. "
-            r"Use {0}\.hset\(\) instead\.$".format(redis_class)
-        )
         h = {b"a": b"1", b"b": b"2", b"c": b"3"}
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(DeprecationWarning):
             assert r.hmset("a", h)
         assert r.hgetall("a") == h
 

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -383,6 +383,9 @@ def test_hgetdel(r):
     assert r.hgetdel("test:hash", "foo", "1") == [None, None]
     assert r.hget("test:hash", "2") == b"2"
 
+    with pytest.raises(exceptions.DataError):
+        r.hgetdel("test:hash")
+
 
 @skip_if_server_version_lt("7.9.0")
 def test_hgetex_no_expiration(r):
@@ -445,6 +448,9 @@ def test_hgetex_invalid_inputs(r):
     with pytest.raises(exceptions.DataError):
         r.hgetex("b", "foo", "1", "3", ex=10, px=6000)
 
+    with pytest.raises(exceptions.DataError):
+        r.hgetex("b", ex=10)
+
 
 @skip_if_server_version_lt("7.9.0")
 def test_hsetex_no_expiration(r):
@@ -454,7 +460,6 @@ def test_hsetex_no_expiration(r):
     assert r.hsetex("test:hash", None, None, mapping={"1": 1, "4": b"four"}) == 1
     assert r.httl("test:hash", "foo", "1", "4") == [-2, -1, -1]
     assert r.hgetex("test:hash", "foo", "1") == [None, b"1"]
-    pass
 
 
 @skip_if_server_version_lt("7.9.0")
@@ -583,6 +588,9 @@ def test_hsetex_invalid_inputs(r):
 
     with pytest.raises(exceptions.DataError):
         r.hsetex("b", None, None)
+
+    with pytest.raises(exceptions.DataError):
+        r.hsetex("b", "foo", "bar", items=["i1", 11, "i2"], px=6000)
 
     with pytest.raises(exceptions.DataError):
         r.hsetex("b", "foo", "bar", ex=10, keepttl=True)

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -3,7 +3,9 @@ import time
 from datetime import datetime, timedelta
 
 import pytest
+from redis import exceptions
 from tests.conftest import skip_if_server_version_lt
+from tests.test_utils import redis_server_time
 
 
 @skip_if_server_version_lt("7.3.240")
@@ -368,3 +370,222 @@ def test_hpttl_multiple_fields_mixed_conditions(r):
 def test_hpttl_nonexistent_key(r):
     r.delete("test:hash")
     assert r.hpttl("test:hash", "field1", "field2", "field3") == [-2, -2, -2]
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hgetdel(r):
+    r.delete("test:hash")
+    r.hset("test:hash", "foo", "bar", mapping={"1": 1, "2": 2})
+    assert r.hgetdel("test:hash", "foo", "1") == [b"bar", b"1"]
+    assert r.hget("test:hash", "foo") is None
+    assert r.hget("test:hash", "1") is None
+    assert r.hget("test:hash", "2") == b"2"
+    assert r.hgetdel("test:hash", "foo", "1") == [None, None]
+    assert r.hget("test:hash", "2") == b"2"
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hgetex_no_expiration(r):
+    r.delete("test:hash")
+    r.hset("b", "foo", "bar", mapping={"1": 1, "2": 2, "3": "three", "4": b"four"})
+
+    assert r.hgetex("b", "foo", "1", "4") == [b"bar", b"1", b"four"]
+    assert r.httl("b", "foo", "1", "4") == [-1, -1, -1]
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hgetex_expiration_configs(r):
+    r.delete("test:hash")
+    r.hset("test:hash", "foo", "bar", mapping={"1": 1, "3": "three", "4": b"four"})
+
+    # test get with multiple fields with expiration set through 'ex'
+    assert r.hgetex("test:hash", "foo", "1", "4", ex=10) == [b"bar", b"1", b"four"]
+    assert r.httl("test:hash", "foo", "1", "4") == [10, 10, 10]
+
+    # test get with multiple fields removing expiration settings with 'persist'
+    assert r.hgetex("test:hash", "foo", "1", "4", persist=True) == [
+        b"bar",
+        b"1",
+        b"four",
+    ]
+    assert r.httl("test:hash", "foo", "1", "4") == [-1, -1, -1]
+
+    # test get with multiple fields with expiration set through 'px'
+    assert r.hgetex("test:hash", "foo", "1", "4", px=6000) == [b"bar", b"1", b"four"]
+    assert r.httl("test:hash", "foo", "1", "4") == [6, 6, 6]
+
+    # test get single field with expiration set through 'pxat'
+    expire_at = redis_server_time(r) + timedelta(minutes=1)
+    assert r.hgetex("test:hash", "foo", pxat=expire_at) == [b"bar"]
+    assert r.httl("test:hash", "foo")[0] <= 61
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hgetex_validate_expired_foields_removed(r):
+    r.delete("test:hash")
+    r.hset("test:hash", "foo", "bar", mapping={"1": 1, "3": "three", "4": b"four"})
+
+    # test get multiple fields with expiration set
+    # validate that expired fields are removed
+    assert r.hgetex("test:hash", "foo", "1", "3", ex=1) == [b"bar", b"1", b"three"]
+    time.sleep(1.1)
+    assert r.hgetex("test:hash", "foo", "1", "3") == [None, None, None]
+    assert r.httl("test:hash", "foo", "1", "3") == [-2, -2, -2]
+    assert r.hgetex("test:hash", "4") == [b"four"]
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hgetex_invalid_inputs(r):
+    with pytest.raises(exceptions.DataError):
+        r.hgetex("b", "foo", "1", "3", ex=10, persist=True)
+
+    with pytest.raises(exceptions.DataError):
+        r.hgetex("b", "foo", "1", "3", ex=10.0, persist=True)
+
+    with pytest.raises(exceptions.DataError):
+        r.hgetex("b", "foo", "1", "3", ex=10, px=6000)
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hsetex_no_expiration(r):
+    r.delete("test:hash")
+
+    # # set items from mapping without expiration
+    assert r.hsetex("test:hash", None, None, mapping={"1": 1, "4": b"four"}) == 1
+    assert r.httl("test:hash", "foo", "1", "4") == [-2, -1, -1]
+    assert r.hgetex("test:hash", "foo", "1") == [None, b"1"]
+    pass
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hsetex_expiration_ex_and_keepttl(r):
+    r.delete("test:hash")
+
+    # set items from key/value provided
+    # combined with mapping and items with expiration - testing ex field
+    assert (
+        r.hsetex(
+            "test:hash",
+            "foo",
+            "bar",
+            mapping={"1": 1, "2": "2"},
+            items=["i1", 11, "i2", 22],
+            ex=10,
+        )
+        == 1
+    )
+    assert r.httl("test:hash", "foo", "1", "2", "i1", "i2") == [
+        10,
+        10,
+        10,
+        10,
+        10,
+    ]
+    assert r.hgetex("test:hash", "foo", "1", "2", "i1", "i2") == [
+        b"bar",
+        b"1",
+        b"2",
+        b"11",
+        b"22",
+    ]
+    time.sleep(1.1)
+    # validate keepttl
+    assert r.hsetex("test:hash", "foo", "bar1", keepttl=True) == 1
+    assert r.httl("test:hash", "foo")[0] < 10
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hsetex_expiration_px(r):
+    r.delete("test:hash")
+    # set items from key/value provided and mapping
+    # with expiration - testing px field
+    assert (
+        r.hsetex("test:hash", "foo", "bar", mapping={"1": 1, "2": "2"}, px=60000) == 1
+    )
+    assert r.httl("test:hash", "foo", "1", "2") == [60, 60, 60]
+    assert r.hgetex("test:hash", "foo", "1", "2") == [b"bar", b"1", b"2"]
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hsetex_expiration_pxat_and_fnx(r):
+    r.delete("test:hash")
+    assert r.hsetex("test:hash", "foo", "bar", mapping={"1": 1, "2": "2"}, ex=30) == 1
+
+    expire_at = redis_server_time(r) + timedelta(minutes=1)
+    assert (
+        r.hsetex(
+            "test:hash", "foo", "bar1", mapping={"new": "ok"}, pxat=expire_at, fnx=True
+        )
+        == 0
+    )
+    ttls = r.httl("test:hash", "foo", "new")
+    assert ttls[0] <= 30
+    assert ttls[1] == -2
+
+    assert r.hgetex("test:hash", "foo", "1", "new") == [b"bar", b"1", None]
+    assert (
+        r.hsetex(
+            "test:hash",
+            "foo_new",
+            "bar1",
+            mapping={"new": "ok"},
+            pxat=expire_at,
+            fnx=True,
+        )
+        == 1
+    )
+    ttls = r.httl("test:hash", "foo", "new")
+    for ttl in ttls:
+        assert ttl <= 61
+    assert r.hgetex("test:hash", "foo", "foo_new", "new") == [b"bar", b"bar1", b"ok"]
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hsetex_expiration_exat_and_fxx(r):
+    r.delete("test:hash")
+    assert r.hsetex("test:hash", "foo", "bar", mapping={"1": 1, "2": "2"}, ex=30) == 1
+
+    expire_at = redis_server_time(r) + timedelta(seconds=10)
+    assert (
+        r.hsetex(
+            "test:hash",
+            "foo",
+            "bar1",
+            mapping={"new": "ok"},
+            exat=expire_at,
+            fxx=True,
+        )
+        == 0
+    )
+    ttls = r.httl("test:hash", "foo", "new")
+    assert 10 < ttls[0] <= 30
+    assert ttls[1] == -2
+
+    assert r.hgetex("test:hash", "foo", "1", "new") == [b"bar", b"1", None]
+    assert (
+        r.hsetex(
+            "test:hash",
+            "foo",
+            "bar1",
+            mapping={"1": "new_value"},
+            exat=expire_at,
+            fxx=True,
+        )
+        == 1
+    )
+    assert r.hgetex("test:hash", "foo", "1") == [b"bar1", b"new_value"]
+
+
+@skip_if_server_version_lt("7.9.0")
+def test_hsetex_invalid_inputs(r):
+    with pytest.raises(exceptions.DataError):
+        r.hsetex("b", "foo", "bar", ex=10.0)
+
+    with pytest.raises(exceptions.DataError):
+        r.hsetex("b", None, None)
+
+    with pytest.raises(exceptions.DataError):
+        r.hsetex("b", "foo", "bar", ex=10, keepttl=True)
+
+    with pytest.raises(exceptions.DataError):
+        r.hsetex("b", "foo", "bar", ex=10, fxx=True, fnx=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import pytest
 from redis.utils import compare_versions
 
@@ -25,3 +26,9 @@ from redis.utils import compare_versions
 )
 def test_compare_versions(version1, version2, expected_res):
     assert compare_versions(version1, version2) == expected_res
+
+
+def redis_server_time(client):
+    seconds, milliseconds = client.time()
+    timestamp = float(f"{seconds}.{milliseconds}")
+    return datetime.fromtimestamp(timestamp)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

- Adding support for new hash commands with expiration options - HGETDEL, HGETEX, HSETEX
- Extracted some common logic related to validation and extraction of expiration configs in helper functions
- Added validation for the inputs of method that executes set command
- Moved a deprecation warning for an exposed method to an annotation 
