### PR TITLE
Handling some special values when transforming response data into list(issue #3573)

### DIFF
--- a/redis/commands/helpers.py
+++ b/redis/commands/helpers.py
@@ -43,19 +43,32 @@ def parse_to_list(response):
     """Optimistically parse the response to a list."""
     res = []
 
+    special_values = {"infinity", "nan", "-infinity"}
+
     if response is None:
         return res
 
     for item in response:
+        if item is None:
+            res.append(None)
+            continue
         try:
-            res.append(int(item))
-        except ValueError:
-            try:
-                res.append(float(item))
-            except ValueError:
-                res.append(nativestr(item))
+            item_str = nativestr(item)
         except TypeError:
             res.append(None)
+            continue
+
+        if isinstance(item_str, str) and item_str.lower() in special_values:
+            res.append(item_str)  # Keep as string
+        else:
+            try:
+                res.append(int(item))
+            except ValueError:
+                try:
+                    res.append(float(item))
+                except ValueError:
+                    res.append(item_str)
+
     return res
 
 

--- a/tests/test_asyncio/test_bloom.py
+++ b/tests/test_asyncio/test_bloom.py
@@ -334,6 +334,34 @@ async def test_topk(decoded_r: redis.Redis):
 
 
 @pytest.mark.redismod
+async def test_topk_list_with_special_words(decoded_r: redis.Redis):
+    # test list with empty buckets
+    assert await decoded_r.topk().reserve("topklist:specialwords", 5, 20, 4, 0.9)
+    assert await decoded_r.topk().add(
+        "topklist:specialwords",
+        "infinity",
+        "B",
+        "nan",
+        "D",
+        "-infinity",
+        "infinity",
+        "infinity",
+        "B",
+        "nan",
+        "G",
+        "D",
+        "B",
+        "D",
+        "infinity",
+        "-infinity",
+        "-infinity",
+    )
+    assert ["infinity", "B", "D", "-infinity", "nan"] == await decoded_r.topk().list(
+        "topklist:specialwords"
+    )
+
+
+@pytest.mark.redismod
 async def test_topk_incrby(decoded_r: redis.Redis):
     await decoded_r.flushdb()
     assert await decoded_r.topk().reserve("topk", 3, 10, 3, 1)

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -365,6 +365,34 @@ def test_topk(client):
 
 
 @pytest.mark.redismod
+def test_topk_list_with_special_words(client):
+    # test list with empty buckets
+    assert client.topk().reserve("topklist:specialwords", 5, 20, 4, 0.9)
+    assert client.topk().add(
+        "topklist:specialwords",
+        "infinity",
+        "B",
+        "nan",
+        "D",
+        "-infinity",
+        "infinity",
+        "infinity",
+        "B",
+        "nan",
+        "G",
+        "D",
+        "B",
+        "D",
+        "infinity",
+        "-infinity",
+        "-infinity",
+    )
+    assert ["infinity", "B", "D", "-infinity", "nan"] == client.topk().list(
+        "topklist:specialwords"
+    )
+
+
+@pytest.mark.redismod
 def test_topk_incrby(client):
     client.flushdb()
     assert client.topk().reserve("topk", 3, 10, 3, 1)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Handling some special values when transforming response data into list (fix for issue #3573 )

In the current implementation of the postprocessing callback we try to convert the returned values directly to ints and then to floats. 
The problem is that for some words, conversion to float succeeds, but they might be intended to be normal words - like infinity, or nan (which can be an abbreviation for an airport). 
