### PR TITLE
Enable specifying load-balancing strategy on per-command basis

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -37,8 +37,6 @@ from redis.cluster import (
     REPLICA,
     SLOT_ID,
     AbstractRedisCluster,
-    LoadBalancer,
-    LoadBalancingStrategy,
     block_pipeline_command,
     get_node_name,
     parse_cluster_slots,
@@ -63,6 +61,7 @@ from redis.exceptions import (
     TimeoutError,
     TryAgainError,
 )
+from redis.load_balancer import LoadBalancer, LoadBalancingStrategy
 from redis.typing import AnyKeyT, EncodableT, KeyT
 from redis.utils import (
     SSL_AVAILABLE,

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -4,7 +4,6 @@ import sys
 import threading
 import time
 from collections import OrderedDict
-from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from redis._parsers import CommandsParser, Encoder
@@ -37,6 +36,7 @@ from redis.exceptions import (
     TimeoutError,
     TryAgainError,
 )
+from redis.load_balancer import LoadBalancer, LoadBalancingStrategy
 from redis.lock import Lock
 from redis.retry import Retry
 from redis.utils import (
@@ -1326,54 +1326,6 @@ class ClusterNode:
     def __del__(self):
         if self.redis_connection is not None:
             self.redis_connection.close()
-
-
-class LoadBalancingStrategy(Enum):
-    ROUND_ROBIN = "round_robin"
-    ROUND_ROBIN_REPLICAS = "round_robin_replicas"
-    RANDOM_REPLICA = "random_replica"
-
-
-class LoadBalancer:
-    """
-    Round-Robin Load Balancing
-    """
-
-    def __init__(self, start_index: int = 0) -> None:
-        self.primary_to_idx = {}
-        self.start_index = start_index
-
-    def get_server_index(
-        self,
-        primary: str,
-        list_size: int,
-        load_balancing_strategy: LoadBalancingStrategy = LoadBalancingStrategy.ROUND_ROBIN,
-    ) -> int:
-        if load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA:
-            return self._get_random_replica_index(list_size)
-        else:
-            return self._get_round_robin_index(
-                primary,
-                list_size,
-                load_balancing_strategy == LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
-            )
-
-    def reset(self) -> None:
-        self.primary_to_idx.clear()
-
-    def _get_random_replica_index(self, list_size: int) -> int:
-        return random.randint(1, list_size - 1)
-
-    def _get_round_robin_index(
-        self, primary: str, list_size: int, replicas_only: bool
-    ) -> int:
-        server_index = self.primary_to_idx.setdefault(primary, self.start_index)
-        if replicas_only and server_index == 0:
-            # skip the primary node index
-            server_index = 1
-        # Update the index for the next round
-        self.primary_to_idx[primary] = (server_index + 1) % list_size
-        return server_index
 
 
 class NodesManager:

--- a/redis/load_balancer.py
+++ b/redis/load_balancer.py
@@ -1,0 +1,49 @@
+from enum import Enum
+
+
+class LoadBalancingStrategy(Enum):
+    ROUND_ROBIN = "round_robin"
+    ROUND_ROBIN_REPLICAS = "round_robin_replicas"
+    RANDOM_REPLICA = "random_replica"
+
+
+class LoadBalancer:
+    """
+    Round-Robin Load Balancing
+    """
+
+    def __init__(self, start_index: int = 0) -> None:
+        self.primary_to_idx = {}
+        self.start_index = start_index
+
+    def get_server_index(
+        self,
+        primary: str,
+        list_size: int,
+        load_balancing_strategy: LoadBalancingStrategy = LoadBalancingStrategy.ROUND_ROBIN,
+    ) -> int:
+        if load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA:
+            return self._get_random_replica_index(list_size)
+        else:
+            return self._get_round_robin_index(
+                primary,
+                list_size,
+                load_balancing_strategy == LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
+            )
+
+    def reset(self) -> None:
+        self.primary_to_idx.clear()
+
+    def _get_random_replica_index(self, list_size: int) -> int:
+        return random.randint(1, list_size - 1)
+
+    def _get_round_robin_index(
+        self, primary: str, list_size: int, replicas_only: bool
+    ) -> int:
+        server_index = self.primary_to_idx.setdefault(primary, self.start_index)
+        if replicas_only and server_index == 0:
+            # skip the primary node index
+            server_index = 1
+        # Update the index for the next round
+        self.primary_to_idx[primary] = (server_index + 1) % list_size
+        return server_index

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -18,7 +18,6 @@ from redis.cluster import (
     PIPELINE_BLOCKED_COMMANDS,
     PRIMARY,
     REPLICA,
-    LoadBalancingStrategy,
     get_node_name,
 )
 from redis.crc import REDIS_CLUSTER_HASH_SLOTS, key_slot
@@ -34,6 +33,7 @@ from redis.exceptions import (
     RedisError,
     ResponseError,
 )
+from redis.load_balancer import LoadBalancingStrategy
 from redis.utils import str_if_bytes
 from tests.conftest import (
     assert_resp_response,

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -20,7 +20,6 @@ from redis.cluster import (
     REDIS_CLUSTER_HASH_SLOTS,
     REPLICA,
     ClusterNode,
-    LoadBalancingStrategy,
     NodesManager,
     RedisCluster,
     get_node_name,
@@ -39,6 +38,7 @@ from redis.exceptions import (
     ResponseError,
     TimeoutError,
 )
+from redis.load_balancer import LoadBalancingStrategy
 from redis.retry import Retry
 from redis.utils import str_if_bytes
 from tests.test_pubsub import wait_for_message


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Resolves https://github.com/redis/redis-py/issues/3591

Allow callers to specify a load-balancing strategy per command. This is useful when some use cases require strong consistency and others do not. This avoids creating separate client instances for these use cases, avoiding duplicate connections.
