### PR TITLE
Marks old RediSearch 1.0 commands as deprecated

### DIFF
--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -23,7 +23,6 @@ ALTER_CMD = "FT.ALTER"
 SEARCH_CMD = "FT.SEARCH"
 ADD_CMD = "FT.ADD"
 ADDHASH_CMD = "FT.ADDHASH"
-DROP_CMD = "FT.DROP"
 DROPINDEX_CMD = "FT.DROPINDEX"
 EXPLAIN_CMD = "FT.EXPLAIN"
 EXPLAINCLI_CMD = "FT.EXPLAINCLI"
@@ -35,7 +34,6 @@ SPELLCHECK_CMD = "FT.SPELLCHECK"
 DICT_ADD_CMD = "FT.DICTADD"
 DICT_DEL_CMD = "FT.DICTDEL"
 DICT_DUMP_CMD = "FT.DICTDUMP"
-GET_CMD = "FT.GET"
 MGET_CMD = "FT.MGET"
 CONFIG_CMD = "FT.CONFIG"
 TAGVALS_CMD = "FT.TAGVALS"
@@ -406,6 +404,9 @@ class SearchCommands:
             doc_id, conn=None, score=score, language=language, replace=replace
         )
 
+    @deprecated_function(
+        version="2.0.0", reason="deprecated since redisearch 2.0"
+    )
     def delete_document(self, doc_id, conn=None, delete_actual_document=False):
         """
         Delete a document from index
@@ -440,6 +441,9 @@ class SearchCommands:
 
         return Document(id=id, **fields)
 
+    @deprecated_function(
+        version="2.0.0", reason="deprecated since redisearch 2.0"
+    )
     def get(self, *ids):
         """
         Returns the full contents of multiple documents.

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -404,9 +404,7 @@ class SearchCommands:
             doc_id, conn=None, score=score, language=language, replace=replace
         )
 
-    @deprecated_function(
-        version="2.0.0", reason="deprecated since redisearch 2.0"
-    )
+    @deprecated_function(version="2.0.0", reason="deprecated since redisearch 2.0")
     def delete_document(self, doc_id, conn=None, delete_actual_document=False):
         """
         Delete a document from index
@@ -441,9 +439,7 @@ class SearchCommands:
 
         return Document(id=id, **fields)
 
-    @deprecated_function(
-        version="2.0.0", reason="deprecated since redisearch 2.0"
-    )
+    @deprecated_function(version="2.0.0", reason="deprecated since redisearch 2.0")
     def get(self, *ids):
         """
         Returns the full contents of multiple documents.


### PR DESCRIPTION
### Pull Request check-list

- [X] Do tests and lints pass with this change?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is the new or changed code fully tested?
- [ ] Is there an example added to the examples folder (if applicable)?


### Description of change

The `FT.DEL` and `FT.MGET` commands are not supported in RediSearch 2.0+. Most of the other RediSearch 1.0-speific commands had already been marked as deprecated, I'm guessing these two were missed.

TODO: Check if we need to document the deprecation.
