### PR TITLE
Removing 'charset' and 'errors' inputs from the Redis initialization arguments - deprecated 3 years ago.

### DIFF
--- a/docs/advanced_features.rst
+++ b/docs/advanced_features.rst
@@ -384,13 +384,13 @@ run_in_thread.
 
 A PubSub object adheres to the same encoding semantics as the client
 instance it was created from. Any channel or pattern that's unicode will
-be encoded using the charset specified on the client before being sent
+be encoded using the encoding specified on the client before being sent
 to Redis. If the client's decode_responses flag is set the False (the
 default), the 'channel', 'pattern' and 'data' values in message
 dictionaries will be byte strings (str on Python 2, bytes on Python 3).
 If the client's decode_responses is True, then the 'channel', 'pattern'
 and 'data' values will be automatically decoded to unicode strings using
-the client's charset.
+the client's encoding.
 
 PubSub objects remember what channels and patterns they are subscribed
 to. In the event of a disconnection such as a network error or timeout,

--- a/redis/client.py
+++ b/redis/client.py
@@ -2,7 +2,6 @@ import copy
 import re
 import threading
 import time
-import warnings
 from itertools import chain
 from typing import (
     TYPE_CHECKING,
@@ -203,8 +202,6 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         unix_socket_path: Optional[str] = None,
         encoding: str = "utf-8",
         encoding_errors: str = "strict",
-        charset: Optional[str] = None,
-        errors: Optional[str] = None,
         decode_responses: bool = False,
         retry_on_timeout: bool = False,
         retry_on_error: Optional[List[Type[Exception]]] = None,
@@ -256,20 +253,6 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         else:
             self._event_dispatcher = event_dispatcher
         if not connection_pool:
-            if charset is not None:
-                warnings.warn(
-                    DeprecationWarning(
-                        '"charset" is deprecated. Use "encoding" instead'
-                    )
-                )
-                encoding = charset
-            if errors is not None:
-                warnings.warn(
-                    DeprecationWarning(
-                        '"errors" is deprecated. Use "encoding_errors" instead'
-                    )
-                )
-                encoding_errors = errors
             if not retry_on_error:
                 retry_on_error = []
             if retry_on_timeout is True:

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -142,7 +142,6 @@ REPLICA = "replica"
 SLOT_ID = "slot-id"
 
 REDIS_ALLOWED_KEYS = (
-    "charset",
     "connection_class",
     "connection_pool",
     "connection_pool_class",
@@ -152,7 +151,6 @@ REDIS_ALLOWED_KEYS = (
     "decode_responses",
     "encoding",
     "encoding_errors",
-    "errors",
     "host",
     "lib_name",
     "lib_version",


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Removing 'charset' and 'errors' inputs from the Redis initialization arguments - deprecated 3 years ago.
