### PR TITLE
When SlotNotCoveredError is raised, the cluster topology should be reinitialized as part of error handling and retrying of the commands.

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -808,10 +808,16 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
                 # and try again with the new setup
                 await self.aclose()
                 raise
-            except ClusterDownError:
+            except (ClusterDownError, SlotNotCoveredError):
                 # ClusterDownError can occur during a failover and to get
                 # self-healed, we will try to reinitialize the cluster layout
                 # and retry executing the command
+
+                # SlotNotCoveredError can occur when the cluster is not fully
+                # initialized or can be temporary issue.
+                # We will try to reinitialize the cluster topology
+                # and retry executing the command
+
                 await self.aclose()
                 await asyncio.sleep(0.25)
                 raise


### PR DESCRIPTION

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Fixes issue #3620 

When we are handling different errors, we run cluster reinitialization that calls CLUSTER SLOTS.
Sometimes the cluster slots temporarily might not be fully covered and if we try to execute a command against key from the missing slots we receive SlotNotCoveredError.
The problem is that after this error appears we don't try to reinitialize again the slots and the Cluster client can't heal itself.

With this change I'm adding error handling for the SlotNotCoveredError, the same way we handle ClusterDownErrors - try to extract the slots coverage after a little sleep.
