### PR TITLE
Fix `AttributeError` in `ClusterPipeline`

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -2122,7 +2122,7 @@ class ClusterPipeline(RedisCluster):
         else:
             self.retry = Retry(
                 backoff=ExponentialWithJitterBackoff(base=1, cap=10),
-                retries=self.cluster_error_retry_attempts,
+                retries=cluster_error_retry_attempts,
             )
 
         self.encoder = Encoder(


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Hey folks, while [running our test suite](https://github.com/getsentry/sentry-python/actions/runs/14832122735/job/41635403613?pr=4359#step:12:141) against the newest redis-py release (6.0.0) we ran into this:

```
tests/integrations/redis/cluster/test_redis_cluster.py:121: in test_rediscluster_pipeline
    pipeline = rc.pipeline()
tests/integrations/redis/cluster/test_redis_cluster.py:16: in <lambda>
    redis.RedisCluster.pipeline = lambda *_, **__: pipeline_cls(None, None)
.tox/py3.13-redis-latest/lib/python3.13/site-packages/redis/utils.py:188: in wrapper
    return func(*args, **kwargs)
.tox/py3.13-redis-latest/lib/python3.13/site-packages/redis/cluster.py:2125: in __init__
    retries=self.cluster_error_retry_attempts,
E   AttributeError: 'ClusterPipeline' object has no attribute 'cluster_error_retry_attempts'
```

I believe this might be a bug in redis-py since `ClusterPipeline` [no longer](https://github.com/redis/redis-py/pull/3622/files) has the attribute `cluster_error_retry_attempts` -- so this code path should probably take it from the (kw)args instead. I grepped for `cluster_error_retry_attempts` and it doesn't seem to be used as an attribute anywhere (e.g. in a parent class).