### PR TITLE
Allow newer PyJWT versions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -70,6 +70,7 @@
     * Close Unix sockets if the connection attempt fails. This prevents `ResourceWarning`s. (#3314)
     * Close SSL sockets if the connection attempt fails, or if validations fail. (#3317)
     * Eliminate mutable default arguments in the `redis.commands.core.Script` class. (#3332)
+    * Allow newer versions of PyJWT as dependency. (#3630)
 
 * 4.1.3 (Feb 8, 2022)
   * Fix flushdb and flushall (#1926)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ ocsp = [
     "requests>=2.31.0",
 ]
 jwt = [
-    "PyJWT~=2.9.0",
+    "PyJWT>=2.9.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Close #3630

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

The PyJWT dependency was fixed on 2.9.0, while all newer versions should be fine.
