### PR TITLE
Export REDIS_MAJOR_VERSION correctly in run-tests

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -66,6 +66,7 @@ runs:
         
         echo "::group::Starting Redis servers"
         redis_major_version=$(echo "$REDIS_VERSION" | grep -oP '^\d+')
+        echo "REDIS_MAJOR_VERSION=${redis_major_version}" >> $GITHUB_ENV
         
         if (( redis_major_version < 8 )); then
           echo "Using redis-stack for module tests"
@@ -87,8 +88,7 @@ runs:
                   
           if (( redis_major_version < 7 )); then
             export REDIS_STACK_EXTRA_ARGS="--tls-auth-clients optional --save ''"
-            export REDIS_EXTRA_ARGS="--tls-auth-clients optional --save ''"
-            echo "REDIS_MAJOR_VERSION=${redis_major_version}" >> $GITHUB_ENV
+            export REDIS_EXTRA_ARGS="--tls-auth-clients optional --save ''"            
           fi
         
           invoke devenv --endpoints=all-stack


### PR DESCRIPTION
Fix issue spotted by @akx https://github.com/redis/redis-py/pull/3415#issuecomment-2671248595 in run-tests reusable workflow