### PR TITLE
Removing connection_pool field from the CommandProtocol definition

### DIFF
--- a/redis/typing.py
+++ b/redis/typing.py
@@ -15,8 +15,6 @@ from typing import (
 
 if TYPE_CHECKING:
     from redis._parsers import Encoder
-    from redis.asyncio.connection import ConnectionPool as AsyncConnectionPool
-    from redis.connection import ConnectionPool
 
 
 Number = Union[int, float]
@@ -52,8 +50,6 @@ ExceptionMappingT = Mapping[str, Union[Type[Exception], Mapping[str, Type[Except
 
 
 class CommandsProtocol(Protocol):
-    connection_pool: Union["AsyncConnectionPool", "ConnectionPool"]
-
     def execute_command(self, *args, **options) -> ResponseT: ...
 
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

With this change, the requirement to initialize `connection_pool` in every class that directly or indirectly inherits from `CommandsProtocol` is removed.

The protocol should define only the methods and properties necessary for command execution. Consumers of `CommandsProtocol` only rely on `execute_command`, so requiring `connection_pool` introduces an unnecessary leak of internal state. 
In some cases, it's not even applicable—such as with cluster clients, where `connection_pool` is not a direct property of the client.

