### PR TITLE
Remove use of deprecated argument (cluster_error_retry_attempts) in RedisCluster.pipeline construction of ClusterPipeline

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -856,7 +856,6 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
             startup_nodes=self.nodes_manager.startup_nodes,
             result_callbacks=self.result_callbacks,
             cluster_response_callbacks=self.cluster_response_callbacks,
-            cluster_error_retry_attempts=self.retry.get_retries(),
             read_from_replicas=self.read_from_replicas,
             load_balancing_strategy=self.load_balancing_strategy,
             reinitialize_steps=self.reinitialize_steps,


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?


### Description of change

`cluster_error_retry_attempts` is a deprecated argument that was being passed to the constructor of ClusterPipeline from the `pipeline` method and thus using the cluster pipeline instance by way of constructing it through the `pipeline()` method was logging a deprecation warning.

Since the value is already being derived from `self.retry` and `retry=self.retry` is already being passed as an argument it should be safe to remove it without any change in behaviour.


#### Example:
```bash
bash-3.2$ python -W error -c 'import redis; redis.RedisCluster.from_url("redis://localhost:7001").pipeline()'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/ali/_dev/_git/redis-py/redis/cluster.py", line 853, in pipeline
    return ClusterPipeline(
           ^^^^^^^^^^^^^^^^
  File "/Users/ali/_dev/_git/redis-py/redis/utils.py", line 187, in wrapper
    warn_deprecated_arg_usage(
  File "/Users/ali/_dev/_git/redis-py/redis/utils.py", line 150, in warn_deprecated_arg_usage
    warnings.warn(msg, category=DeprecationWarning, stacklevel=stacklevel)
DeprecationWarning: Call to '__init__' function with deprecated usage of input argument/s 'cluster_error_retry_attempts'. (Please configure the 'retry' object instead) -- Deprecated since version 6.0.0.
```
