### PR TITLE
Removing references to old docs site 'https://redis-py.readthedocs/' replaced by 'https://redis.readthedocs.io/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The Python interface to the Redis key-value store.
 
 [![CI](https://github.com/redis/redis-py/workflows/CI/badge.svg?branch=master)](https://github.com/redis/redis-py/actions?query=workflow%3ACI+branch%3Amaster)
-[![docs](https://readthedocs.org/projects/redis/badge/?version=stable&style=flat)](https://redis-py.readthedocs.io/en/stable/)
+[![docs](https://readthedocs.org/projects/redis/badge/?version=stable&style=flat)](https://redis.readthedocs.io/en/stable/)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![pypi](https://badge.fury.io/py/redis.svg)](https://pypi.org/project/redis/)
 [![pre-release](https://img.shields.io/github/v/release/redis/redis-py?include_prereleases&label=latest-prerelease)](https://github.com/redis/redis-py/releases)

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,3 +1,3 @@
 # Examples
 
-Examples of redis-py usage go here. They're being linked to the [generated documentation](https://redis-py.readthedocs.org).
+Examples of redis-py usage go here. They're being linked to the [generated documentation](https://redis.readthedocs.org).

--- a/docs/examples/opentelemetry/README.md
+++ b/docs/examples/opentelemetry/README.md
@@ -4,7 +4,7 @@ This example demonstrates how to monitor Redis using [OpenTelemetry](https://ope
 [Uptrace](https://github.com/uptrace/uptrace). It requires Docker to start Redis Server and Uptrace.
 
 See
-[Monitoring redis-py performance with OpenTelemetry](https://redis-py.readthedocs.io/en/latest/opentelemetry.html)
+[Monitoring redis-py performance with OpenTelemetry](https://redis.readthedocs.io/en/latest/opentelemetry.html)
 for details.
 
 **Step 1**. Download the example using Git:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

The supported Read The Docs has been changed from '`https://redis-py.readthedocs/`' to '`https://redis.readthedocs.io/`' almost a year and a half ago, but some references to the old site have not been updated.
With this PR I'm updating all the docs refs to point to the new site that is being updated on each merge and each release.

The old site has already been decommissioned.
