### PR TITLE
Removing the threading.Lock locks and replacing them with RLock objects to avoid deadlocks.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -368,9 +368,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         ]:
             raise RedisError("Client caching is only supported with RESP version 3")
 
-        # TODO: To avoid breaking changes during the bug fix, we have to keep non-reentrant lock.
-        # TODO: Remove this before next major version (7.0.0)
-        self.single_connection_lock = threading.Lock()
+        self.single_connection_lock = threading.RLock()
         self.connection = None
         self._single_connection_client = single_connection_client
         if self._single_connection_client:
@@ -776,9 +774,7 @@ class PubSub:
         else:
             self._event_dispatcher = event_dispatcher
 
-        # TODO: To avoid breaking changes during the bug fix, we have to keep non-reentrant lock.
-        # TODO: Remove this before next major version (7.0.0)
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         if self.encoder is None:
             self.encoder = self.connection_pool.get_encoder()
         self.health_check_response_b = self.encoder.encode(self.HEALTH_CHECK_MESSAGE)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -810,7 +810,7 @@ class CacheProxyConnection(ConnectionInterface):
         self,
         conn: ConnectionInterface,
         cache: CacheInterface,
-        pool_lock: threading.Lock,
+        pool_lock: threading.RLock,
     ):
         self.pid = os.getpid()
         self._conn = conn
@@ -1422,13 +1422,7 @@ class ConnectionPool:
         # release the lock.
 
         self._fork_lock = threading.RLock()
-
-        if self.cache is None:
-            self._lock = threading.RLock()
-        else:
-            # TODO: To avoid breaking changes during the bug fix, we have to keep non-reentrant lock.
-            # TODO: Remove this before next major version (7.0.0)
-            self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
         self.reset()
 

--- a/redis/event.py
+++ b/redis/event.py
@@ -152,7 +152,7 @@ class AfterSingleConnectionInstantiationEvent:
         self,
         connection,
         client_type: ClientType,
-        connection_lock: Union[threading.Lock, asyncio.Lock],
+        connection_lock: Union[threading.RLock, asyncio.Lock],
     ):
         self._connection = connection
         self._client_type = client_type
@@ -167,7 +167,7 @@ class AfterSingleConnectionInstantiationEvent:
         return self._client_type
 
     @property
-    def connection_lock(self) -> Union[threading.Lock, asyncio.Lock]:
+    def connection_lock(self) -> Union[threading.RLock, asyncio.Lock]:
         return self._connection_lock
 
 
@@ -177,7 +177,7 @@ class AfterPubSubConnectionInstantiationEvent:
         pubsub_connection,
         connection_pool,
         client_type: ClientType,
-        connection_lock: Union[threading.Lock, asyncio.Lock],
+        connection_lock: Union[threading.RLock, asyncio.Lock],
     ):
         self._pubsub_connection = pubsub_connection
         self._connection_pool = connection_pool
@@ -197,7 +197,7 @@ class AfterPubSubConnectionInstantiationEvent:
         return self._client_type
 
     @property
-    def connection_lock(self) -> Union[threading.Lock, asyncio.Lock]:
+    def connection_lock(self) -> Union[threading.RLock, asyncio.Lock]:
         return self._connection_lock
 
 

--- a/tests/test_cluster_transaction.py
+++ b/tests/test_cluster_transaction.py
@@ -285,7 +285,7 @@ class TestClusterTransaction:
         mock_pool = Mock(spec=ConnectionPool)
         mock_pool.get_connection.return_value = mock_connection
         mock_pool._available_connections = [mock_connection]
-        mock_pool._lock = threading.Lock()
+        mock_pool._lock = threading.RLock()
 
         _node_migrating, node_importing = _find_source_and_target_node_for_slot(r, slot)
         node_importing.redis_connection.connection_pool = mock_pool
@@ -310,7 +310,7 @@ class TestClusterTransaction:
         mock_pool = Mock(spec=ConnectionPool)
         mock_pool.get_connection.return_value = mock_connection
         mock_pool._available_connections = [mock_connection]
-        mock_pool._lock = threading.Lock()
+        mock_pool._lock = threading.RLock()
 
         _node_migrating, node_importing = _find_source_and_target_node_for_slot(r, slot)
         node_importing.redis_connection.connection_pool = mock_pool

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -442,7 +442,7 @@ class TestUnitCacheProxyConnection:
         mock_connection.credential_provider = UsernamePasswordCredentialProvider()
 
         proxy_connection = CacheProxyConnection(
-            mock_connection, cache, threading.Lock()
+            mock_connection, cache, threading.RLock()
         )
         proxy_connection.disconnect()
 
@@ -492,7 +492,7 @@ class TestUnitCacheProxyConnection:
         mock_connection.can_read.return_value = False
 
         proxy_connection = CacheProxyConnection(
-            mock_connection, mock_cache, threading.Lock()
+            mock_connection, mock_cache, threading.RLock()
         )
         proxy_connection.send_command(*["GET", "foo"], **{"keys": ["foo"]})
         assert proxy_connection.read_response() == b"bar"
@@ -554,7 +554,7 @@ class TestUnitCacheProxyConnection:
         mock_connection.can_read.return_value = False
 
         proxy_connection = CacheProxyConnection(
-            mock_connection, mock_cache, threading.Lock()
+            mock_connection, mock_cache, threading.RLock()
         )
         proxy_connection.send_command(*["GET", "foo"], **{"keys": ["foo"]})
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -323,7 +323,7 @@ class TestStreamingCredentialProvider:
         }
         mock_pool.get_connection.return_value = mock_connection
         mock_pool._available_connections = [mock_connection, mock_another_connection]
-        mock_pool._lock = threading.Lock()
+        mock_pool._lock = threading.RLock()
         auth_token = None
 
         def re_auth_callback(token):
@@ -382,7 +382,7 @@ class TestStreamingCredentialProvider:
             mock_another_connection,
             mock_failed_connection,
         ]
-        mock_pool._lock = threading.Lock()
+        mock_pool._lock = threading.RLock()
 
         def _raise(error: RedisError):
             pass
@@ -442,7 +442,7 @@ class TestStreamingCredentialProvider:
             mock_another_connection,
         ]
         mock_pool._available_connections = [mock_another_connection]
-        mock_pool._lock = threading.Lock()
+        mock_pool._lock = threading.RLock()
         auth_token = None
 
         def re_auth_callback(token):
@@ -502,7 +502,7 @@ class TestStreamingCredentialProvider:
             mock_another_connection,
         ]
         mock_pool._available_connections = [mock_another_connection]
-        mock_pool._lock = threading.Lock()
+        mock_pool._lock = threading.RLock()
         auth_token = None
 
         def re_auth_callback(token):
@@ -560,7 +560,7 @@ class TestStreamingCredentialProvider:
         }
         mock_pool.get_connection.return_value = mock_connection
         mock_pool._available_connections = [mock_connection, mock_another_connection]
-        mock_pool._lock = threading.Lock()
+        mock_pool._lock = threading.RLock()
 
         Redis(
             connection_pool=mock_pool,


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Usage of `threading.Lock` has introduced deadlocks in the client. 
With this change, I'm removing all places that can cause such issues.
**The change is breaking, because it changes the interfaces of several objects and cannot  be released before the next major release, which will be 7.0.0**
