### PR TITLE
Removing synchronous context manager handling from async RedisCluster.

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1581,15 +1581,6 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
     def __await__(self) -> Generator[Any, None, "ClusterPipeline"]:
         return self.initialize().__await__()
 
-    def __enter__(self) -> "ClusterPipeline":
-        # TODO: Remove this method before 7.0.0
-        self._execution_strategy._command_queue = []
-        return self
-
-    def __exit__(self, exc_type: None, exc_value: None, traceback: None) -> None:
-        # TODO: Remove this method before 7.0.0
-        self._execution_strategy._command_queue = []
-
     def __bool__(self) -> bool:
         "Pipeline instances should  always evaluate to True on Python 3+"
         return True


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Removing support for using AsyncRedisCluster as a synchronous context manager. This class is designed primarily for asynchronous usage, and the majority of its methods are async. Allowing it to be used in a synchronous context is misleading and could result in incorrect or unintended behavior.
