### PR TITLE
Allow newer PyJWT versions for branch 5.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -67,6 +67,7 @@
     * Close Unix sockets if the connection attempt fails. This prevents `ResourceWarning`s. (#3314)
     * Close SSL sockets if the connection attempt fails, or if validations fail. (#3317)
     * Eliminate mutable default arguments in the `redis.commands.core.Script` class. (#3332)
+    * Allow newer versions of PyJWT as dependency. (#3630)
 
 * 4.1.3 (Feb 8, 2022)
   * Fix flushdb and flushall (#1926)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 async-timeout>=4.0.3
-PyJWT~=2.9.0
+PyJWT>=2.9.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         'async-timeout>=4.0.3; python_full_version<"3.11.3"',
-        "PyJWT~=2.9.0",
+        "PyJWT>=2.9.0",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Backported from the master branch (#3636).

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Allow PyJWT versions newer than `2.9.*`, since there are not any known compatibility issues with those. This change is already present in the master branch; it just needs to be backported and released on the 5.3 branch.