### PR TITLE
`LoadBalancer` keyed on slot instead of primary node, not reset on `NodesManager.initialize()`

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1835,7 +1835,6 @@ class NodesManager:
 
     def reset(self):
         pass
-    
 
     def remap_host_port(self, host: str, port: int) -> Tuple[str, int]:
         """

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1835,6 +1835,7 @@ class NodesManager:
 
     def reset(self):
         pass
+    
 
     def remap_host_port(self, host: str, port: int) -> Tuple[str, int]:
         """

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1403,12 +1403,12 @@ class LoadBalancer:
     """
 
     def __init__(self, start_index: int = 0) -> None:
-        self.primary_to_idx = {}
+        self.slot_to_idx = {}
         self.start_index = start_index
 
     def get_server_index(
         self,
-        primary: str,
+        slot: int,
         list_size: int,
         load_balancing_strategy: LoadBalancingStrategy = LoadBalancingStrategy.ROUND_ROBIN,
     ) -> int:
@@ -1416,26 +1416,26 @@ class LoadBalancer:
             return self._get_random_replica_index(list_size)
         else:
             return self._get_round_robin_index(
-                primary,
+                slot,
                 list_size,
                 load_balancing_strategy == LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
             )
 
     def reset(self) -> None:
-        self.primary_to_idx.clear()
+        self.slot_to_idx.clear()
 
     def _get_random_replica_index(self, list_size: int) -> int:
         return random.randint(1, list_size - 1)
 
     def _get_round_robin_index(
-        self, primary: str, list_size: int, replicas_only: bool
+        self, slot: int, list_size: int, replicas_only: bool
     ) -> int:
-        server_index = self.primary_to_idx.setdefault(primary, self.start_index)
+        server_index = self.slot_to_idx.setdefault(slot, self.start_index)
         if replicas_only and server_index == 0:
             # skip the primary node index
             server_index = 1
         # Update the index for the next round
-        self.primary_to_idx[primary] = (server_index + 1) % list_size
+        self.slot_to_idx[slot] = (server_index + 1) % list_size
         return server_index
 
 
@@ -1575,9 +1575,8 @@ class NodesManager:
 
         if len(self.slots_cache[slot]) > 1 and load_balancing_strategy:
             # get the server index using the strategy defined in load_balancing_strategy
-            primary_name = self.slots_cache[slot][0].name
             node_idx = self.read_load_balancer.get_server_index(
-                primary_name, len(self.slots_cache[slot]), load_balancing_strategy
+                slot, len(self.slots_cache[slot]), load_balancing_strategy
             )
         elif (
             server_type is None
@@ -1835,11 +1834,7 @@ class NodesManager:
                 node.redis_connection.close()
 
     def reset(self):
-        try:
-            self.read_load_balancer.reset()
-        except TypeError:
-            # The read_load_balancer is None, do nothing
-            pass
+        pass
 
     def remap_host_port(self, host: str, port: int) -> Tuple[str, int]:
         """

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -2444,33 +2444,31 @@ class TestNodesManager:
             slot_1: [node_1, node_2, node_3],
             slot_2: [node_4, node_5],
         }
-        primary1_name = n_manager.slots_cache[slot_1][0].name
-        primary2_name = n_manager.slots_cache[slot_2][0].name
         list1_size = len(n_manager.slots_cache[slot_1])
         list2_size = len(n_manager.slots_cache[slot_2])
 
         # default load balancer strategy: LoadBalancerStrategy.ROUND_ROBIN
         # slot 1
-        assert lb.get_server_index(primary1_name, list1_size) == 0
-        assert lb.get_server_index(primary1_name, list1_size) == 1
-        assert lb.get_server_index(primary1_name, list1_size) == 2
-        assert lb.get_server_index(primary1_name, list1_size) == 0
+        assert lb.get_server_index(slot_1, list1_size) == 0
+        assert lb.get_server_index(slot_1, list1_size) == 1
+        assert lb.get_server_index(slot_1, list1_size) == 2
+        assert lb.get_server_index(slot_1, list1_size) == 0
 
         # slot 2
-        assert lb.get_server_index(primary2_name, list2_size) == 0
-        assert lb.get_server_index(primary2_name, list2_size) == 1
-        assert lb.get_server_index(primary2_name, list2_size) == 0
+        assert lb.get_server_index(slot_2, list2_size) == 0
+        assert lb.get_server_index(slot_2, list2_size) == 1
+        assert lb.get_server_index(slot_2, list2_size) == 0
 
         lb.reset()
-        assert lb.get_server_index(primary1_name, list1_size) == 0
-        assert lb.get_server_index(primary2_name, list2_size) == 0
+        assert lb.get_server_index(slot_1, list1_size) == 0
+        assert lb.get_server_index(slot_2, list2_size) == 0
 
         # reset the indexes before load balancing strategy test
         lb.reset()
         # load balancer strategy: LoadBalancerStrategy.ROUND_ROBIN_REPLICAS
         for i in [1, 2, 1]:
             srv_index = lb.get_server_index(
-                primary1_name,
+                slot_1,
                 list1_size,
                 load_balancing_strategy=LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
             )
@@ -2481,7 +2479,7 @@ class TestNodesManager:
         # load balancer strategy: LoadBalancerStrategy.RANDOM_REPLICA
         for i in range(5):
             srv_index = lb.get_server_index(
-                primary1_name,
+                slot_1,
                 list1_size,
                 load_balancing_strategy=LoadBalancingStrategy.RANDOM_REPLICA,
             )

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2549,32 +2549,30 @@ class TestNodesManager:
             slot_1: [node_1, node_2, node_3],
             slot_2: [node_4, node_5],
         }
-        primary1_name = n_manager.slots_cache[slot_1][0].name
-        primary2_name = n_manager.slots_cache[slot_2][0].name
         list1_size = len(n_manager.slots_cache[slot_1])
         list2_size = len(n_manager.slots_cache[slot_2])
 
         # default load balancer strategy: LoadBalancerStrategy.ROUND_ROBIN
         # slot 1
-        assert lb.get_server_index(primary1_name, list1_size) == 0
-        assert lb.get_server_index(primary1_name, list1_size) == 1
-        assert lb.get_server_index(primary1_name, list1_size) == 2
-        assert lb.get_server_index(primary1_name, list1_size) == 0
+        assert lb.get_server_index(slot_1, list1_size) == 0
+        assert lb.get_server_index(slot_1, list1_size) == 1
+        assert lb.get_server_index(slot_1, list1_size) == 2
+        assert lb.get_server_index(slot_1, list1_size) == 0
         # slot 2
-        assert lb.get_server_index(primary2_name, list2_size) == 0
-        assert lb.get_server_index(primary2_name, list2_size) == 1
-        assert lb.get_server_index(primary2_name, list2_size) == 0
+        assert lb.get_server_index(slot_2, list2_size) == 0
+        assert lb.get_server_index(slot_2, list2_size) == 1
+        assert lb.get_server_index(slot_2, list2_size) == 0
 
         lb.reset()
-        assert lb.get_server_index(primary1_name, list1_size) == 0
-        assert lb.get_server_index(primary2_name, list2_size) == 0
+        assert lb.get_server_index(slot_1, list1_size) == 0
+        assert lb.get_server_index(slot_2, list2_size) == 0
 
         # reset the indexes before load balancing strategy test
         lb.reset()
         # load balancer strategy: LoadBalancerStrategy.ROUND_ROBIN_REPLICAS
         for i in [1, 2, 1]:
             srv_index = lb.get_server_index(
-                primary1_name,
+                slot_1,
                 list1_size,
                 load_balancing_strategy=LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
             )
@@ -2585,7 +2583,7 @@ class TestNodesManager:
         # load balancer strategy: LoadBalancerStrategy.RANDOM_REPLICA
         for i in range(5):
             srv_index = lb.get_server_index(
-                primary1_name,
+                slot_1,
                 list1_size,
                 load_balancing_strategy=LoadBalancingStrategy.RANDOM_REPLICA,
             )


### PR DESCRIPTION
### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)? [link](https://github.com/drewfustin/redis-py/actions/runs/15764094627)
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

### Description of change

- Fixes #3681
- `LoadBalancer` now uses `slot_to_idx` instead of `primary_to_idx`, using slot as the key instead of primary node name.
- When `NodesManager` resets in `initialize`, it no longer runs `LoadBalancer.reset()` which would clear the `slot_to_idx` dictionary.
- Tests `TestNodesManager.test_load_balancer` updated accordingly.

As noted in #3681, reseting the load balancer on `NodesManager.initialize()` causes the index associated with the primary node to reset to 0. If a `ConnectionError` or `TimeoutError` is raised by an attempt to connect to a primary node, `NodesManager.initialize()` is called, and the the load balancer's index for that node will reset to 0. Therefore, the next attempt in the retry loop will not move on from the primary node to a replica node (with index > 0) as expected, but will instead retry the primary node again (and presumably raise the same error).

Since `NodesManager.initialize()` being called on `ConnectionError` or `TimeoutError` is the valid strategy, and since the primary node's host will often be replaced in tandem with events that cause these errors (e.g. when a primary node is deleted and then recreated in Kubernetes), keying the `LoadBalancer` dictionary on the primary node's name (`host:port`) doesn't feel appropriate. Instead, keying the dictionary on the Redis Cluster's slot seems to be a better strategy. As such, the `server_index` corresponding to key `slot` doesn't need to be reset to 0 on `NodesManager.initialize()` as the `slot` isn't expected to change and need to be reset, only the `host:port` would require such. Instead, the `slot` can maintain its "state" even when the `NodesManager` is reinitialized, thus resolving #3681.

With the fix in this PR implemented, the output of the loop from #3681 becomes what is expected when the primary node goes down (the load balancer continues to the next node on a `TimeoutError`):

```
Attempt 1
idx: 2 | node: 100.66.151.143:6379 | type: replica
'bar'

Attempt 2
idx: 0 | node: 100.66.122.229:6379 | type: primary
Exception: Timeout connecting to server

Attempt 3
idx: 1 | node: 100.66.151.143:6379 | type: replica
'bar'

Attempt 4
idx: 2 | node: 100.66.106.241:6379 | type: replica
'bar'

Attempt 5
idx: 0 | node: 100.66.122.229:6379 | type: primary
Exception: Error 113 connecting to 100.66.122.229:6379. No route to host.
```