### PR TITLE
Add support for new BITOP operations: DIFF, DIFF1, ANDOR, ONE

### DIFF
--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -880,6 +880,130 @@ class TestRedisCommands:
         assert int(binascii.hexlify(await r.get("res3")), 16) == 0x000000FF
 
     @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.2.0")
+    async def test_bitop_diff(self, r: redis.Redis):
+        """Test BITOP DIFF operation"""
+        # Set up test data: a=0b11110000, b=0b11000000, c=0b10000000
+        await r.set("a", b"\xf0")  # 11110000
+        await r.set("b", b"\xc0")  # 11000000
+        await r.set("c", b"\x80")  # 10000000
+
+        # DIFF: a AND NOT(b OR c) = 11110000 AND NOT(11000000) = 11110000 AND 00111111 = 00110000
+        result = await r.bitop("DIFF", "result", "a", "b", "c")
+        assert result == 1  # Length of result
+        assert await r.get("result") == b"\x30"  # 00110000
+
+        # Test with non-existent keys
+        await r.bitop("DIFF", "result2", "a", "nonexistent")
+        assert await r.get("result2") == b"\xf0"  # Should be same as 'a'
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.2.0")
+    async def test_bitop_diff1(self, r: redis.Redis):
+        """Test BITOP DIFF1 operation"""
+        # Set up test data: a=0b11110000, b=0b11000000, c=0b10000000
+        await r.set("a", b"\xf0")  # 11110000
+        await r.set("b", b"\xc0")  # 11000000
+        await r.set("c", b"\x80")  # 10000000
+
+        # DIFF1: NOT(a) AND (b OR c) = NOT(11110000) AND (11000000) = 00001111 AND 11000000 = 00000000
+        result = await r.bitop("DIFF1", "result", "a", "b", "c")
+        assert result == 1  # Length of result
+        assert await r.get("result") == b"\x00"  # 00000000
+
+        # Test with different data where result is non-zero
+        await r.set("d", b"\x0f")  # 00001111
+        await r.set("e", b"\x03")  # 00000011
+        # DIFF1: NOT(d) AND e = NOT(00001111) AND 00000011 = 11110000 AND 00000011 = 00000000
+        await r.bitop("DIFF1", "result2", "d", "e")
+        assert await r.get("result2") == b"\x00"
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.2.0")
+    async def test_bitop_andor(self, r: redis.Redis):
+        """Test BITOP ANDOR operation"""
+        # Set up test data: a=0b11110000, b=0b11000000, c=0b10000000
+        await r.set("a", b"\xf0")  # 11110000
+        await r.set("b", b"\xc0")  # 11000000
+        await r.set("c", b"\x80")  # 10000000
+
+        # ANDOR: a AND (b OR c) = 11110000 AND (11000000) = 11110000 AND 11000000 = 11000000
+        result = await r.bitop("ANDOR", "result", "a", "b", "c")
+        assert result == 1  # Length of result
+        assert await r.get("result") == b"\xc0"  # 11000000
+
+        # Test with non-overlapping bits
+        await r.set("x", b"\xf0")  # 11110000
+        await r.set("y", b"\x0f")  # 00001111
+        await r.bitop("ANDOR", "result2", "x", "y")
+        assert await r.get("result2") == b"\x00"  # No overlap
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.2.0")
+    async def test_bitop_one(self, r: redis.Redis):
+        """Test BITOP ONE operation"""
+        # Set up test data: a=0b11110000, b=0b11000000, c=0b10000000
+        await r.set("a", b"\xf0")  # 11110000
+        await r.set("b", b"\xc0")  # 11000000
+        await r.set("c", b"\x80")  # 10000000
+
+        # ONE: bits set in exactly one key
+        # Position analysis:
+        # Bit 7: a=1, b=1, c=1 -> count=3 -> not included
+        # Bit 6: a=1, b=1, c=0 -> count=2 -> not included
+        # Bit 5: a=1, b=0, c=0 -> count=1 -> included
+        # Bit 4: a=1, b=0, c=0 -> count=1 -> included
+        # Expected result: 00110000 = 0x30
+        result = await r.bitop("ONE", "result", "a", "b", "c")
+        assert result == 1  # Length of result
+        assert await r.get("result") == b"\x30"  # 00110000
+
+        # Test with two keys (should be equivalent to XOR)
+        await r.set("x", b"\xf0")  # 11110000
+        await r.set("y", b"\x0f")  # 00001111
+        await r.bitop("ONE", "result2", "x", "y")
+        assert await r.get("result2") == b"\xff"  # 11111111 (XOR result)
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.2.0")
+    async def test_bitop_new_operations_with_empty_keys(self, r: redis.Redis):
+        """Test new BITOP operations with empty/non-existent keys"""
+        await r.set("a", b"\xff")  # 11111111
+
+        # Test with empty destination
+        await r.bitop("DIFF", "empty_result", "nonexistent", "a")
+        assert await r.get("empty_result") is None
+
+        await r.bitop("DIFF1", "empty_result2", "a", "nonexistent")
+        assert await r.get("empty_result2") is None
+
+        await r.bitop("ANDOR", "empty_result3", "a", "nonexistent")
+        assert await r.get("empty_result3") is None
+
+        await r.bitop("ONE", "empty_result4", "nonexistent")
+        assert await r.get("empty_result4") is None
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.2.0")
+    async def test_bitop_new_operations_return_values(self, r: redis.Redis):
+        """Test that new BITOP operations return correct length values"""
+        await r.set("a", b"\xff\x00\xff")  # 3 bytes
+        await r.set("b", b"\x00\xff")      # 2 bytes
+
+        # All operations should return the length of the result string
+        result1 = await r.bitop("DIFF", "result1", "a", "b")
+        assert result1 == 3  # Length of longest input
+
+        result2 = await r.bitop("DIFF1", "result2", "a", "b")
+        assert result2 == 3
+
+        result3 = await r.bitop("ANDOR", "result3", "a", "b")
+        assert result3 == 3
+
+        result4 = await r.bitop("ONE", "result4", "a", "b")
+        assert result4 == 3
+
+    @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("2.8.7")
     async def test_bitpos(self, r: redis.Redis):
         key = "key:bitpos"

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -880,7 +880,7 @@ class TestRedisCommands:
         assert int(binascii.hexlify(await r.get("res3")), 16) == 0x000000FF
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     async def test_bitop_diff(self, r: redis.Redis):
         await r.set("a", b"\xf0")
         await r.set("b", b"\xc0")
@@ -894,7 +894,7 @@ class TestRedisCommands:
         assert await r.get("result2") == b"\xf0"
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     async def test_bitop_diff1(self, r: redis.Redis):
         await r.set("a", b"\xf0")
         await r.set("b", b"\xc0")
@@ -910,7 +910,7 @@ class TestRedisCommands:
         assert await r.get("result2") == b"\x00"
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     async def test_bitop_andor(self, r: redis.Redis):
         await r.set("a", b"\xf0")
         await r.set("b", b"\xc0")
@@ -926,7 +926,7 @@ class TestRedisCommands:
         assert await r.get("result2") == b"\x00"
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     async def test_bitop_one(self, r: redis.Redis):
         await r.set("a", b"\xf0")
         await r.set("b", b"\xc0")
@@ -942,7 +942,7 @@ class TestRedisCommands:
         assert await r.get("result2") == b"\xff"
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     async def test_bitop_new_operations_with_empty_keys(self, r: redis.Redis):
         await r.set("a", b"\xff")
 
@@ -959,7 +959,7 @@ class TestRedisCommands:
         assert await r.get("empty_result4") is None
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     async def test_bitop_new_operations_return_values(self, r: redis.Redis):
         await r.set("a", b"\xff\x00\xff")
         await r.set("b", b"\x00\xff")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1314,7 +1314,7 @@ class TestRedisCommands:
         assert int(binascii.hexlify(r["res3"]), 16) == 0x000000FF
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     def test_bitop_diff(self, r):
         r["a"] = b"\xf0"
         r["b"] = b"\xc0"
@@ -1328,7 +1328,7 @@ class TestRedisCommands:
         assert r["result2"] == b"\xf0"
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     def test_bitop_diff1(self, r):
         r["a"] = b"\xf0"
         r["b"] = b"\xc0"
@@ -1344,7 +1344,7 @@ class TestRedisCommands:
         assert r["result2"] == b"\x00"
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     def test_bitop_andor(self, r):
         r["a"] = b"\xf0"
         r["b"] = b"\xc0"
@@ -1360,7 +1360,7 @@ class TestRedisCommands:
         assert r["result2"] == b"\x00"
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     def test_bitop_one(self, r):
         r["a"] = b"\xf0"
         r["b"] = b"\xc0"
@@ -1376,7 +1376,7 @@ class TestRedisCommands:
         assert r["result2"] == b"\xff"
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     def test_bitop_new_operations_with_empty_keys(self, r):
         r["a"] = b"\xff"
 
@@ -1393,7 +1393,7 @@ class TestRedisCommands:
         assert r.get("empty_result4") is None
 
     @pytest.mark.onlynoncluster
-    @skip_if_server_version_lt("8.2.0")
+    @skip_if_server_version_lt("8.1.224")
     def test_bitop_new_operations_return_values(self, r):
         r["a"] = b"\xff\x00\xff"
         r["b"] = b"\x00\xff"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1316,8 +1316,8 @@ class TestRedisCommands:
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.2.0")
     def test_bitop_diff(self, r):
-        r["a"] = b"\xf0" 
-        r["b"] = b"\xc0" 
+        r["a"] = b"\xf0"
+        r["b"] = b"\xc0"
         r["c"] = b"\x80"
 
         result = r.bitop("DIFF", "result", "a", "b", "c")
@@ -1330,15 +1330,15 @@ class TestRedisCommands:
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.2.0")
     def test_bitop_diff1(self, r):
-        r["a"] = b"\xf0" 
-        r["b"] = b"\xc0" 
-        r["c"] = b"\x80" 
+        r["a"] = b"\xf0"
+        r["b"] = b"\xc0"
+        r["c"] = b"\x80"
 
         result = r.bitop("DIFF1", "result", "a", "b", "c")
         assert result == 1
         assert r["result"] == b"\x00"
 
-        r["d"] = b"\x0f" 
+        r["d"] = b"\x0f"
         r["e"] = b"\x03"
         r.bitop("DIFF1", "result2", "d", "e")
         assert r["result2"] == b"\x00"
@@ -1346,16 +1346,16 @@ class TestRedisCommands:
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.2.0")
     def test_bitop_andor(self, r):
-        r["a"] = b"\xf0" 
-        r["b"] = b"\xc0" 
-        r["c"] = b"\x80" 
+        r["a"] = b"\xf0"
+        r["b"] = b"\xc0"
+        r["c"] = b"\x80"
 
         result = r.bitop("ANDOR", "result", "a", "b", "c")
-        assert result == 1 
-        assert r["result"] == b"\xc0" 
+        assert result == 1
+        assert r["result"] == b"\xc0"
 
-        r["x"] = b"\xf0" 
-        r["y"] = b"\x0f" 
+        r["x"] = b"\xf0"
+        r["y"] = b"\x0f"
         r.bitop("ANDOR", "result2", "x", "y")
         assert r["result2"] == b"\x00"
 
@@ -1371,7 +1371,7 @@ class TestRedisCommands:
         assert r["result"] == b"\x30"
 
         r["x"] = b"\xf0"
-        r["y"] = b"\x0f" 
+        r["y"] = b"\x0f"
         r.bitop("ONE", "result2", "x", "y")
         assert r["result2"] == b"\xff"
 
@@ -1381,13 +1381,13 @@ class TestRedisCommands:
         r["a"] = b"\xff"
 
         r.bitop("DIFF", "empty_result", "nonexistent", "a")
-        assert r.get("empty_result") is None
+        assert r.get("empty_result") == b"\x00"
 
         r.bitop("DIFF1", "empty_result2", "a", "nonexistent")
-        assert r.get("empty_result2") is None
+        assert r.get("empty_result2") == b"\x00"
 
         r.bitop("ANDOR", "empty_result3", "a", "nonexistent")
-        assert r.get("empty_result3") is None
+        assert r.get("empty_result3") == b"\x00"
 
         r.bitop("ONE", "empty_result4", "nonexistent")
         assert r.get("empty_result4") is None


### PR DESCRIPTION
### Summary
This PR adds support for four new BITOP operations that will be available in Redis 8.2+: DIFF, DIFF1, ANDOR, and ONE. These operations extend Redis bitmap functionality to support common set operations that previously required multiple commands or Lua scripts.

### New Operations
BITOP DIFF: Returns members of the first bitmap that are not members of any other bitmaps (X ∧ ¬(Y1 ∨ Y2 ∨ ...))
BITOP DIFF1: Returns members of any bitmap except the first that are not members of the first bitmap (¬X ∧ (Y1 ∨ Y2 ∨ ...))
BITOP ANDOR: Returns members of the first bitmap that are also members of one or more other bitmaps (X ∧ (Y1 ∨ Y2 ∨ ...))
BITOP ONE: Returns members of exactly one of the given bitmaps (generalized XOR for multiple keys)
### Changes Made
Tests: Added comprehensive test coverage for all four new operations
Synchronous tests in tests/test_commands.py
Asynchronous tests in tests/test_asyncio/test_commands.py
Tests include bitwise logic verification, edge cases, and return value validation
All tests gated with @skip_if_server_version_lt("8.2.0") for compatibility