### PR TITLE
docs: fix `zadd` command parameter description

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -4172,17 +4172,17 @@ class SortedSetCommands(CommandsProtocol):
         the existing score will be incremented by. When using this mode the
         return value of ZADD will be the new score of the element.
 
-        ``LT`` Only update existing elements if the new score is less than
+        ``lt`` only updates existing elements if the new score is less than
         the current score. This flag doesn't prevent adding new elements.
 
-        ``GT`` Only update existing elements if the new score is greater than
+        ``gt`` only updates existing elements if the new score is greater than
         the current score. This flag doesn't prevent adding new elements.
 
         The return value of ZADD varies based on the mode specified. With no
         options, ZADD returns the number of new elements added to the sorted
         set.
 
-        ``NX``, ``LT``, and ``GT`` are mutually exclusive options.
+        ``nx``, ``lt``, and ``gt`` are mutually exclusive options.
 
         See: https://redis.io/commands/ZADD
         """


### PR DESCRIPTION
### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?


### Description of change

I changed the case, because they are all in lower-case as parameters of `zadd()`. And fixed the description to be in style with others.
