### PR TITLE
blocking_timeout should default to self.timeout

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -219,7 +219,7 @@ class Lock:
         if blocking is None:
             blocking = self.blocking
         if blocking_timeout is None:
-            blocking_timeout = self.blocking_timeout
+            blocking_timeout = self.blocking_timeout or self.timeout
         stop_trying_at = None
         if blocking_timeout is not None:
             stop_trying_at = mod_time.monotonic() + blocking_timeout


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [NA] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [NA] Is there an example added to the examples folder (if applicable)?

### Description of change

Default the `blocking_timeout` on `Lock.acquire` to `self.timeout`.

I ran into a platform specific error, which prevented redis-py from acquiring a Lock. Although the `timeout` was set, there was no `blocking_timeout`.  This led to a test suite hanging on an infinite loop, minutes longer than the explicit timeout.  There is no reason for a blocking_timeout to ever be longer than the normal timeout.

If the acquire succeeds after the Lock.timeout expires, the lock will already fail.  This change simply makes that failure instant, and prevents potentially infinite loops.