### PR TITLE
Fix docstring for ssl_check_hostname

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1379,7 +1379,7 @@ class SSLConnection(Connection):
             ssl_cert_reqs: The string value for the SSLContext.verify_mode (none, optional, required), or an ssl.VerifyMode. Defaults to "required".
             ssl_ca_certs: The path to a file of concatenated CA certificates in PEM format. Defaults to None.
             ssl_ca_data: Either an ASCII string of one or more PEM-encoded certificates or a bytes-like object of DER-encoded certificates.
-            ssl_check_hostname: If set, match the hostname during the SSL handshake. Defaults to False.
+            ssl_check_hostname: If set, match the hostname during the SSL handshake. Defaults to True.
             ssl_ca_path: The path to a directory containing several CA certificates in PEM format. Defaults to None.
             ssl_password: Password for unlocking an encrypted private key. Defaults to None.
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [N/A (doc only)] Do tests and lints pass with this change?
- [N/A (doc only)] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [N/A (doc only)] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [N/A (doc only)] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

The default value of `ssl_check_hostname` was changed in #3626 but the docstring still stated the default was `False`. This PR just changes that docstring text to match the new default.
