### PR TITLE
[#3612] Generating unique command cache key

### DIFF
--- a/redis/cache.py
+++ b/redis/cache.py
@@ -19,6 +19,7 @@ class EvictionPolicyType(Enum):
 class CacheKey:
     command: str
     redis_keys: tuple
+    redis_args: tuple = ()
 
 
 class CacheEntry:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1214,7 +1214,7 @@ class CacheProxyConnection(ConnectionInterface):
         with self._cache_lock:
             # Command is write command or not allowed
             # to be cached.
-            if not self._cache.is_cachable(CacheKey(command=args[0], redis_keys=())):
+            if not self._cache.is_cachable(CacheKey(command=args[0], redis_keys=(), redis_args=())):
                 self._current_command_cache_key = None
                 self._conn.send_command(*args, **kwargs)
                 return
@@ -1224,7 +1224,7 @@ class CacheProxyConnection(ConnectionInterface):
 
         # Creates cache key.
         self._current_command_cache_key = CacheKey(
-            command=args[0], redis_keys=tuple(kwargs.get("keys"))
+            command=args[0], redis_keys=tuple(kwargs.get("keys")), redis_args=args
         )
 
         with self._cache_lock:


### PR DESCRIPTION


### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
PR tries to solve the client-side-caching not updating local cache key for various different args fields. While creating CacheKey model instance only present state only considering command_key and key names tuple. Which omitting different field names should have different cache key for HGET. 

My maintaining Model field of redis_args for CacheKey class will resolve the issue of having non-uniqueness of key generation. 

How to reproduce issue?
Example-1:
mentioned in this issue #3612 

Example-2
```python
import redis
from redis.cache import CacheConfig

url = 'xxx'
name = 'abcde'

r = redis.from_url(url, protocol=3, cache_config=CacheConfig())
r1 = redis.from_url(url)
r1.hset(name, key="field3", value="ccc")
r1.hset(name, key="field4", value="ddd")
r1.hset(name, key="field5", value="eee")

print(r.hget(name, "field3")) # print b'ccc' -> After fix print b'ccc'
print(r.hget(name, 'field4')) # print b'ccc' -> After fix print b'ddd'
print(r.hget(name, 'field5')) # print b'ccc' -> After fix print b'eee'

```
##### Conclusion
I was not able to run whole test folder but I have ran `test_encoding`, `test_cache` which looks essential for change PR proposing. Feel free to update me by adding comments, I am new to contribution would like to incorporate changes
