### PR TITLE
Fix automation scenarion maint notification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,12 @@ filterwarnings = [
     # Ignore a coverage warning when COVERAGE_CORE=sysmon for Pythons < 3.12.
     "ignore:sys.monitoring isn't available:coverage.exceptions.CoverageWarning",
 ]
+log_cli_level = "DEBUG"
+log_cli_date_format = "%H:%M:%S:%f"
+log_cli = true
+log_cli_format = "%(asctime)s %(levelname)s %(threadName)s: %(message)s"
+log_level = "DEBUG"
+capture = "yes"
 
 [tool.ruff]
 target-version = "py39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,11 +80,11 @@ filterwarnings = [
     # Ignore a coverage warning when COVERAGE_CORE=sysmon for Pythons < 3.12.
     "ignore:sys.monitoring isn't available:coverage.exceptions.CoverageWarning",
 ]
-log_cli_level = "DEBUG"
+log_cli_level = "INFO"
 log_cli_date_format = "%H:%M:%S:%f"
-log_cli = true
+log_cli = false
 log_cli_format = "%(asctime)s %(levelname)s %(threadName)s: %(message)s"
-log_level = "DEBUG"
+log_level = "INFO"
 capture = "yes"
 
 [tool.ruff]

--- a/tests/test_scenario/maint_notifications_helpers.py
+++ b/tests/test_scenario/maint_notifications_helpers.py
@@ -164,22 +164,22 @@ class ClusterOperations:
                 shards_section_started = False
 
         # Find empty node (node with no shards from ANY database)
-        empty_nodes = all_nodes - nodes_with_any_shards
+        nodes_with_no_shards_target_bdb = all_nodes - nodes_with_target_db_shards
 
         logging.debug(f"All nodes: {all_nodes}")
         logging.debug(f"Nodes with shards from any database: {nodes_with_any_shards}")
         logging.debug(f"Nodes with target database shards: {nodes_with_target_db_shards}")
         logging.debug(f"Master nodes (target database only): {master_nodes}")
-        logging.debug(f"Empty nodes: {empty_nodes}")
+        logging.debug(f"Nodes with no shards from target database: {nodes_with_no_shards_target_bdb}")
 
-        if not empty_nodes:
-            raise ValueError("No empty nodes (nodes without shards) found")
+        if not nodes_with_no_shards_target_bdb:
+            raise ValueError("All nodes have shards from target database")
 
         if not master_nodes:
-            raise ValueError("No nodes with master shards found")
+            raise ValueError("No nodes with master shards from target database found")
 
         # Return the first available empty node and master node (numeric part only)
-        empty_node = next(iter(empty_nodes)).split(":")[1]  # node:1 -> 1
+        empty_node = next(iter(nodes_with_no_shards_target_bdb)).split(":")[1]  # node:1 -> 1
         target_node = next(iter(master_nodes)).split(":")[1]  # node:2 -> 2
 
         return target_node, empty_node

--- a/tests/test_scenario/maint_notifications_helpers.py
+++ b/tests/test_scenario/maint_notifications_helpers.py
@@ -168,9 +168,13 @@ class ClusterOperations:
 
         logging.debug(f"All nodes: {all_nodes}")
         logging.debug(f"Nodes with shards from any database: {nodes_with_any_shards}")
-        logging.debug(f"Nodes with target database shards: {nodes_with_target_db_shards}")
+        logging.debug(
+            f"Nodes with target database shards: {nodes_with_target_db_shards}"
+        )
         logging.debug(f"Master nodes (target database only): {master_nodes}")
-        logging.debug(f"Nodes with no shards from target database: {nodes_with_no_shards_target_bdb}")
+        logging.debug(
+            f"Nodes with no shards from target database: {nodes_with_no_shards_target_bdb}"
+        )
 
         if not nodes_with_no_shards_target_bdb:
             raise ValueError("All nodes have shards from target database")
@@ -179,7 +183,9 @@ class ClusterOperations:
             raise ValueError("No nodes with master shards from target database found")
 
         # Return the first available empty node and master node (numeric part only)
-        empty_node = next(iter(nodes_with_no_shards_target_bdb)).split(":")[1]  # node:1 -> 1
+        empty_node = next(iter(nodes_with_no_shards_target_bdb)).split(":")[
+            1
+        ]  # node:1 -> 1
         target_node = next(iter(master_nodes)).split(":")[1]  # node:2 -> 2
 
         return target_node, empty_node

--- a/tests/test_scenario/maint_notifications_helpers.py
+++ b/tests/test_scenario/maint_notifications_helpers.py
@@ -116,8 +116,9 @@ class ClusterOperations:
 
         # Get all node IDs from CLUSTER NODES section
         all_nodes = set()
-        nodes_with_shards = set()
-        master_nodes = set()
+        nodes_with_any_shards = set()  # Nodes with shards from ANY database
+        nodes_with_target_db_shards = set()  # Nodes with shards from target database
+        master_nodes = set()  # Master nodes for target database only
 
         for line in lines:
             line = line.strip()
@@ -146,21 +147,29 @@ class ClusterOperations:
                 # Parse shard line: db:1  m-standard  redis:1  node:2  master  0-8191  1.4MB  OK
                 parts = line.split()
                 if len(parts) >= 5:
+                    db_id = parts[0]  # db:1, db:2, etc.
                     node_id = parts[3]  # node:2
                     shard_role = parts[4]  # master/slave - this is what matters
 
-                    nodes_with_shards.add(node_id)
-                    if shard_role == "master":
-                        master_nodes.add(node_id)
+                    # Track ALL nodes with shards (for finding truly empty nodes)
+                    nodes_with_any_shards.add(node_id)
+
+                    # Only track master nodes for the specific database we're testing
+                    bdb_id = endpoint_config.get("bdb_id")
+                    if db_id == f"db:{bdb_id}":
+                        nodes_with_target_db_shards.add(node_id)
+                        if shard_role == "master":
+                            master_nodes.add(node_id)
             elif line.startswith("ENDPOINTS:") or not line:
                 shards_section_started = False
 
-        # Find empty node (node with no shards)
-        empty_nodes = all_nodes - nodes_with_shards
+        # Find empty node (node with no shards from ANY database)
+        empty_nodes = all_nodes - nodes_with_any_shards
 
         logging.debug(f"All nodes: {all_nodes}")
-        logging.debug(f"Nodes with shards: {nodes_with_shards}")
-        logging.debug(f"Master nodes: {master_nodes}")
+        logging.debug(f"Nodes with shards from any database: {nodes_with_any_shards}")
+        logging.debug(f"Nodes with target database shards: {nodes_with_target_db_shards}")
+        logging.debug(f"Master nodes (target database only): {master_nodes}")
         logging.debug(f"Empty nodes: {empty_nodes}")
 
         if not empty_nodes:


### PR DESCRIPTION
The current scenario tests have 3 issues which we have to fix for our nightly CI to work.
1. they would not work so well with a cluster that has multiple dbs, so I fixed the logic to choose: 
    Master node of our target db
    Any node without shards of the target db
2. They require more logs (This part of the PR can be removed, depending on comments)
3. They take too long due to clean-up. The clean-up can be mostly removed besides the failover one. Because migrate and bind are operations that should take the cluster into usable for next scenario tests. The only exception is migrate only tests. 
(a notification is sent only when we did mgirate + bind, because the proxy is pointing towards "empty" node)
