### PR TITLE
fix(async): apply socket_timeout per read in async parsers

### DIFF
--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -518,7 +518,9 @@ class _AsyncRESPBase(AsyncBaseParser):
         self._pos = 0
 
     def _clear(self):
-        self._buffer = b""
+        """Clear parsed data but preserve unconsumed pipelined bytes."""
+        self._buffer = self._buffer[self._pos :]
+        self._pos = 0
         self._chunks.clear()
 
     def on_connect(self, connection):
@@ -527,7 +529,10 @@ class _AsyncRESPBase(AsyncBaseParser):
         if self._stream is None:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         self.encoder = connection.encoder
-        self._clear()
+        # Full reset on (re)connect — discard stale data from old connection
+        self._buffer = b""
+        self._pos = 0
+        self._chunks.clear()
         self._connected = True
 
     def on_disconnect(self):

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -1,7 +1,13 @@
 import logging
+import sys
 from abc import ABC, abstractmethod
 from asyncio import IncompleteReadError, StreamReader
 from typing import Awaitable, Callable, List, Optional, Protocol, Union
+
+if sys.version_info >= (3, 11, 3):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 
 from redis.maint_notifications import (
     MaintenanceNotification,
@@ -13,7 +19,6 @@ from redis.maint_notifications import (
     OSSNodeMigratedNotification,
     OSSNodeMigratingNotification,
 )
-from redis.utils import deprecated_function, safe_str
 
 from ..exceptions import (
     AskError,
@@ -36,6 +41,7 @@ from ..exceptions import (
     TryAgainError,
 )
 from ..typing import EncodableT
+from ..utils import SENTINEL, deprecated_function, safe_str
 from .encoders import Encoder
 from .socket import SERVER_CLOSED_CONNECTION_ERROR, SocketBuffer
 
@@ -183,7 +189,10 @@ class AsyncBaseParser(BaseParser):
         pass
 
     async def read_response(
-        self, disable_decoding: bool = False
+        self,
+        disable_decoding: bool = False,
+        push_request: bool = False,
+        timeout: Union[float, object] = SENTINEL,
     ) -> Union[EncodableT, ResponseError, None, List[EncodableT]]:
         raise NotImplementedError()
 
@@ -545,40 +554,65 @@ class _AsyncRESPBase(AsyncBaseParser):
         # parser and fail loudly if the private buffer API changes.
         return bool(self._stream._buffer) or self._stream.at_eof()
 
-    async def _read(self, length: int) -> bytes:
+    async def _read_from_stream(
+        self, timeout: Union[float, object] = SENTINEL, max_bytes: int = 0
+    ) -> bytes:
+        """
+        Read the next chunk from the underlying stream with an optional
+        per-read timeout.  This mirrors the sync client's per-recv timeout
+        semantics: each individual socket read gets its own timeout window.
+
+        ``max_bytes`` limits how many bytes may be returned. When 0, the
+        parser's ``_read_size`` is used.
+        """
+        stream = self._stream
+        if stream is None:
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+        size = max_bytes if max_bytes > 0 else self._read_size
+        if timeout is not SENTINEL and isinstance(timeout, (int, float)):
+            async with async_timeout(timeout):
+                return await stream.read(size)
+        return await stream.read(size)
+
+    async def _read(
+        self, length: int, timeout: Union[float, object] = SENTINEL
+    ) -> bytes:
         """
         Read `length` bytes of data.  These are assumed to be followed
         by a '\r\n' terminator which is subsequently discarded.
         """
         want = length + 2
         end = self._pos + want
-        if len(self._buffer) >= end:
-            result = self._buffer[self._pos : end - 2]
-        else:
-            tail = self._buffer[self._pos :]
+        while len(self._buffer) < end:
+            need = end - len(self._buffer)
             try:
-                data = await self._stream.readexactly(want - len(tail))
+                chunk = await self._read_from_stream(
+                    timeout=timeout, max_bytes=min(need, self._read_size)
+                )
             except IncompleteReadError as error:
                 raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
-            result = (tail + data)[:-2]
-            self._chunks.append(data)
-        self._pos += want
+            if not chunk:
+                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+            self._buffer += chunk
+        result = self._buffer[self._pos : end - 2]
+        self._pos = end
         return result
 
-    async def _readline(self) -> bytes:
+    async def _readline(self, timeout: Union[float, object] = SENTINEL) -> bytes:
         """
         read an unknown number of bytes up to the next '\r\n'
         line separator, which is discarded.
         """
-        found = self._buffer.find(b"\r\n", self._pos)
-        if found >= 0:
-            result = self._buffer[self._pos : found]
-        else:
-            tail = self._buffer[self._pos :]
-            data = await self._stream.readline()
-            if not data.endswith(b"\r\n"):
+        while True:
+            found = self._buffer.find(b"\r\n", self._pos)
+            if found >= 0:
+                result = self._buffer[self._pos : found]
+                self._pos = found + 2
+                return result
+            try:
+                chunk = await self._read_from_stream(timeout=timeout)
+            except IncompleteReadError as error:
+                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
+            if not chunk:
                 raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-            result = (tail + data)[:-2]
-            self._chunks.append(data)
-        self._pos += len(result) + 2
-        return result
+            self._buffer += chunk

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -178,11 +178,32 @@ class _RESPBase(BaseParser):
 class AsyncBaseParser(BaseParser):
     """Base parsing class for the python-backed async parser"""
 
-    __slots__ = "_stream", "_read_size"
+    __slots__ = "_stream", "_read_size", "_socket_timeout"
 
     def __init__(self, socket_read_size: int):
         self._stream: Optional[StreamReader] = None
         self._read_size = socket_read_size
+        # SENTINEL: no maintenance override active, the timeout argument
+        # passed to read_response is used as-is. A numeric value (or None
+        # for blocking) is pushed here by the connection's
+        # update_current_socket_timeout when a maintenance notification
+        # relaxes or restores socket deadlines mid-response (#4177).
+        self._socket_timeout: Union[float, object, None] = SENTINEL
+
+    def _effective_read_timeout(self, timeout: Union[float, object, None]):
+        """Resolve the per-read timeout for the next socket read.
+
+        A numeric ``timeout`` argument is the connection's socket_timeout
+        handed down by read_response for per-read windows. When the
+        maintenance-notification machinery relaxes or restores that timeout
+        mid-response it pushes the new value onto the parser, so reads that
+        start after the update must use the stored value rather than the
+        one captured when read_response was entered. A stored ``None``
+        means the read must block (relaxed with no deadline).
+        """
+        if isinstance(timeout, (int, float)) and self._socket_timeout is not SENTINEL:
+            return self._socket_timeout
+        return timeout
 
     @deprecated_function(
         version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
@@ -545,6 +566,9 @@ class _AsyncRESPBase(AsyncBaseParser):
         # Full reset on (re)connect — discard stale data from old connection
         self._buffer = b""
         self._pos = 0
+        # Drop any stale maintenance override; the connection hands its
+        # current socket_timeout down as the read timeout argument.
+        self._socket_timeout = SENTINEL
         self._connected = True
 
     def on_disconnect(self):
@@ -594,6 +618,7 @@ class _AsyncRESPBase(AsyncBaseParser):
         if stream is None:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         size = max_bytes if max_bytes > 0 else self._read_size
+        timeout = self._effective_read_timeout(timeout)
         if timeout is not SENTINEL and isinstance(timeout, (int, float)):
             async with async_timeout(timeout) as active_timeout:
                 # Expose the in-flight deadline so the connection can relax
@@ -614,17 +639,25 @@ class _AsyncRESPBase(AsyncBaseParser):
         """
         want = length + 2
         end = self._pos + want
-        while len(self._buffer) < end:
-            need = end - len(self._buffer)
-            try:
-                chunk = await self._read_from_stream(
-                    timeout=timeout, max_bytes=min(need, self._read_size)
-                )
-            except IncompleteReadError as error:
-                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
-            if not chunk:
-                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-            self._buffer += chunk
+        buffered = len(self._buffer)
+        if buffered < end:
+            chunks = []
+            while buffered < end:
+                need = end - buffered
+                try:
+                    chunk = await self._read_from_stream(
+                        timeout=timeout, max_bytes=min(need, self._read_size)
+                    )
+                except IncompleteReadError as error:
+                    raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
+                if not chunk:
+                    raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+                chunks.append(chunk)
+                buffered += len(chunk)
+            # Join once: repeated ``self._buffer += chunk`` re-copies the
+            # whole buffer per chunk, which is quadratic on large bulk
+            # replies and can stall the event loop.
+            self._buffer = b"".join((self._buffer, *chunks))
         result = self._buffer[self._pos : end - 2]
         self._pos = end
         return result
@@ -634,16 +667,35 @@ class _AsyncRESPBase(AsyncBaseParser):
         read an unknown number of bytes up to the next '\r\n'
         line separator, which is discarded.
         """
+        found = self._buffer.find(b"\r\n", self._pos)
+        if found >= 0:
+            result = self._buffer[self._pos : found]
+            self._pos = found + 2
+            return result
+        # The terminator is not fully buffered yet. Read chunk by chunk and
+        # accumulate into a list, joining once at the end — repeated
+        # ``self._buffer += chunk`` re-copies the whole buffer per chunk,
+        # which is quadratic on long lines.
+        chunks = []
+        pending = 0
+        # One byte of lookback catches a '\r' at the end of the unconsumed
+        # buffer straddling the first new chunk.
+        tail = self._buffer[-1:] if self._pos < len(self._buffer) else b""
         while True:
-            found = self._buffer.find(b"\r\n", self._pos)
-            if found >= 0:
-                result = self._buffer[self._pos : found]
-                self._pos = found + 2
-                return result
             try:
                 chunk = await self._read_from_stream(timeout=timeout)
             except IncompleteReadError as error:
                 raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
             if not chunk:
                 raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-            self._buffer += chunk
+            idx = (tail + chunk).find(b"\r\n")
+            if idx >= 0:
+                # Absolute index of the '\r' within buffer + pending + chunk.
+                found = len(self._buffer) + pending + idx - len(tail)
+                self._buffer = b"".join((self._buffer, *chunks, chunk))
+                result = self._buffer[self._pos : found]
+                self._pos = found + 2
+                return result
+            chunks.append(chunk)
+            pending += len(chunk)
+            tail = chunk[-1:]

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -619,7 +619,10 @@ class _AsyncRESPBase(AsyncBaseParser):
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         size = max_bytes if max_bytes > 0 else self._read_size
         timeout = self._effective_read_timeout(timeout)
-        if timeout is not SENTINEL and isinstance(timeout, (int, float)):
+        if timeout is not SENTINEL:
+            # Enter the context even for a blocking (None) read: a later
+            # maintenance restore can only retighten an in-flight read when
+            # its context is exposed here, mirroring the hiredis parser.
             async with async_timeout(timeout) as active_timeout:
                 # Expose the in-flight deadline so the connection can relax
                 # it when a maintenance notification arrives mid-read (#4177).

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -642,18 +642,28 @@ class _AsyncRESPBase(AsyncBaseParser):
         buffered = len(self._buffer)
         if buffered < end:
             chunks = []
-            while buffered < end:
-                need = end - buffered
-                try:
-                    chunk = await self._read_from_stream(
-                        timeout=timeout, max_bytes=min(need, self._read_size)
-                    )
-                except IncompleteReadError as error:
-                    raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
-                if not chunk:
-                    raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-                chunks.append(chunk)
-                buffered += len(chunk)
+            try:
+                while buffered < end:
+                    need = end - buffered
+                    try:
+                        chunk = await self._read_from_stream(
+                            timeout=timeout, max_bytes=min(need, self._read_size)
+                        )
+                    except IncompleteReadError as error:
+                        raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
+                    if not chunk:
+                        raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+                    chunks.append(chunk)
+                    buffered += len(chunk)
+            except BaseException:
+                # A timeout or cancellation must not drop bytes already
+                # consumed from the stream: an explicit caller timeout makes
+                # read_response return None without disconnecting, so a retry
+                # would continue from the wrong offset and desynchronize the
+                # protocol. Flush the partial payload back into the buffer.
+                if chunks:
+                    self._buffer = b"".join((self._buffer, *chunks))
+                raise
             # Join once: repeated ``self._buffer += chunk`` re-copies the
             # whole buffer per chunk, which is quadratic on large bulk
             # replies and can stall the event loop.
@@ -681,21 +691,29 @@ class _AsyncRESPBase(AsyncBaseParser):
         # One byte of lookback catches a '\r' at the end of the unconsumed
         # buffer straddling the first new chunk.
         tail = self._buffer[-1:] if self._pos < len(self._buffer) else b""
-        while True:
-            try:
-                chunk = await self._read_from_stream(timeout=timeout)
-            except IncompleteReadError as error:
-                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
-            if not chunk:
-                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-            idx = (tail + chunk).find(b"\r\n")
-            if idx >= 0:
-                # Absolute index of the '\r' within buffer + pending + chunk.
-                found = len(self._buffer) + pending + idx - len(tail)
-                self._buffer = b"".join((self._buffer, *chunks, chunk))
-                result = self._buffer[self._pos : found]
-                self._pos = found + 2
-                return result
-            chunks.append(chunk)
-            pending += len(chunk)
-            tail = chunk[-1:]
+        try:
+            while True:
+                try:
+                    chunk = await self._read_from_stream(timeout=timeout)
+                except IncompleteReadError as error:
+                    raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
+                if not chunk:
+                    raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+                idx = (tail + chunk).find(b"\r\n")
+                if idx >= 0:
+                    # Absolute index of the '\r' within buffer + pending + chunk.
+                    found = len(self._buffer) + pending + idx - len(tail)
+                    self._buffer = b"".join((self._buffer, *chunks, chunk))
+                    result = self._buffer[self._pos : found]
+                    self._pos = found + 2
+                    return result
+                chunks.append(chunk)
+                pending += len(chunk)
+                tail = chunk[-1:]
+        except BaseException:
+            # Same contract as _read: bytes already consumed from the stream
+            # must survive a timeout/cancellation so a retrying caller stays
+            # in sync with the protocol.
+            if chunks:
+                self._buffer = b"".join((self._buffer, *chunks))
+            raise

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -534,7 +534,9 @@ class _AsyncRESPBase(AsyncBaseParser):
         self._active_read_timeout = None
 
     def _clear(self):
-        self._buffer = b""
+        """Clear parsed data but preserve unconsumed pipelined bytes."""
+        self._buffer = self._buffer[self._pos :]
+        self._pos = 0
         self._chunks.clear()
 
     def on_connect(self, connection):
@@ -543,7 +545,10 @@ class _AsyncRESPBase(AsyncBaseParser):
         if self._stream is None:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         self.encoder = connection.encoder
-        self._clear()
+        # Full reset on (re)connect — discard stale data from old connection
+        self._buffer = b""
+        self._pos = 0
+        self._chunks.clear()
         self._connected = True
 
     def on_disconnect(self):

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -521,7 +521,6 @@ class _AsyncRESPBase(AsyncBaseParser):
         "encoder",
         "_buffer",
         "_pos",
-        "_chunks",
         "_active_read_timeout",
     )
 
@@ -529,7 +528,6 @@ class _AsyncRESPBase(AsyncBaseParser):
         super().__init__(socket_read_size)
         self.encoder: Optional[Encoder] = None
         self._buffer = b""
-        self._chunks = []
         self._pos = 0
         self._active_read_timeout = None
 
@@ -537,7 +535,6 @@ class _AsyncRESPBase(AsyncBaseParser):
         """Clear parsed data but preserve unconsumed pipelined bytes."""
         self._buffer = self._buffer[self._pos :]
         self._pos = 0
-        self._chunks.clear()
 
     def on_connect(self, connection):
         """Called when the stream connects"""
@@ -548,7 +545,6 @@ class _AsyncRESPBase(AsyncBaseParser):
         # Full reset on (re)connect — discard stale data from old connection
         self._buffer = b""
         self._pos = 0
-        self._chunks.clear()
         self._connected = True
 
     def on_disconnect(self):

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -1,7 +1,13 @@
 import logging
+import sys
 from abc import ABC, abstractmethod
 from asyncio import IncompleteReadError, StreamReader
 from typing import Awaitable, Callable, List, Optional, Protocol, Union
+
+if sys.version_info >= (3, 11, 3):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 
 from redis.maint_notifications import (
     MaintenanceNotification,
@@ -13,7 +19,6 @@ from redis.maint_notifications import (
     OSSNodeMigratedNotification,
     OSSNodeMigratingNotification,
 )
-from redis.utils import deprecated_function, safe_str
 
 from ..exceptions import (
     AskError,
@@ -37,6 +42,7 @@ from ..exceptions import (
     TryAgainError,
 )
 from ..typing import EncodableT
+from ..utils import SENTINEL, deprecated_function, safe_str
 from .encoders import Encoder
 from .socket import SERVER_CLOSED_CONNECTION_ERROR, SocketBuffer
 
@@ -192,7 +198,10 @@ class AsyncBaseParser(BaseParser):
         pass
 
     async def read_response(
-        self, disable_decoding: bool = False
+        self,
+        disable_decoding: bool = False,
+        push_request: bool = False,
+        timeout: Union[float, object] = SENTINEL,
     ) -> Union[EncodableT, ResponseError, None, List[EncodableT]]:
         raise NotImplementedError()
 
@@ -508,7 +517,13 @@ class AsyncPushNotificationsParser(Protocol):
 class _AsyncRESPBase(AsyncBaseParser):
     """Base class for async resp parsing"""
 
-    __slots__ = AsyncBaseParser.__slots__ + ("encoder", "_buffer", "_pos", "_chunks")
+    __slots__ = AsyncBaseParser.__slots__ + (
+        "encoder",
+        "_buffer",
+        "_pos",
+        "_chunks",
+        "_active_read_timeout",
+    )
 
     def __init__(self, socket_read_size: int):
         super().__init__(socket_read_size)
@@ -516,6 +531,7 @@ class _AsyncRESPBase(AsyncBaseParser):
         self._buffer = b""
         self._chunks = []
         self._pos = 0
+        self._active_read_timeout = None
 
     def _clear(self):
         self._buffer = b""
@@ -562,40 +578,71 @@ class _AsyncRESPBase(AsyncBaseParser):
         # parser and fail loudly if the private buffer API changes.
         return bool(self._stream._buffer)
 
-    async def _read(self, length: int) -> bytes:
+    async def _read_from_stream(
+        self, timeout: Union[float, object] = SENTINEL, max_bytes: int = 0
+    ) -> bytes:
+        """
+        Read the next chunk from the underlying stream with an optional
+        per-read timeout.  This mirrors the sync client's per-recv timeout
+        semantics: each individual socket read gets its own timeout window.
+
+        ``max_bytes`` limits how many bytes may be returned. When 0, the
+        parser's ``_read_size`` is used.
+        """
+        stream = self._stream
+        if stream is None:
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+        size = max_bytes if max_bytes > 0 else self._read_size
+        if timeout is not SENTINEL and isinstance(timeout, (int, float)):
+            async with async_timeout(timeout) as active_timeout:
+                # Expose the in-flight deadline so the connection can relax
+                # it when a maintenance notification arrives mid-read (#4177).
+                self._active_read_timeout = active_timeout
+                try:
+                    return await stream.read(size)
+                finally:
+                    self._active_read_timeout = None
+        return await stream.read(size)
+
+    async def _read(
+        self, length: int, timeout: Union[float, object] = SENTINEL
+    ) -> bytes:
         """
         Read `length` bytes of data.  These are assumed to be followed
         by a '\r\n' terminator which is subsequently discarded.
         """
         want = length + 2
         end = self._pos + want
-        if len(self._buffer) >= end:
-            result = self._buffer[self._pos : end - 2]
-        else:
-            tail = self._buffer[self._pos :]
+        while len(self._buffer) < end:
+            need = end - len(self._buffer)
             try:
-                data = await self._stream.readexactly(want - len(tail))
+                chunk = await self._read_from_stream(
+                    timeout=timeout, max_bytes=min(need, self._read_size)
+                )
             except IncompleteReadError as error:
                 raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
-            result = (tail + data)[:-2]
-            self._chunks.append(data)
-        self._pos += want
+            if not chunk:
+                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+            self._buffer += chunk
+        result = self._buffer[self._pos : end - 2]
+        self._pos = end
         return result
 
-    async def _readline(self) -> bytes:
+    async def _readline(self, timeout: Union[float, object] = SENTINEL) -> bytes:
         """
         read an unknown number of bytes up to the next '\r\n'
         line separator, which is discarded.
         """
-        found = self._buffer.find(b"\r\n", self._pos)
-        if found >= 0:
-            result = self._buffer[self._pos : found]
-        else:
-            tail = self._buffer[self._pos :]
-            data = await self._stream.readline()
-            if not data.endswith(b"\r\n"):
+        while True:
+            found = self._buffer.find(b"\r\n", self._pos)
+            if found >= 0:
+                result = self._buffer[self._pos : found]
+                self._pos = found + 2
+                return result
+            try:
+                chunk = await self._read_from_stream(timeout=timeout)
+            except IncompleteReadError as error:
+                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from error
+            if not chunk:
                 raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-            result = (tail + data)[:-2]
-            self._chunks.append(data)
-        self._pos += len(result) + 2
-        return result
+            self._buffer += chunk

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -1,8 +1,14 @@
 import select
 import selectors
 import socket
+import sys
 from logging import getLogger
 from typing import Callable, List, Optional, TypedDict, Union
+
+if sys.version_info >= (3, 11, 3):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 
 from ..exceptions import ConnectionError, InvalidResponse, RedisError, TimeoutError
 from ..typing import EncodableT
@@ -265,8 +271,12 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         # with a real StreamReader guard this private buffer API in CI.
         return bool(self._stream._buffer)
 
-    async def read_from_socket(self):
-        buffer = await self._stream.read(self._read_size)
+    async def read_from_socket(self, timeout: Union[float, object] = SENTINEL):
+        if timeout is not SENTINEL:
+            async with async_timeout(timeout):
+                buffer = await self._stream.read(self._read_size)
+        else:
+            buffer = await self._stream.read(self._read_size)
         if not buffer or not isinstance(buffer, bytes):
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from None
         self._reader.feed(buffer)
@@ -275,7 +285,10 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         return True
 
     async def read_response(
-        self, disable_decoding: bool = False, push_request: bool = False
+        self,
+        disable_decoding: bool = False,
+        push_request: bool = False,
+        timeout: Union[float, object] = SENTINEL,
     ) -> Union[EncodableT, List[EncodableT]]:
         # If `on_disconnect()` has been called, prohibit any more reads
         # even if they could happen because data might be present.
@@ -289,7 +302,7 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
             response = self._reader.gets()
 
         while response is NOT_ENOUGH_DATA:
-            await self.read_from_socket()
+            await self.read_from_socket(timeout=timeout)
             if disable_decoding:
                 response = self._reader.gets(False)
             else:
@@ -306,7 +319,9 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
             response = await self.handle_push_response(response)
             if not push_request:
                 return await self.read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
+                    disable_decoding=disable_decoding,
+                    push_request=push_request,
+                    timeout=timeout,
                 )
             else:
                 return response

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -1,8 +1,14 @@
 import select
 import selectors
 import socket
+import sys
 from logging import getLogger
 from typing import Callable, List, Optional, TypedDict, Union
+
+if sys.version_info >= (3, 11, 3):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 
 from ..exceptions import ConnectionError, InvalidResponse, RedisError, TimeoutError
 from ..typing import EncodableT
@@ -269,13 +275,14 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
 class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
     """Async implementation of parser class for connections using Hiredis"""
 
-    __slots__ = ("_reader",)
+    __slots__ = ("_reader", "_active_read_timeout")
 
     def __init__(self, socket_read_size: int):
         if not HIREDIS_AVAILABLE:
             raise RedisError("Hiredis is not available.")
         super().__init__(socket_read_size=socket_read_size)
         self._reader = None
+        self._active_read_timeout = None
         self.pubsub_push_handler_func = self.handle_pubsub_push_response
         self.invalidation_push_handler_func = None
         self._hiredis_PushNotificationType = None
@@ -338,8 +345,18 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         # with a real StreamReader guard this private buffer API in CI.
         return bool(self._stream._buffer)
 
-    async def read_from_socket(self):
-        buffer = await self._stream.read(self._read_size)
+    async def read_from_socket(self, timeout: Union[float, object] = SENTINEL):
+        if timeout is not SENTINEL:
+            async with async_timeout(timeout) as active_timeout:
+                # Expose the in-flight deadline so the connection can relax
+                # it when a maintenance notification arrives mid-read (#4177).
+                self._active_read_timeout = active_timeout
+                try:
+                    buffer = await self._stream.read(self._read_size)
+                finally:
+                    self._active_read_timeout = None
+        else:
+            buffer = await self._stream.read(self._read_size)
         if not buffer or not isinstance(buffer, bytes):
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from None
         self._reader.feed(buffer)
@@ -348,7 +365,10 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         return True
 
     async def read_response(
-        self, disable_decoding: bool = False, push_request: bool = False
+        self,
+        disable_decoding: bool = False,
+        push_request: bool = False,
+        timeout: Union[float, object] = SENTINEL,
     ) -> Union[EncodableT, List[EncodableT]]:
         # If `on_disconnect()` has been called, prohibit any more reads
         # even if they could happen because data might be present.
@@ -362,7 +382,7 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
             response = self._reader.gets()
 
         while response is NOT_ENOUGH_DATA:
-            await self.read_from_socket()
+            await self.read_from_socket(timeout=timeout)
             if disable_decoding:
                 response = self._reader.gets(False)
             else:
@@ -379,7 +399,9 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
             response = await self.handle_push_response(response)
             if not push_request:
                 return await self.read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
+                    disable_decoding=disable_decoding,
+                    push_request=push_request,
+                    timeout=timeout,
                 )
             else:
                 return response

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -275,7 +275,7 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
 class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
     """Async implementation of parser class for connections using Hiredis"""
 
-    __slots__ = ("_reader", "_active_read_timeout")
+    __slots__ = ("_reader", "_active_read_timeout", "_socket_timeout")
 
     def __init__(self, socket_read_size: int):
         if not HIREDIS_AVAILABLE:
@@ -283,6 +283,7 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         super().__init__(socket_read_size=socket_read_size)
         self._reader = None
         self._active_read_timeout = None
+        self._socket_timeout = SENTINEL
         self.pubsub_push_handler_func = self.handle_pubsub_push_response
         self.invalidation_push_handler_func = None
         self._hiredis_PushNotificationType = None
@@ -306,6 +307,9 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
             kwargs["errors"] = connection.encoder.encoding_errors
 
         self._reader = hiredis.Reader(**kwargs)
+        # Drop any stale maintenance override; the connection hands its
+        # current socket_timeout down as the read timeout argument.
+        self._socket_timeout = SENTINEL
         self._connected = True
 
         try:
@@ -346,6 +350,7 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         return bool(self._stream._buffer)
 
     async def read_from_socket(self, timeout: Union[float, object] = SENTINEL):
+        timeout = self._effective_read_timeout(timeout)
         if timeout is not SENTINEL:
             async with async_timeout(timeout) as active_timeout:
                 # Expose the in-flight deadline so the connection can relax

--- a/redis/_parsers/resp2.py
+++ b/redis/_parsers/resp2.py
@@ -78,7 +78,9 @@ class _RESP2Parser(_RESPBase):
 class _AsyncRESP2Parser(_AsyncRESPBase):
     """Async class for the RESP2 protocol"""
 
-    async def read_response(self, disable_decoding: bool = False):
+    async def read_response(
+        self, disable_decoding: bool = False, timeout: Union[float, object] = SENTINEL
+    ):
         if not self._connected:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         if self._chunks:
@@ -86,15 +88,17 @@ class _AsyncRESP2Parser(_AsyncRESPBase):
             self._buffer += b"".join(self._chunks)
             self._chunks.clear()
         self._pos = 0
-        response = await self._read_response(disable_decoding=disable_decoding)
+        response = await self._read_response(
+            disable_decoding=disable_decoding, timeout=timeout
+        )
         # Successfully parsing a response allows us to clear our parsing buffer
         self._clear()
         return response
 
     async def _read_response(
-        self, disable_decoding: bool = False
+        self, disable_decoding: bool = False, timeout: Union[float, object] = SENTINEL
     ) -> Union[EncodableT, ResponseError, None]:
-        raw = await self._readline()
+        raw = await self._readline(timeout=timeout)
         response: Any
         byte, response = raw[:1], raw[1:]
 
@@ -122,13 +126,17 @@ class _AsyncRESP2Parser(_AsyncRESPBase):
         elif byte == b"$" and response == b"-1":
             return None
         elif byte == b"$":
-            response = await self._read(int(response))
+            response = await self._read(int(response), timeout=timeout)
         # multi-bulk response
         elif byte == b"*" and response == b"-1":
             return None
         elif byte == b"*":
             response = [
-                (await self._read_response(disable_decoding))
+                (
+                    await self._read_response(
+                        disable_decoding=disable_decoding, timeout=timeout
+                    )
+                )
                 for _ in range(int(response))  # noqa
             ]
         else:

--- a/redis/_parsers/resp2.py
+++ b/redis/_parsers/resp2.py
@@ -83,10 +83,6 @@ class _AsyncRESP2Parser(_AsyncRESPBase):
     ):
         if not self._connected:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-        if self._chunks:
-            # augment parsing buffer with previously read data
-            self._buffer += b"".join(self._chunks)
-            self._chunks.clear()
         self._pos = 0
         response = await self._read_response(
             disable_decoding=disable_decoding, timeout=timeout

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -153,6 +153,7 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
             return self._read_response(
                 disable_decoding=disable_decoding,
                 push_request=push_request,
+                timeout=timeout,
             )
         else:
             raise InvalidResponse(f"Protocol Error: {raw!r}")
@@ -175,7 +176,10 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
         return response
 
     async def read_response(
-        self, disable_decoding: bool = False, push_request: bool = False
+        self,
+        disable_decoding: bool = False,
+        push_request: bool = False,
+        timeout: Union[float, object] = SENTINEL,
     ):
         if self._chunks:
             # augment parsing buffer with previously read data
@@ -183,18 +187,23 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             self._chunks.clear()
         self._pos = 0
         response = await self._read_response(
-            disable_decoding=disable_decoding, push_request=push_request
+            disable_decoding=disable_decoding,
+            push_request=push_request,
+            timeout=timeout,
         )
         # Successfully parsing a response allows us to clear our parsing buffer
         self._clear()
         return response
 
     async def _read_response(
-        self, disable_decoding: bool = False, push_request: bool = False
+        self,
+        disable_decoding: bool = False,
+        push_request: bool = False,
+        timeout: Union[float, object] = SENTINEL,
     ) -> Union[EncodableT, ResponseError, None]:
         if not self._stream or not self.encoder:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-        raw = await self._readline()
+        raw = await self._readline(timeout=timeout)
         response: Any
         byte, response = raw[:1], raw[1:]
 
@@ -204,7 +213,7 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
         # server returned an error
         if byte in (b"-", b"!"):
             if byte == b"!":
-                response = await self._read(int(response))
+                response = await self._read(int(response), timeout=timeout)
             response = response.decode("utf-8", errors="replace")
             error = self.parse_error(response)
             # if the error is a ConnectionError, raise immediately so the user
@@ -234,14 +243,18 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             return response == b"t"
         # bulk response
         elif byte == b"$":
-            response = await self._read(int(response))
+            response = await self._read(int(response), timeout=timeout)
         # verbatim string response
         elif byte == b"=":
-            response = (await self._read(int(response)))[4:]
+            response = (await self._read(int(response), timeout=timeout))[4:]
         # array response
         elif byte == b"*":
             response = [
-                (await self._read_response(disable_decoding=disable_decoding))
+                (
+                    await self._read_response(
+                        disable_decoding=disable_decoding, timeout=timeout
+                    )
+                )
                 for _ in range(int(response))
             ]
         # set response
@@ -249,7 +262,11 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             # redis can return unhashable types (like dict) in a set,
             # so we always convert to a list, to have predictable return types
             response = [
-                (await self._read_response(disable_decoding=disable_decoding))
+                (
+                    await self._read_response(
+                        disable_decoding=disable_decoding, timeout=timeout
+                    )
+                )
                 for _ in range(int(response))
             ]
         # map response
@@ -259,9 +276,13 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             # became defined to be left-right in version 3.8
             resp_dict = {}
             for _ in range(int(response)):
-                key = await self._read_response(disable_decoding=disable_decoding)
+                key = await self._read_response(
+                    disable_decoding=disable_decoding, timeout=timeout
+                )
                 resp_dict[key] = await self._read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
+                    disable_decoding=disable_decoding,
+                    push_request=push_request,
+                    timeout=timeout,
                 )
             response = resp_dict
         # push response
@@ -269,7 +290,9 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             response = [
                 (
                     await self._read_response(
-                        disable_decoding=disable_decoding, push_request=push_request
+                        disable_decoding=disable_decoding,
+                        push_request=push_request,
+                        timeout=timeout,
                     )
                 )
                 for _ in range(int(response))
@@ -277,7 +300,9 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             response = await self.handle_push_response(response)
             if not push_request:
                 return await self._read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
+                    disable_decoding=disable_decoding,
+                    push_request=push_request,
+                    timeout=timeout,
                 )
             else:
                 return response

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -181,10 +181,6 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
         push_request: bool = False,
         timeout: Union[float, object] = SENTINEL,
     ):
-        if self._chunks:
-            # augment parsing buffer with previously read data
-            self._buffer += b"".join(self._chunks)
-            self._chunks.clear()
         self._pos = 0
         response = await self._read_response(
             disable_decoding=disable_decoding,

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -779,15 +779,16 @@ class AbstractConnection:
         host_error = self._host_error()
         try:
             if read_timeout is not None and self.protocol in ["3", 3]:
-                async with async_timeout(read_timeout):
-                    response = await self._parser.read_response(
-                        disable_decoding=disable_decoding, push_request=push_request
-                    )
+                response = await self._parser.read_response(
+                    disable_decoding=disable_decoding,
+                    push_request=push_request,
+                    timeout=read_timeout,
+                )
             elif read_timeout is not None:
-                async with async_timeout(read_timeout):
-                    response = await self._parser.read_response(
-                        disable_decoding=disable_decoding
-                    )
+                response = await self._parser.read_response(
+                    disable_decoding=disable_decoding,
+                    timeout=read_timeout,
+                )
             elif self.protocol in ["3", 3]:
                 response = await self._parser.read_response(
                     disable_decoding=disable_decoding, push_request=push_request

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -494,6 +494,10 @@ class AsyncMaintNotificationsAbstractConnection:
 
     def _reschedule_active_read_timeout(self, timeout: float | None) -> None:
         timeout_context = getattr(self, "_active_read_timeout", None)
+        if timeout_context is None and self._parser is not None:
+            # Per-read timeouts (#3454) live inside the parser; the parser
+            # stashes the in-flight read context there instead.
+            timeout_context = getattr(self._parser, "_active_read_timeout", None)
         if timeout_context is None:
             # No read_response call is currently inside its socket timeout
             # context, so there is no in-flight deadline to relax or restore.
@@ -1277,24 +1281,32 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             read_timeout = timeout if timeout is not None else self.socket_timeout
         host_error = self._host_error()
         try:
-            if read_timeout is not None:
-                timeout_context = async_timeout(read_timeout)
-                if timeout is None:
-                    async with timeout_context as active_timeout:
-                        self._active_read_timeout = active_timeout
-                        try:
-                            response = await self._read_response_from_parser(
-                                disable_decoding=disable_decoding,
-                                push_request=push_request,
-                            )
-                        finally:
-                            self._active_read_timeout = None
+            if timeout is None and read_timeout is not None:
+                # socket_timeout fallback: hand the timeout to the parser so
+                # each individual stream read gets its own window (#3454),
+                # matching the sync client's per-recv semantics. The parser
+                # stashes each in-flight read context so the maintenance
+                # notification machinery can still relax a deadline (#4177).
+                if check_protocol_version(self.protocol, 3):
+                    response = await self._parser.read_response(
+                        disable_decoding=disable_decoding,
+                        push_request=push_request,
+                        timeout=read_timeout,
+                    )
                 else:
-                    async with timeout_context:
-                        response = await self._read_response_from_parser(
-                            disable_decoding=disable_decoding,
-                            push_request=push_request,
-                        )
+                    response = await self._parser.read_response(
+                        disable_decoding=disable_decoding,
+                        timeout=read_timeout,
+                    )
+            elif read_timeout is not None:
+                # explicit caller timeout: single deadline for the whole
+                # response. Not tracked for rescheduling, matching the
+                # previous behavior for caller-supplied timeouts.
+                async with async_timeout(read_timeout):
+                    response = await self._read_response_from_parser(
+                        disable_decoding=disable_decoding,
+                        push_request=push_request,
+                    )
             else:
                 response = await self._read_response_from_parser(
                     disable_decoding=disable_decoding,

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -491,6 +491,14 @@ class AsyncMaintNotificationsAbstractConnection:
     ) -> None:
         timeout = relaxed_timeout if relaxed_timeout != -1 else self.socket_timeout
         self._reschedule_active_read_timeout(timeout)
+        # Also stash the new deadline on the parser so socket reads that
+        # START after this update use it. Rescheduling above only covers
+        # the read that is in flight right now; without this, later reads
+        # in the same read_response keep the deadline captured at entry
+        # (mirrors the sync client's update_parser_timeout, #4177).
+        parser = self._parser
+        if parser is not None and hasattr(parser, "_socket_timeout"):
+            parser._socket_timeout = timeout
 
     def _reschedule_active_read_timeout(self, timeout: float | None) -> None:
         timeout_context = getattr(self, "_active_read_timeout", None)

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -11,6 +11,7 @@ from redis.asyncio.connection import (
     Connection,
     ConnectionPool,
     UnixDomainSocketConnection,
+    async_timeout,
 )
 from redis.asyncio.maint_notifications import (
     AsyncMaintNotificationsConnectionHandler,
@@ -1646,9 +1647,17 @@ async def test_read_response_reschedules_active_socket_timeout():
     connection = Connection(socket_timeout=0.01)
 
     class RelaxingParser:
-        async def read_response(self, disable_decoding=False, push_request=False):
-            connection.update_current_socket_timeout(0.2)
-            await asyncio.sleep(0.05)
+        def __init__(self):
+            self._active_read_timeout = None
+
+        async def read_response(
+            self, disable_decoding=False, push_request=False, timeout=None
+        ):
+            async with async_timeout(timeout) as active:
+                self._active_read_timeout = active
+                connection.update_current_socket_timeout(0.2)
+                await asyncio.sleep(0.05)
+                self._active_read_timeout = None
             return b"OK"
 
     connection._parser = RelaxingParser()
@@ -1662,9 +1671,17 @@ async def test_read_response_reschedules_active_socket_timeout_to_blocking():
     connection = Connection(socket_timeout=0.01)
 
     class RelaxingParser:
-        async def read_response(self, disable_decoding=False, push_request=False):
-            connection.update_current_socket_timeout(None)
-            await asyncio.sleep(0.05)
+        def __init__(self):
+            self._active_read_timeout = None
+
+        async def read_response(
+            self, disable_decoding=False, push_request=False, timeout=None
+        ):
+            async with async_timeout(timeout) as active:
+                self._active_read_timeout = active
+                connection.update_current_socket_timeout(None)
+                await asyncio.sleep(0.05)
+                self._active_read_timeout = None
             return b"OK"
 
     connection._parser = RelaxingParser()

--- a/tests/test_asyncio/test_async_timeout_per_read.py
+++ b/tests/test_asyncio/test_async_timeout_per_read.py
@@ -1,0 +1,278 @@
+"""Tests for per-read socket_timeout semantics on async connections.
+
+Issue: redis/redis-py#3454 — socket_timeout on async connection should apply
+per individual socket read, matching the sync client behavior, rather than to
+the entire response.
+"""
+
+import asyncio
+
+import pytest
+
+from redis._parsers import _AsyncRESP2Parser, _AsyncRESP3Parser
+from redis.asyncio.connection import Connection
+from redis.utils import HIREDIS_AVAILABLE
+
+if HIREDIS_AVAILABLE:
+    from redis._parsers import _AsyncHiredisParser
+    from redis._parsers.hiredis import NOT_ENOUGH_DATA
+
+
+class SlowChunkStream:
+    """Mock StreamReader that returns data one chunk at a time with delays."""
+
+    def __init__(self, chunks, delay_between_chunks):
+        self._chunks = list(chunks)
+        self._delay = delay_between_chunks
+        self._buffer = b""
+        self._pos = 0
+        self._chunk_index = 0
+
+    def at_eof(self):
+        return self._chunk_index >= len(self._chunks) and self._pos >= len(self._buffer)
+
+    async def read(self, _want):
+        if self._pos >= len(self._buffer):
+            if self._chunk_index >= len(self._chunks):
+                return b""
+            if self._delay:
+                await asyncio.sleep(self._delay)
+            self._buffer = self._chunks[self._chunk_index]
+            self._chunk_index += 1
+            self._pos = 0
+        result = self._buffer[self._pos :]
+        self._pos += len(result)
+        return result
+
+    async def readline(self):
+        if self._pos >= len(self._buffer):
+            if self._chunk_index >= len(self._chunks):
+                return b""
+            if self._delay:
+                await asyncio.sleep(self._delay)
+            self._buffer = self._chunks[self._chunk_index]
+            self._chunk_index += 1
+            self._pos = 0
+        nl = self._buffer.find(b"\n", self._pos)
+        if nl < 0:
+            result = self._buffer[self._pos :]
+            self._pos = len(self._buffer)
+            return result
+        result = self._buffer[self._pos : nl + 1]
+        self._pos = nl + 1
+        return result
+
+    async def readexactly(self, length):
+        result = bytearray()
+        while len(result) < length:
+            if self._pos >= len(self._buffer):
+                if self._chunk_index >= len(self._chunks):
+                    raise asyncio.IncompleteReadError(bytes(result), length)
+                if self._delay:
+                    await asyncio.sleep(self._delay)
+                self._buffer = self._chunks[self._chunk_index]
+                self._chunk_index += 1
+                self._pos = 0
+            take = min(length - len(result), len(self._buffer) - self._pos)
+            result.extend(self._buffer[self._pos : self._pos + take])
+            self._pos += take
+        return bytes(result)
+
+
+class _DummyEncoder:
+    decode_responses = False
+    encoding = "utf-8"
+    encoding_errors = "strict"
+
+    def decode(self, value):
+        if isinstance(value, bytes):
+            return value.decode(self.encoding, self.encoding_errors)
+        if isinstance(value, list):
+            return [self.decode(v) for v in value]
+        return value
+
+
+def _make_resp2_parser(stream, read_size=4096):
+    parser = _AsyncRESP2Parser(socket_read_size=read_size)
+    parser._stream = stream
+    parser._connected = True
+    parser.encoder = _DummyEncoder()
+    return parser
+
+
+def _make_resp3_parser(stream, read_size=4096):
+    parser = _AsyncRESP3Parser(socket_read_size=read_size)
+    parser._stream = stream
+    parser._connected = True
+    parser.encoder = _DummyEncoder()
+    return parser
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_per_read_timeout_allows_slow_multi_chunk_response(factory):
+    """
+    A response that takes longer than the timeout in total, but where each
+    individual socket read completes quickly, must succeed under per-read
+    timeout semantics.
+    """
+    # Bulk string payload split across several chunks with 0.05s delay each.
+    payload = b"hello world this is a moderately large bulk string value"
+    chunks = [
+        b"$" + str(len(payload)).encode() + b"\r\n",
+        payload[:10],
+        payload[10:25],
+        payload[25:40],
+        payload[40:] + b"\r\n",
+    ]
+    stream = SlowChunkStream(chunks, delay_between_chunks=0.05)
+    parser = factory(stream)
+
+    # Total elapsed will be ~0.2s, but each read is only 0.05s.
+    # With per-read semantics a 0.1s timeout should allow it.
+    response = await parser.read_response(timeout=0.1)
+    assert response == payload.decode()
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_per_read_timeout_fails_when_single_read_exceeds_timeout(factory):
+    """
+    If an individual socket read itself exceeds the timeout, the parser must
+    raise a timeout error.
+    """
+    chunks = [b"$5\r\n", b"hello", b"\r\n"]
+    # 0.3s delay per chunk means the second read will exceed a 0.1s timeout.
+    stream = SlowChunkStream(chunks, delay_between_chunks=0.3)
+    parser = factory(stream)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await parser.read_response(timeout=0.1)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_per_read_timeout_propagates_through_nested_arrays(factory):
+    """
+    Nested RESP arrays must keep the per-read timeout on every recursive
+    _readline/_read call.
+    """
+    # *2\r\n$5\r\nhello\r\n$5\r\nworld\r\n split into many chunks
+    chunks = [
+        b"*2\r\n",
+        b"$5\r\n",
+        b"hello",
+        b"\r\n$5\r\n",
+        b"world",
+        b"\r\n",
+    ]
+    stream = SlowChunkStream(chunks, delay_between_chunks=0.04)
+    parser = factory(stream)
+
+    # Total ~0.24s but each read 0.04s; 0.1s per-read timeout should pass.
+    response = await parser.read_response(timeout=0.1)
+    assert response == ["hello", "world"]
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_no_timeout_when_sentinel_default(factory):
+    """When no timeout is supplied (SENTINEL default), reads must not time out."""
+    chunks = [b"+OK\r\n"]
+    stream = SlowChunkStream(chunks, delay_between_chunks=0.1)
+    parser = factory(stream)
+
+    from redis.utils import SENTINEL
+
+    response = await parser.read_response(timeout=SENTINEL)
+    assert response == "OK"
+
+
+@pytest.mark.skipif(not HIREDIS_AVAILABLE, reason="hiredis is not installed")
+async def test_hiredis_per_read_timeout_allows_slow_multi_chunk_response():
+    """
+    The hiredis async parser must also apply timeout per read_from_socket call,
+    not across the entire read_response loop.
+    """
+    import hiredis
+
+    payload = b"hello world this is a moderately large bulk string value"
+    chunks = [
+        b"$" + str(len(payload)).encode() + b"\r\n",
+        payload[:10],
+        payload[10:25],
+        payload[25:40],
+        payload[40:] + b"\r\n",
+    ]
+    stream = SlowChunkStream(chunks, delay_between_chunks=0.05)
+
+    parser = _AsyncHiredisParser(socket_read_size=4096)
+    parser._stream = stream
+    parser._connected = True
+    parser._reader = hiredis.Reader(
+        protocolError=Exception,
+        replyError=Exception,
+        notEnoughData=NOT_ENOUGH_DATA,
+    )
+
+    response = await parser.read_response(timeout=0.1)
+    assert response == payload
+
+
+@pytest.mark.skipif(not HIREDIS_AVAILABLE, reason="hiredis is not installed")
+async def test_hiredis_per_read_timeout_fails_when_chunk_too_slow():
+    """Hiredis parser must raise when a single read_from_socket exceeds timeout."""
+    import hiredis
+
+    chunks = [b"$5\r\n", b"hello", b"\r\n"]
+    stream = SlowChunkStream(chunks, delay_between_chunks=0.3)
+
+    parser = _AsyncHiredisParser(socket_read_size=4096)
+    parser._stream = stream
+    parser._connected = True
+    parser._reader = hiredis.Reader(
+        protocolError=Exception,
+        replyError=Exception,
+        notEnoughData=NOT_ENOUGH_DATA,
+    )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await parser.read_response(timeout=0.1)
+
+
+@pytest.mark.parametrize("protocol", [2, 3])
+async def test_connection_passes_timeout_to_parser(protocol):
+    """
+    Connection.read_response must pass its timeout through to the parser
+    rather than wrapping the parser call in an outer timeout context.
+    """
+    conn = Connection(protocol=protocol, socket_timeout=0.05)
+    # Ensure parser is the Python-backed one for this test.
+    from redis._parsers import _AsyncRESP2Parser, _AsyncRESP3Parser
+
+    expected_class = _AsyncRESP2Parser if protocol == 2 else _AsyncRESP3Parser
+    assert isinstance(conn._parser, expected_class)
+
+    # Patch the parser to record the timeout it receives.
+    recorded = {}
+
+    async def fake_read_response(*args, **kwargs):
+        recorded["timeout"] = kwargs.get("timeout")
+        return "OK"
+
+    conn._parser.read_response = fake_read_response
+    response = await conn.read_response(timeout=0.42)
+    assert response == "OK"
+    assert recorded["timeout"] == 0.42

--- a/tests/test_asyncio/test_async_timeout_per_read.py
+++ b/tests/test_asyncio/test_async_timeout_per_read.py
@@ -255,15 +255,13 @@ async def test_hiredis_per_read_timeout_fails_when_chunk_too_slow():
 @pytest.mark.parametrize("protocol", [2, 3])
 async def test_connection_passes_timeout_to_parser(protocol):
     """
-    Connection.read_response must pass its timeout through to the parser
-    rather than wrapping the parser call in an outer timeout context.
+    Connection.read_response must hand the socket_timeout fallback to the
+    parser per read rather than wrapping the parser call in an outer timeout
+    context, while explicit caller timeouts keep their single-deadline
+    wrapper.
     """
     conn = Connection(protocol=protocol, socket_timeout=0.05)
-    # Ensure parser is the Python-backed one for this test.
-    from redis._parsers import _AsyncRESP2Parser, _AsyncRESP3Parser
-
-    expected_class = _AsyncRESP2Parser if protocol == 2 else _AsyncRESP3Parser
-    assert isinstance(conn._parser, expected_class)
+    assert conn._parser is not None
 
     # Patch the parser to record the timeout it receives.
     recorded = {}
@@ -273,6 +271,16 @@ async def test_connection_passes_timeout_to_parser(protocol):
         return "OK"
 
     conn._parser.read_response = fake_read_response
+
+    # timeout=None falls back to socket_timeout: the parser gets the
+    # per-read window.
+    response = await conn.read_response(timeout=None)
+    assert response == "OK"
+    assert recorded["timeout"] == 0.05
+
+    # An explicit caller timeout keeps the whole-response wrapper, so the
+    # parser receives no timeout of its own.
+    recorded["timeout"] = "unset"
     response = await conn.read_response(timeout=0.42)
     assert response == "OK"
-    assert recorded["timeout"] == 0.42
+    assert recorded["timeout"] is None

--- a/tests/test_asyncio/test_async_timeout_per_read.py
+++ b/tests/test_asyncio/test_async_timeout_per_read.py
@@ -476,3 +476,73 @@ async def test_bulk_read_across_many_small_chunks(factory):
     stream = SlowChunkStream(chunks, delay_between_chunks=0)
     parser = factory(stream, read_size=64)
     assert await parser.read_response() == payload.decode()
+
+
+class StallStream:
+    """Mock StreamReader that blocks forever once its queued chunks run out.
+
+    Simulates a server that stops sending mid-reply: the queued chunks are
+    delivered, then every read stalls until the per-read timeout cancels it.
+    """
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self._buffer = b""
+        self._pos = 0
+
+    def feed(self, chunk):
+        self._chunks.append(chunk)
+
+    def at_eof(self):
+        return not self._chunks and self._pos >= len(self._buffer)
+
+    async def read(self, _want):
+        if self._pos >= len(self._buffer):
+            if not self._chunks:
+                await asyncio.sleep(60)
+                return b""
+            self._buffer = self._chunks.pop(0)
+            self._pos = 0
+        result = self._buffer[self._pos :]
+        self._pos += len(result)
+        return result
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_timeout_preserves_partially_consumed_bulk(factory):
+    """
+    A per-read timeout firing mid-payload must not drop the bytes already
+    consumed from the stream. Explicit caller timeouts make read_response
+    return None without disconnecting, so a retry on the same connection
+    must reparse the complete reply instead of desynchronizing.
+    """
+    payload = b"helloworld"
+    stream = StallStream([b"$10\r\n", payload[:5]])
+    parser = factory(stream)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await parser.read_response(timeout=0.05)
+
+    stream.feed(payload[5:] + b"\r\n")
+    assert await parser.read_response(timeout=1) == payload.decode()
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_timeout_preserves_partially_consumed_line(factory):
+    """Same preservation contract for a line split across the timeout."""
+    stream = StallStream([b"+hel", b"lo"])
+    parser = factory(stream)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await parser.read_response(timeout=0.05)
+
+    stream.feed(b" world\r\n")
+    assert await parser.read_response(timeout=1) == "hello world"

--- a/tests/test_asyncio/test_async_timeout_per_read.py
+++ b/tests/test_asyncio/test_async_timeout_per_read.py
@@ -79,6 +79,37 @@ class SlowChunkStream:
         return bytes(result)
 
 
+class HookedStream:
+    """Mock StreamReader that fires a hook after every socket read.
+
+    Used to simulate the maintenance-notification machinery pushing a new
+    per-read timeout onto the parser while a read_response is in progress.
+    """
+
+    def __init__(self, chunks_with_delays, on_read):
+        self._steps = list(chunks_with_delays)
+        self._on_read = on_read
+        self._buffer = b""
+        self._pos = 0
+
+    def at_eof(self):
+        return not self._steps and self._pos >= len(self._buffer)
+
+    async def read(self, _want):
+        if self._pos >= len(self._buffer):
+            if not self._steps:
+                return b""
+            delay, data = self._steps.pop(0)
+            if delay:
+                await asyncio.sleep(delay)
+            self._buffer = data
+            self._pos = 0
+            self._on_read()
+        result = self._buffer[self._pos :]
+        self._pos += len(result)
+        return result
+
+
 class _DummyEncoder:
     decode_responses = False
     encoding = "utf-8"
@@ -284,3 +315,164 @@ async def test_connection_passes_timeout_to_parser(protocol):
     response = await conn.read_response(timeout=0.42)
     assert response == "OK"
     assert recorded["timeout"] is None
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_relaxed_timeout_reaches_reads_started_after_update(factory):
+    """
+    When the maintenance machinery relaxes the per-read timeout while a
+    read_response is in progress, socket reads that START after the update
+    must use the relaxed deadline, not the one captured at entry (#4177).
+    """
+    payload = b"x" * 50
+    holder = {}
+
+    def relax():
+        holder["parser"]._socket_timeout = 0.5
+
+    steps = [(0, b"$50\r\n"), (0, payload[:10]), (0.2, payload[10:] + b"\r\n")]
+    stream = HookedStream(steps, on_read=relax)
+    parser = factory(stream)
+    holder["parser"] = parser
+
+    # The entry timeout (0.05) would abort the 0.2s final read; the relaxed
+    # 0.5 deadline pushed after the first read must cover it instead.
+    response = await parser.read_response(timeout=0.05)
+    assert response == payload.decode()
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_stored_timeout_overrides_timeout_captured_at_entry(factory):
+    """
+    The stored maintenance timeout wins over the timeout argument captured
+    when read_response was entered, in both directions.
+    """
+    payload = b"x" * 50
+    holder = {}
+
+    def tighten():
+        holder["parser"]._socket_timeout = 0.05
+
+    steps = [(0, b"$50\r\n"), (0, payload[:10]), (0.2, payload[10:] + b"\r\n")]
+    stream = HookedStream(steps, on_read=tighten)
+    parser = factory(stream)
+    holder["parser"] = parser
+
+    # Entry timeout is a generous 0.5s, but the tightened 0.05 deadline
+    # pushed after the first read must abort the 0.2s final read.
+    with pytest.raises(asyncio.TimeoutError):
+        await parser.read_response(timeout=0.5)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_stored_timeout_none_makes_later_reads_block(factory):
+    """A stored None (relaxed with no deadline) makes later reads block."""
+    payload = b"x" * 50
+    holder = {}
+
+    def relax_to_blocking():
+        holder["parser"]._socket_timeout = None
+
+    steps = [(0, b"$50\r\n"), (0, payload[:10]), (0.2, payload[10:] + b"\r\n")]
+    stream = HookedStream(steps, on_read=relax_to_blocking)
+    parser = factory(stream)
+    holder["parser"] = parser
+
+    response = await parser.read_response(timeout=0.05)
+    assert response == payload.decode()
+
+
+@pytest.mark.parametrize("protocol", [2, 3])
+async def test_update_current_socket_timeout_pushes_to_parser(protocol):
+    """
+    Connection.update_current_socket_timeout must push the new deadline
+    onto the parser so reads started after the update pick it up, matching
+    the sync client's update_parser_timeout.
+    """
+    conn = Connection(protocol=protocol, socket_timeout=0.05)
+    parser = conn._parser
+
+    # Relax: parser sees the relaxed deadline.
+    conn.update_current_socket_timeout(0.2)
+    assert parser._socket_timeout == 0.2
+
+    # Relax to blocking: parser reads must block.
+    conn.update_current_socket_timeout(None)
+    assert parser._socket_timeout is None
+
+    # Restore: -1 resolves to the connection's current socket_timeout.
+    conn.update_current_socket_timeout(-1)
+    assert parser._socket_timeout == 0.05
+
+
+@pytest.mark.skipif(not HIREDIS_AVAILABLE, reason="hiredis is not installed")
+async def test_hiredis_relaxed_timeout_reaches_reads_started_after_update():
+    """The hiredis parser must also honor a relaxed deadline on later reads."""
+    import hiredis
+
+    payload = b"x" * 50
+    holder = {}
+
+    def relax():
+        holder["parser"]._socket_timeout = 0.5
+
+    steps = [(0, b"$50\r\n"), (0, payload[:10]), (0.2, payload[10:] + b"\r\n")]
+    stream = HookedStream(steps, on_read=relax)
+
+    parser = _AsyncHiredisParser(socket_read_size=4096)
+    parser._stream = stream
+    parser._connected = True
+    parser._reader = hiredis.Reader(
+        protocolError=Exception,
+        replyError=Exception,
+        notEnoughData=NOT_ENOUGH_DATA,
+    )
+    holder["parser"] = parser
+
+    response = await parser.read_response(timeout=0.05)
+    assert response == payload
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_readline_terminator_straddling_chunks(factory):
+    """A '\\r\\n' split across two socket reads must still terminate the line."""
+    stream = SlowChunkStream([b"+OK\r", b"\n"], delay_between_chunks=0)
+    parser = factory(stream)
+    assert await parser.read_response() == "OK"
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_resp2_parser, _make_resp3_parser],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_bulk_read_across_many_small_chunks(factory):
+    """
+    Bulk replies arriving in many small chunks must parse correctly while
+    the parser accumulates chunks without repeatedly copying the buffer.
+    """
+    payload = bytes(65 + (i % 26) for i in range(4096))
+    chunks = (
+        [b"$4096\r\n"]
+        + [payload[i : i + 64] for i in range(0, len(payload), 64)]
+        + [b"\r\n"]
+    )
+    stream = SlowChunkStream(chunks, delay_between_chunks=0)
+    parser = factory(stream, read_size=64)
+    assert await parser.read_response() == payload.decode()

--- a/tests/test_asyncio/test_async_timeout_per_read.py
+++ b/tests/test_asyncio/test_async_timeout_per_read.py
@@ -394,6 +394,63 @@ async def test_stored_timeout_none_makes_later_reads_block(factory):
     assert response == payload.decode()
 
 
+@pytest.mark.parametrize(
+    "parser_class, protocol",
+    [(_AsyncRESP2Parser, 2), (_AsyncRESP3Parser, 3)],
+    ids=["AsyncRESP2Parser", "AsyncRESP3Parser"],
+)
+async def test_restore_bounds_in_flight_blocking_read(parser_class, protocol):
+    """
+    A maintenance relax stores None (blocking) on the parser. A read that
+    starts relaxed must still expose its in-flight timeout context so a
+    later restore can bound it; otherwise the Python parser hangs past the
+    restored socket_timeout until the server sends data. The hiredis parser
+    already wraps blocking reads for this reason.
+    """
+    never = asyncio.Event()
+
+    class HangingStream:
+        _buffer = b""
+
+        def at_eof(self):
+            return False
+
+        async def read(self, _want):
+            await never.wait()
+            return b""
+
+    conn = Connection(protocol=protocol, socket_timeout=0.05, parser_class=parser_class)
+    parser = conn._parser
+    parser._stream = HangingStream()
+    parser._connected = True
+    parser.encoder = _DummyEncoder()
+    # The maintenance machinery relaxed this connection to blocking before
+    # the read started.
+    parser._socket_timeout = None
+
+    task = asyncio.create_task(parser.read_response(timeout=0.05))
+    try:
+        for _ in range(100):
+            if parser._active_read_timeout is not None:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("blocking read never exposed an in-flight timeout context")
+
+        # Maintenance ends: restore the connection socket_timeout. The
+        # in-flight relaxed read must be retightened and abort.
+        conn.update_current_socket_timeout(-1)
+        done, _pending = await asyncio.wait({task}, timeout=2.0)
+        assert task in done, "restored socket_timeout did not bound the in-flight read"
+        with pytest.raises(asyncio.TimeoutError):
+            task.result()
+    finally:
+        never.set()
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
 @pytest.mark.parametrize("protocol", [2, 3])
 async def test_update_current_socket_timeout_pushes_to_parser(protocol):
     """


### PR DESCRIPTION
Fixes #3454

The async client was wrapping the entire parser.read_response() call in async_timeout, so socket_timeout applied to the whole response. The sync client applies it per socket recv() instead.

This change passes the timeout down to the async parsers (RESP2, RESP3, and Hiredis) and applies it around each individual stream read, matching the sync semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core async read/timeout and RESP parsing paths used on every command; behavior changes for slow multi-chunk replies and maintenance deadline updates, though heavily tested.
> 
> **Overview**
> Fixes **#3454** by changing how async `Connection.read_response` applies `socket_timeout`: instead of one `async_timeout` around the whole parse, the connection passes the deadline into **RESP2**, **RESP3**, and **Hiredis** parsers so **each** `StreamReader.read` gets its own window, matching sync `recv` behavior. Explicit caller timeouts still use a single outer deadline (unchanged).
> 
> The Python async RESP stack is reworked around `_read_from_stream`, chunk-wise `_read` / `_readline`, and buffer clears that **keep pipelined bytes** and **retain partial reads** after timeout/cancel so retries stay on-protocol. **#4177** maintenance handling is wired through parser `_socket_timeout`, `_effective_read_timeout`, and in-flight `_active_read_timeout` so `update_current_socket_timeout` can relax/restore deadlines mid-`read_response` (including later reads and blocking reads). Coverage is expanded in `test_async_timeout_per_read.py` and maintenance reschedule tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f88345555807e4a262c155b528cc21d4a24cb81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->