### PR TITLE
Eliminate GC refcounting cycle on _connect exception

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1555,6 +1555,14 @@ class Connection(AbstractConnection):
         # we want to mimic what socket.create_connection does to support
         # ipv4/ipv6, but we want to set options prior to calling
         # socket.connect()
+
+        # Last caught connection error.
+        # Re-thrown if we are unable to connect to any of the options returned
+        # by getaddrinfo.
+        # Note that we must clear this variable before returning - otherwise,
+        # a caught err's traceback points to this frame, which points to err.
+        # Clearing this lets refcounting reclaim the exception immediately
+        # without deferring to the python garbage collector.
         err = None
 
         for res in socket.getaddrinfo(
@@ -1581,6 +1589,10 @@ class Connection(AbstractConnection):
 
                 # set the socket_timeout now that we're connected
                 sock.settimeout(self.socket_timeout)
+
+                # If a previous connection attempt failed, clear the error
+                err = None
+
                 return sock
 
             except OSError as _:
@@ -1593,7 +1605,11 @@ class Connection(AbstractConnection):
                     sock.close()
 
         if err is not None:
-            raise err
+            try:
+                raise err
+            finally:
+                # Ensure we clear local references to caught exceptions
+                err = None
         raise OSError("socket.getaddrinfo returned an empty list")
 
     def _host_error(self):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -574,6 +574,35 @@ class TestConnection:
         mock_sock.close.assert_called_once()
         assert conn._sock is None
 
+    def test_connect_breaks_exception_reference_cycle(self):
+        """
+        On connection failure, _connect must not leave its frame retaining the
+        raised exception.
+        The exception's traceback references the frame, so a retained local
+        would form a cycle only reclaimable by the GC.
+        The finally clause in _connect breaks it by clearing the local.
+        """
+        conn = Connection(host="localhost", port=6379)
+        addr_info = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 6379))
+        with (
+            patch.object(socket, "getaddrinfo", return_value=[addr_info]),
+            patch.object(socket, "socket") as socket_factory,
+        ):
+            socket_factory.return_value.connect.side_effect = OSError("refused")
+            with pytest.raises(OSError) as exc_info:
+                conn._connect()
+
+        # Locate the _connect frame in the propagated traceback and confirm its
+        # err local was cleared, proving no exception<->frame cycle survives.
+        connect_frame = None
+        tb = exc_info.value.__traceback__
+        while tb is not None:
+            if tb.tb_frame.f_code.co_name == "_connect":
+                connect_frame = tb.tb_frame
+            tb = tb.tb_next
+        assert connect_frame is not None
+        assert connect_frame.f_locals.get("err") is None
+
     @pytest.mark.parametrize(
         "connection_kwargs",
         [

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -5,6 +5,7 @@ import select
 import selectors
 import socket
 import ssl
+import sys
 import threading
 import time
 import types
@@ -601,6 +602,40 @@ class TestConnection:
                 connect_frame = tb.tb_frame
             tb = tb.tb_next
         assert connect_frame is not None
+        assert connect_frame.f_locals.get("err") is None
+
+    def test_connect_breaks_reference_cycle_when_a_later_address_succeeds(self):
+        """
+        When an address fails but a later one connects, _connect must not
+        return while still holding the caught exception.
+        The exception's traceback references the frame, so a retained local
+        would form a cycle only reclaimable by the GC.
+        """
+        conn = Connection(host="localhost", port=6379)
+        addr_infos = [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 6379)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.2", 6379)),
+        ]
+
+        # _connect calls getaddrinfo, so hook that as a way to peek the caller
+        connect_frames = []
+
+        def capturing_getaddrinfo(*args, **kwargs):
+            connect_frames.append(sys._getframe(1))
+            return addr_infos
+
+        failing_sock, working_sock = MagicMock(), MagicMock()
+        failing_sock.connect.side_effect = OSError("refused")
+
+        with (
+            patch.object(socket, "getaddrinfo", capturing_getaddrinfo),
+            patch.object(socket, "socket", side_effect=[failing_sock, working_sock]),
+        ):
+            assert conn._connect() is working_sock
+
+        # Error should be cleared in the connect frame
+        assert len(connect_frames) == 1
+        (connect_frame,) = connect_frames
         assert connect_frame.f_locals.get("err") is None
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of change

Currently, in `_connect`, if an exception is thrown while trying different address infos, it is cached to be thrown only if _no_ connection succeeds. However, storing a caught exception inside the local stack frame creates a circular reference: the exception's traceback contains a pointer to the current frame, which contains the `err` local, which points to the exception again. This creates garbage that can only be collected by the fallback mark and sweep python GC. 

Break this cycle by clearing the local exception value on re-raise, allowing the error to be reclaimed via refcounting. This is useful for applications that disable or otherwise limit the python garbage collector.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TCP connect error-handling cleanup with no API or connection-semantics change; tests lock in frame-local clearing behavior.
> 
> **Overview**
> Fixes a **reference cycle** in `Connection._connect` when iterating over `getaddrinfo` results: a failed attempt stores the caught `OSError` in `err` for possible re-raise, but that exception’s traceback keeps the stack frame alive, and the frame still holds `err`—so cleanup depended on the cyclic GC instead of refcounting.
> 
> On **success** after an earlier failure, **`err` is set to `None`** before returning the socket. When **all addresses fail**, re-raise is wrapped in **`try` / `finally`** so **`err` is cleared** after `raise err`, matching the intent described in `read_response` (drop locals that pin exceptions).
> 
> Two unit tests assert that the `_connect` frame’s **`err` local is `None`** after total failure and after fail-then-succeed multi-address connect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33aae85399d05041b2614c8ab16c8dc36153ac96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->