### PR TITLE
fix: honor read_from_replicas for sharded pubsub subscriptions in ClusterPubSub

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -3742,6 +3742,19 @@ class ClusterPubSub(PubSub):
                 return None
         return message
 
+    def _eligible_subscription_nodes(self, slot: int) -> Dict[str, "ClusterNode"]:
+        """
+        Nodes a shard subscription may live on for ``slot``, keyed by node
+        name. Mirrors regular pubsub node selection: replicas are eligible
+        only when replica reads are enabled.
+        """
+        nodes = self.cluster.nodes_manager.slots_cache.get(slot) or []
+        if not (
+            self.cluster.read_from_replicas or self.cluster.load_balancing_strategy
+        ):
+            nodes = nodes[:1]
+        return {node.name: node for node in nodes}
+
     async def ssubscribe(
         self, *args: ChannelT | Subscription, **kwargs: PubSubHandler
     ) -> None:
@@ -3759,25 +3772,38 @@ class ClusterPubSub(PubSub):
         # re-acquire this lock (asyncio.Lock is non-reentrant).
         async with self._shard_state_lock:
             for s_channel, handler in s_channels.items():
-                node = self.cluster.get_node_from_key(s_channel)
+                slot = self.cluster.keyslot(s_channel)
+                node = self.cluster.nodes_manager.get_node_from_slot(
+                    slot,
+                    self.cluster.read_from_replicas,
+                    self.cluster.load_balancing_strategy,
+                )
                 if not node:
                     continue
                 # Lazy re-route: if this channel is already tracked against a
-                # different node (e.g. after a slot migration), migrate it now
-                # so the caller's intent is applied on the current owner.
+                # different node, migrate it now so the caller's intent is
+                # applied on the current owner — unless the tracked node
+                # still serves the slot, in which case leave it alone.
                 normalized_key = next(iter(self._normalize_keys({s_channel: None})))
                 old_name = self._shard_channel_to_node.get(normalized_key)
                 if old_name and old_name != node.name:
-                    # Match PubSub.ssubscribe() dict.update() semantics: the
-                    # caller's newly supplied handler (including None) always
-                    # overrides any previously registered handler.
-                    await self._migrate_shard_channel(
-                        normalized_key,
-                        handler,
-                        old_name,
-                        node,
-                    )
-                    continue
+                    tracked_node = self._eligible_subscription_nodes(slot).get(old_name)
+                    if tracked_node is not None:
+                        # The tracked node still serves the channel's slot
+                        # (the balancer merely picked a sibling); keep the
+                        # subscription where it is to avoid churn.
+                        node = tracked_node
+                    else:
+                        # Match PubSub.ssubscribe() dict.update() semantics: the
+                        # caller's newly supplied handler (including None) always
+                        # overrides any previously registered handler.
+                        await self._migrate_shard_channel(
+                            normalized_key,
+                            handler,
+                            old_name,
+                            node,
+                        )
+                        continue
                 pubsub = self._get_node_pubsub(node)
                 if handler:
                     await pubsub.ssubscribe(Subscription(s_channel, handler))
@@ -3813,10 +3839,21 @@ class ClusterPubSub(PubSub):
                 if name and name in self.node_pubsub_mapping:
                     pubsub = self.node_pubsub_mapping[name]
                 else:
-                    node = self.cluster.get_node_from_key(s_channel)
-                    if not node or node.name not in self.node_pubsub_mapping:
+                    # No reverse-index entry: check every node that may hold
+                    # the subscription for this slot (with replica reads
+                    # enabled that is not necessarily the primary).
+                    slot = self.cluster.keyslot(s_channel)
+                    eligible = self._eligible_subscription_nodes(slot)
+                    if not eligible:
+                        raise SlotNotCoveredError(
+                            f'Slot "{slot}" is not covered by the cluster.'
+                        )
+                    name = next(
+                        (n for n in eligible if n in self.node_pubsub_mapping), None
+                    )
+                    if name is None:
                         continue
-                    pubsub = self.node_pubsub_mapping[node.name]
+                    pubsub = self.node_pubsub_mapping[name]
                 await pubsub.sunsubscribe(s_channel)
                 self.pending_unsubscribe_shard_channels.update(
                     pubsub.pending_unsubscribe_shard_channels
@@ -3825,18 +3862,28 @@ class ClusterPubSub(PubSub):
     async def reinitialize_shard_subscriptions(self) -> None:
         """
         Reconcile per-node shard subscriptions against the cluster's current
-        slot ownership map. For each tracked shard channel whose owning node
-        has changed (e.g. after CLUSTER SETSLOT / failover), sunsubscribe on
-        the old node's pubsub and ssubscribe on the new owner's pubsub,
-        preserving any registered handler.
+        slot ownership map. For each tracked shard channel whose node no
+        longer serves the channel's slot (e.g. after CLUSTER SETSLOT /
+        failover), sunsubscribe on the old node's pubsub and ssubscribe on a
+        node currently serving the slot, preserving any registered handler.
         """
         uncovered: list = []
         made_progress = False
         first_migrate_error: Optional[BaseException] = None
         async with self._shard_state_lock:
             for channel, handler in list(self.shard_channels.items()):
+                slot = self.cluster.keyslot(channel)
+                old_name = self._shard_channel_to_node.get(channel)
+                if old_name and old_name in self._eligible_subscription_nodes(slot):
+                    # The tracked node still serves the channel's slot under
+                    # the current routing configuration; nothing to do.
+                    continue
                 try:
-                    new_node = self.cluster.get_node_from_key(channel)
+                    new_node = self.cluster.nodes_manager.get_node_from_slot(
+                        slot,
+                        self.cluster.read_from_replicas,
+                        self.cluster.load_balancing_strategy,
+                    )
                 except SlotNotCoveredError:
                     # Slot is transiently uncovered (mid-migration / partial
                     # topology refresh). Defer this channel so coverable
@@ -3845,9 +3892,6 @@ class ClusterPubSub(PubSub):
                     # channel was reconciled. Retry happens on the next
                     # slots-cache change notification.
                     uncovered.append(channel)
-                    continue
-                old_name = self._shard_channel_to_node.get(channel)
-                if old_name == new_node.name:
                     continue
                 try:
                     await self._migrate_shard_channel(

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -3839,8 +3839,8 @@ class ClusterPubSub(PubSub):
                 if name and name in self.node_pubsub_mapping:
                     pubsub = self.node_pubsub_mapping[name]
                 else:
-                    # No reverse-index entry: check every node that may hold
-                    # the subscription for this slot (with replica reads
+                    # No reverse-index entry: find the node whose pubsub
+                    # actually holds the subscription (with replica reads
                     # enabled that is not necessarily the primary).
                     slot = self.cluster.keyslot(s_channel)
                     eligible = self._eligible_subscription_nodes(slot)
@@ -3848,12 +3848,17 @@ class ClusterPubSub(PubSub):
                         raise SlotNotCoveredError(
                             f'Slot "{slot}" is not covered by the cluster.'
                         )
-                    name = next(
-                        (n for n in eligible if n in self.node_pubsub_mapping), None
-                    )
-                    if name is None:
+                    pubsub = None
+                    for name in eligible:
+                        candidate = self.node_pubsub_mapping.get(name)
+                        if (
+                            candidate is not None
+                            and normalized_key in candidate.shard_channels
+                        ):
+                            pubsub = candidate
+                            break
+                    if pubsub is None:
                         continue
-                    pubsub = self.node_pubsub_mapping[name]
                 await pubsub.sunsubscribe(s_channel)
                 self.pending_unsubscribe_shard_channels.update(
                     pubsub.pending_unsubscribe_shard_channels

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2205,7 +2205,7 @@ class NodesManager:
                 )
                 return self.slots_cache[slot][node_idx]
             return self.slots_cache[slot][0]
-        except (IndexError, TypeError):
+        except (KeyError, IndexError, TypeError):
             raise SlotNotCoveredError(
                 f'Slot "{slot}" not covered by the cluster. '
                 f'"require_full_coverage={self.require_full_coverage}"'

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3157,8 +3157,8 @@ class ClusterPubSub(PubSub):
                 if name and name in self.node_pubsub_mapping:
                     p = self.node_pubsub_mapping[name]
                 else:
-                    # No reverse-index entry: check every node that may hold
-                    # the subscription for this slot (with replica reads
+                    # No reverse-index entry: find the node whose pubsub
+                    # actually holds the subscription (with replica reads
                     # enabled that is not necessarily the primary).
                     slot = self.cluster.keyslot(s_channel)
                     eligible = self._eligible_subscription_nodes(slot)
@@ -3166,12 +3166,17 @@ class ClusterPubSub(PubSub):
                         raise SlotNotCoveredError(
                             f'Slot "{slot}" is not covered by the cluster.'
                         )
-                    name = next(
-                        (n for n in eligible if n in self.node_pubsub_mapping), None
-                    )
-                    if name is None:
+                    p = None
+                    for name in eligible:
+                        candidate = self.node_pubsub_mapping.get(name)
+                        if (
+                            candidate is not None
+                            and normalized_key in candidate.shard_channels
+                        ):
+                            p = candidate
+                            break
+                    if p is None:
                         continue
-                    p = self.node_pubsub_mapping[name]
                 p.sunsubscribe(s_channel)
                 self.pending_unsubscribe_shard_channels.update(
                     p.pending_unsubscribe_shard_channels

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3063,6 +3063,19 @@ class ClusterPubSub(PubSub):
                 return None
         return message
 
+    def _eligible_subscription_nodes(self, slot):
+        """
+        Nodes a shard subscription may live on for ``slot``, keyed by node
+        name. Mirrors regular pubsub node selection: replicas are eligible
+        only when replica reads are enabled.
+        """
+        nodes = self.cluster.nodes_manager.slots_cache.get(slot) or []
+        if not (
+            self.cluster.read_from_replicas or self.cluster.load_balancing_strategy
+        ):
+            nodes = nodes[:1]
+        return {node.name: node for node in nodes}
+
     def ssubscribe(
         self, *args: ChannelT | Subscription, **kwargs: PubSubHandler
     ) -> None:
@@ -3079,25 +3092,38 @@ class ClusterPubSub(PubSub):
         # not mutated concurrently.
         with self._shard_state_lock:
             for s_channel, handler in s_channels.items():
-                node = self.cluster.get_node_from_key(s_channel)
+                slot = self.cluster.keyslot(s_channel)
+                node = self.cluster.nodes_manager.get_node_from_slot(
+                    slot,
+                    self.cluster.read_from_replicas,
+                    self.cluster.load_balancing_strategy,
+                )
                 if not node:
                     continue
                 # Lazy re-route: if this channel is already tracked against a
-                # different node (e.g. after a slot migration), migrate it now
-                # so the caller's intent is applied on the current owner.
+                # different node, migrate it now so the caller's intent is
+                # applied on the current owner — unless the tracked node
+                # still serves the slot, in which case leave it alone.
                 normalized_key = next(iter(self._normalize_keys({s_channel: None})))
                 old_name = self._shard_channel_to_node.get(normalized_key)
                 if old_name and old_name != node.name:
-                    # Match PubSub.ssubscribe() dict.update() semantics: the
-                    # caller's newly supplied handler (including None) always
-                    # overrides any previously registered handler.
-                    self._migrate_shard_channel(
-                        normalized_key,
-                        handler,
-                        old_name,
-                        node,
-                    )
-                    continue
+                    tracked_node = self._eligible_subscription_nodes(slot).get(old_name)
+                    if tracked_node is not None:
+                        # The tracked node still serves the channel's slot
+                        # (the balancer merely picked a sibling); keep the
+                        # subscription where it is to avoid churn.
+                        node = tracked_node
+                    else:
+                        # Match PubSub.ssubscribe() dict.update() semantics: the
+                        # caller's newly supplied handler (including None) always
+                        # overrides any previously registered handler.
+                        self._migrate_shard_channel(
+                            normalized_key,
+                            handler,
+                            old_name,
+                            node,
+                        )
+                        continue
                 pubsub = self._get_node_pubsub(node)
                 if handler:
                     pubsub.ssubscribe(Subscription(s_channel, handler))
@@ -3131,10 +3157,21 @@ class ClusterPubSub(PubSub):
                 if name and name in self.node_pubsub_mapping:
                     p = self.node_pubsub_mapping[name]
                 else:
-                    node = self.cluster.get_node_from_key(s_channel)
-                    if not node or node.name not in self.node_pubsub_mapping:
+                    # No reverse-index entry: check every node that may hold
+                    # the subscription for this slot (with replica reads
+                    # enabled that is not necessarily the primary).
+                    slot = self.cluster.keyslot(s_channel)
+                    eligible = self._eligible_subscription_nodes(slot)
+                    if not eligible:
+                        raise SlotNotCoveredError(
+                            f'Slot "{slot}" is not covered by the cluster.'
+                        )
+                    name = next(
+                        (n for n in eligible if n in self.node_pubsub_mapping), None
+                    )
+                    if name is None:
                         continue
-                    p = self.node_pubsub_mapping[node.name]
+                    p = self.node_pubsub_mapping[name]
                 p.sunsubscribe(s_channel)
                 self.pending_unsubscribe_shard_channels.update(
                     p.pending_unsubscribe_shard_channels
@@ -3143,18 +3180,28 @@ class ClusterPubSub(PubSub):
     def reinitialize_shard_subscriptions(self):
         """
         Reconcile per-node shard subscriptions against the cluster's current
-        slot ownership map. For each tracked shard channel whose owning node
-        has changed (e.g. after CLUSTER SETSLOT / failover), sunsubscribe on
-        the old node's pubsub and ssubscribe on the new owner's pubsub,
-        preserving any registered handler.
+        slot ownership map. For each tracked shard channel whose node no
+        longer serves the channel's slot (e.g. after CLUSTER SETSLOT /
+        failover), sunsubscribe on the old node's pubsub and ssubscribe on a
+        node currently serving the slot, preserving any registered handler.
         """
         uncovered: list = []
         made_progress = False
         first_migrate_error: Optional[BaseException] = None
         with self._shard_state_lock:
             for channel, handler in list(self.shard_channels.items()):
+                slot = self.cluster.keyslot(channel)
+                old_name = self._shard_channel_to_node.get(channel)
+                if old_name and old_name in self._eligible_subscription_nodes(slot):
+                    # The tracked node still serves the channel's slot under
+                    # the current routing configuration; nothing to do.
+                    continue
                 try:
-                    new_node = self.cluster.get_node_from_key(channel)
+                    new_node = self.cluster.nodes_manager.get_node_from_slot(
+                        slot,
+                        self.cluster.read_from_replicas,
+                        self.cluster.load_balancing_strategy,
+                    )
                 except SlotNotCoveredError:
                     # Slot is transiently uncovered (mid-migration / partial
                     # topology refresh). Defer this channel so coverable
@@ -3163,9 +3210,6 @@ class ClusterPubSub(PubSub):
                     # channel was reconciled. Retry happens on the next
                     # slots-cache change notification.
                     uncovered.append(channel)
-                    continue
-                old_name = self._shard_channel_to_node.get(channel)
-                if old_name == new_node.name:
                     continue
                 try:
                     self._migrate_shard_channel(channel, handler, old_name, new_node)

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -2047,6 +2047,9 @@ class TestClusterPubSubSlotMigration:
         pubsub.ignore_subscribe_messages = False
         # ClusterPubSub-specific state.
         pubsub.cluster = MagicMock()
+        pubsub.cluster.read_from_replicas = False
+        pubsub.cluster.load_balancing_strategy = None
+        pubsub.cluster.nodes_manager.slots_cache = {}
         pubsub.node_pubsub_mapping = {}
         pubsub._shard_channel_to_node = {}
         pubsub._shard_state_lock = asyncio.Lock()
@@ -2081,7 +2084,9 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[new_node.name] = new_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: old_node.name}
-        pubsub.cluster.get_node_from_key.return_value = new_node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [new_node]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_node
 
         await pubsub.reinitialize_shard_subscriptions()
 
@@ -2097,12 +2102,14 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[owner.name] = owner_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: owner.name}
-        pubsub.cluster.get_node_from_key.return_value = owner
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [owner]}
 
         await pubsub.reinitialize_shard_subscriptions()
 
         owner_ps.sunsubscribe.assert_not_awaited()
         owner_ps.ssubscribe.assert_not_awaited()
+        pubsub.cluster.nodes_manager.get_node_from_slot.assert_not_called()
         assert pubsub._shard_channel_to_node[channel] == owner.name
 
     async def test_reinitialize_tolerates_old_node_disconnect(self):
@@ -2125,7 +2132,9 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[new_node.name] = new_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: old_node.name}
-        pubsub.cluster.get_node_from_key.return_value = new_node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [new_node]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_node
         # Old node is still known to the cluster (transient error).
         pubsub.cluster.get_node.return_value = old_node
 
@@ -2160,7 +2169,9 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[new_node.name] = new_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: old_node.name}
-        pubsub.cluster.get_node_from_key.return_value = new_node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [new_node]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_node
         # Old node was removed from topology.
         pubsub.cluster.get_node.return_value = None
 
@@ -2174,8 +2185,8 @@ class TestClusterPubSubSlotMigration:
         """
         After a slot migration, sunsubscribe must hit the node that currently
         holds the subscription (tracked in ``_shard_channel_to_node``) rather
-        than re-resolving via ``cluster.get_node_from_key``, which by then
-        points to the new owner and would miss the actual subscription.
+        than re-resolving by slot, which by then points to the new owner and
+        would miss the actual subscription.
         """
         pubsub = self._make_cluster_pubsub()
         holding_node_name = "127.0.0.1:7000"
@@ -2187,7 +2198,6 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[new_owner.name] = new_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: holding_node_name}
-        pubsub.cluster.get_node_from_key.return_value = new_owner
 
         await pubsub.sunsubscribe(channel)
 
@@ -2212,7 +2222,9 @@ class TestClusterPubSubSlotMigration:
         # Channel was previously subscribed with no handler.
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: old_node.name}
-        pubsub.cluster.get_node_from_key.return_value = new_node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [new_node]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_node
 
         new_handler = MagicMock()
         await pubsub.ssubscribe(foo=new_handler)
@@ -2231,7 +2243,9 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[new_node.name] = new_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: old_node.name}
-        pubsub.cluster.get_node_from_key.return_value = new_node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [new_node]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_node
 
         new_handler = MagicMock()
         await pubsub.ssubscribe(Subscription(channel, new_handler))
@@ -2241,14 +2255,14 @@ class TestClusterPubSubSlotMigration:
 
     async def test_ssubscribe_skips_channel_when_node_resolution_returns_none(self):
         """
-        Regression: cluster.get_node_from_key may return None for channels
-        whose slot is transiently uncovered. ssubscribe must skip such
-        channels rather than dereference None (which would crash on
-        ``node.name`` either in the reverse-index comparison or inside
+        Regression: cluster.nodes_manager.get_node_from_slot may return None
+        for channels whose slot is transiently uncovered. ssubscribe must
+        skip such channels rather than dereference None (which would crash
+        on ``node.name`` either in the reverse-index comparison or inside
         ``_get_node_pubsub``). Mirrors the sync counterpart's guard.
         """
         pubsub = self._make_cluster_pubsub()
-        pubsub.cluster.get_node_from_key.return_value = None
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = None
         # Stale reverse-index entry also present to exercise both crash paths:
         # the old_name != node.name comparison and the downstream fallthrough.
         pubsub._shard_channel_to_node = {b"foo": "127.0.0.1:7000"}
@@ -2258,6 +2272,118 @@ class TestClusterPubSubSlotMigration:
         # No migration, no per-node pubsub creation, no mapping mutation.
         assert pubsub.node_pubsub_mapping == {}
         assert pubsub._shard_channel_to_node == {b"foo": "127.0.0.1:7000"}
+
+    async def test_ssubscribe_routes_to_replica_when_read_from_replicas(self):
+        """
+        Regression for #3266: shard subscriptions must honor the cluster's
+        read_from_replicas / load_balancing_strategy routing instead of
+        always resolving the slot's primary.
+        """
+        pubsub = self._make_cluster_pubsub()
+        pubsub.cluster.read_from_replicas = True
+        replica = self._make_node("127.0.0.1:7001")
+        replica_ps = self._make_node_pubsub()
+        pubsub.node_pubsub_mapping[replica.name] = replica_ps
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = replica
+
+        await pubsub.ssubscribe(b"foo")
+
+        pubsub.cluster.nodes_manager.get_node_from_slot.assert_called_once_with(
+            42, True, None
+        )
+        replica_ps.ssubscribe.assert_awaited_once_with(b"foo")
+        assert pubsub._shard_channel_to_node[b"foo"] == replica.name
+
+    async def test_ssubscribe_keeps_tracked_node_when_balancer_picks_sibling(self):
+        """
+        Re-subscribing must not bounce a channel between nodes of the same
+        shard: when the tracked node still serves the slot, the subscription
+        stays put even if the balancer would pick a sibling now.
+        """
+        pubsub = self._make_cluster_pubsub()
+        pubsub.cluster.read_from_replicas = True
+        primary = self._make_node("127.0.0.1:7000")
+        replica = self._make_node("127.0.0.1:7001")
+        replica_ps = self._make_node_pubsub({b"foo": None})
+        pubsub.node_pubsub_mapping[replica.name] = replica_ps
+        pubsub.shard_channels = {b"foo": None}
+        pubsub._shard_channel_to_node = {b"foo": replica.name}
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [primary, replica]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = primary
+
+        handler = MagicMock()
+        await pubsub.ssubscribe(Subscription(b"foo", handler))
+
+        replica_ps.sunsubscribe.assert_not_awaited()
+        replica_ps.ssubscribe.assert_awaited_once_with(Subscription(b"foo", handler))
+        assert pubsub._shard_channel_to_node[b"foo"] == replica.name
+
+    async def test_reinitialize_keeps_channel_on_replica_still_serving_slot(self):
+        """
+        With replica routing enabled, a topology refresh must not migrate a
+        shard subscription off a node that still serves the channel's slot.
+        """
+        pubsub = self._make_cluster_pubsub()
+        pubsub.cluster.read_from_replicas = True
+        primary = self._make_node("127.0.0.1:7000")
+        replica = self._make_node("127.0.0.1:7001")
+        replica_ps = self._make_node_pubsub({b"foo": None})
+        pubsub.node_pubsub_mapping[replica.name] = replica_ps
+        pubsub.shard_channels = {b"foo": None}
+        pubsub._shard_channel_to_node = {b"foo": replica.name}
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [primary, replica]}
+
+        await pubsub.reinitialize_shard_subscriptions()
+
+        replica_ps.sunsubscribe.assert_not_awaited()
+        pubsub.cluster.nodes_manager.get_node_from_slot.assert_not_called()
+        assert pubsub._shard_channel_to_node[b"foo"] == replica.name
+
+    async def test_reinitialize_migrates_channel_when_node_stops_serving_slot(self):
+        pubsub = self._make_cluster_pubsub()
+        pubsub.cluster.read_from_replicas = True
+        old_replica = self._make_node("127.0.0.1:7001")
+        new_replica = self._make_node("127.0.0.1:7003")
+        old_ps = self._make_node_pubsub({b"foo": None})
+        new_ps = self._make_node_pubsub()
+        pubsub.node_pubsub_mapping[old_replica.name] = old_ps
+        pubsub.node_pubsub_mapping[new_replica.name] = new_ps
+        pubsub.shard_channels = {b"foo": None}
+        pubsub._shard_channel_to_node = {b"foo": old_replica.name}
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {
+            42: [self._make_node("127.0.0.1:7002"), new_replica]
+        }
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_replica
+
+        await pubsub.reinitialize_shard_subscriptions()
+
+        old_ps.sunsubscribe.assert_awaited_once_with(b"foo")
+        new_ps.ssubscribe.assert_awaited_once_with(b"foo")
+        assert pubsub._shard_channel_to_node[b"foo"] == new_replica.name
+
+    async def test_sunsubscribe_fallback_considers_all_slot_nodes(self):
+        """
+        When the reverse index has no entry, the fallback must consider
+        every node serving the slot (the subscription may live on a replica
+        when replica routing is enabled), not only the primary.
+        """
+        pubsub = self._make_cluster_pubsub()
+        pubsub.cluster.read_from_replicas = True
+        primary = self._make_node("127.0.0.1:7000")
+        replica = self._make_node("127.0.0.1:7001")
+        replica_ps = self._make_node_pubsub({b"foo": None})
+        pubsub.node_pubsub_mapping[replica.name] = replica_ps
+        pubsub.shard_channels = {b"foo": None}
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [primary, replica]}
+
+        await pubsub.sunsubscribe(b"foo")
+
+        replica_ps.sunsubscribe.assert_awaited_once_with(b"foo")
 
     async def test_aclose_clears_state_and_cancels_reconcile_tasks(self):
         """
@@ -2349,12 +2475,18 @@ class TestClusterPubSubSlotMigration:
             uncovered_channel: old_node.name,
         }
 
-        def _resolve(channel, *args, **kwargs):
-            if channel == uncovered_channel:
-                raise SlotNotCoveredError('Slot "0" is not covered by the cluster.')
+        pubsub.cluster.keyslot.side_effect = lambda ch: {
+            covered_channel: 1,
+            uncovered_channel: 2,
+        }[ch]
+        pubsub.cluster.nodes_manager.slots_cache = {1: [new_node]}
+
+        def _resolve(slot, *args, **kwargs):
+            if slot == 2:
+                raise SlotNotCoveredError('Slot "2" is not covered by the cluster.')
             return new_node
 
-        pubsub.cluster.get_node_from_key.side_effect = _resolve
+        pubsub.cluster.nodes_manager.get_node_from_slot.side_effect = _resolve
 
         with pytest.raises(SlotNotCoveredError):
             await pubsub.reinitialize_shard_subscriptions()

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -2367,15 +2367,20 @@ class TestClusterPubSubSlotMigration:
 
     async def test_sunsubscribe_fallback_considers_all_slot_nodes(self):
         """
-        When the reverse index has no entry, the fallback must consider
-        every node serving the slot (the subscription may live on a replica
-        when replica routing is enabled), not only the primary.
+        When the reverse index has no entry, the fallback must route to the
+        node whose pubsub actually holds the subscription (which may be a
+        replica when replica routing is enabled), not simply the first
+        slot-serving node that has a per-node pubsub.
         """
         pubsub = self._make_cluster_pubsub()
         pubsub.cluster.read_from_replicas = True
         primary = self._make_node("127.0.0.1:7000")
         replica = self._make_node("127.0.0.1:7001")
+        # The primary also has a per-node pubsub (for other channels), but
+        # only the replica's pubsub holds the target subscription.
+        primary_ps = self._make_node_pubsub({b"other": None})
         replica_ps = self._make_node_pubsub({b"foo": None})
+        pubsub.node_pubsub_mapping[primary.name] = primary_ps
         pubsub.node_pubsub_mapping[replica.name] = replica_ps
         pubsub.shard_channels = {b"foo": None}
         pubsub.cluster.keyslot.return_value = 42
@@ -2384,6 +2389,7 @@ class TestClusterPubSubSlotMigration:
         await pubsub.sunsubscribe(b"foo")
 
         replica_ps.sunsubscribe.assert_awaited_once_with(b"foo")
+        primary_ps.sunsubscribe.assert_not_awaited()
 
     async def test_aclose_clears_state_and_cancels_reconcile_tasks(self):
         """

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -21,7 +21,7 @@ import redis.asyncio as redis
 from redis.asyncio import Subscription
 from redis._parsers import Encoder
 from redis.asyncio.client import PubSub
-from redis.asyncio.cluster import ClusterPubSub
+from redis.asyncio.cluster import ClusterPubSub, NodesManager
 from redis.crc import key_slot
 
 from redis.exceptions import ConnectionError, SlotNotCoveredError, TimeoutError
@@ -2273,6 +2273,22 @@ class TestClusterPubSubSlotMigration:
         assert pubsub.node_pubsub_mapping == {}
         assert pubsub._shard_channel_to_node == {b"foo": "127.0.0.1:7000"}
 
+    async def test_ssubscribe_raises_slot_not_covered_for_uncovered_slot(self):
+        """
+        Subscribing to a channel whose slot is missing from the slots cache
+        must surface SlotNotCoveredError from the real nodes-manager
+        resolution — not a bare KeyError — matching the sync client.
+        """
+        pubsub = self._make_cluster_pubsub()
+        nodes_manager = pubsub.cluster.nodes_manager
+        nodes_manager.get_node_from_slot = functools.partial(
+            NodesManager.get_node_from_slot, nodes_manager
+        )
+        pubsub.cluster.keyslot.return_value = 42
+
+        with pytest.raises(SlotNotCoveredError):
+            await pubsub.ssubscribe(b"foo")
+
     async def test_ssubscribe_routes_to_replica_when_read_from_replicas(self):
         """
         Regression for #3266: shard subscriptions must honor the cluster's
@@ -2475,24 +2491,27 @@ class TestClusterPubSubSlotMigration:
         new_ps = self._make_node_pubsub()
         pubsub.node_pubsub_mapping[old_node.name] = old_ps
         pubsub.node_pubsub_mapping[new_node.name] = new_ps
-        pubsub.shard_channels = {covered_channel: None, uncovered_channel: None}
+        # The uncovered channel is iterated FIRST: an implementation that
+        # aborts the pass on SlotNotCoveredError instead of deferring would
+        # never reach the coverable sibling and fail the assertions below.
+        pubsub.shard_channels = {uncovered_channel: None, covered_channel: None}
         pubsub._shard_channel_to_node = {
-            covered_channel: old_node.name,
             uncovered_channel: old_node.name,
+            covered_channel: old_node.name,
         }
 
         pubsub.cluster.keyslot.side_effect = lambda ch: {
             covered_channel: 1,
             uncovered_channel: 2,
         }[ch]
-        pubsub.cluster.nodes_manager.slots_cache = {1: [new_node]}
-
-        def _resolve(slot, *args, **kwargs):
-            if slot == 2:
-                raise SlotNotCoveredError('Slot "2" is not covered by the cluster.')
-            return new_node
-
-        pubsub.cluster.nodes_manager.get_node_from_slot.side_effect = _resolve
+        # Resolve through the real NodesManager.get_node_from_slot with slot 2
+        # genuinely absent from slots_cache, so the test proves the uncovered
+        # slot surfaces as SlotNotCoveredError (not a bare KeyError) here.
+        nodes_manager = pubsub.cluster.nodes_manager
+        nodes_manager.slots_cache = {1: [new_node]}
+        nodes_manager.get_node_from_slot = functools.partial(
+            NodesManager.get_node_from_slot, nodes_manager
+        )
 
         with pytest.raises(SlotNotCoveredError):
             await pubsub.reinitialize_shard_subscriptions()

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -2019,6 +2019,75 @@ class TestClusterPubSubResubscribe:
             await p.aclose()
 
 
+class TestClusterPubSubReplicaRouting:
+    """
+    Cluster-only end-to-end tests for shard pubsub honoring the cluster's
+    replica routing configuration (#3266).
+    """
+
+    async def _wait_for_sharded_message(self, pubsub, timeout=2.0):
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + timeout
+        while loop.time() < deadline:
+            msg = await pubsub.get_sharded_message(timeout=0.1)
+            if msg is not None:
+                return msg
+        return None
+
+    @pytest.mark.onlycluster
+    @skip_if_server_version_lt("7.0.0")
+    async def test_ssubscribe_with_read_from_replicas_receives_spublish(
+        self, create_redis
+    ):
+        """
+        With read_from_replicas enabled, shard subscriptions are round-robined
+        across a slot's primary and replicas; SPUBLISH-ed messages must reach
+        the subscription wherever it was placed.
+        """
+        r = await create_redis(cls=redis.RedisCluster, read_from_replicas=True)
+        # Same slot via hash tag: two consecutive round-robin resolutions land
+        # on different shard nodes, so with a replica present at least one
+        # subscription lives on a replica and its delivery path is exercised.
+        ch_a, ch_b = "{replica-routed}a", "{replica-routed}b"
+        slot_nodes = r.nodes_manager.slots_cache[r.keyslot(ch_a)]
+        if len(slot_nodes) < 2:
+            pytest.skip("cluster has no replica for the channels' shard")
+
+        p = r.pubsub()
+        try:
+            await p.ssubscribe(ch_a, ch_b)
+            for _ in range(2):
+                msg = await self._wait_for_sharded_message(p)
+                assert msg is not None
+                assert msg["type"] == "ssubscribe"
+
+            subscribed_nodes = {
+                p._shard_channel_to_node[ch_a.encode()],
+                p._shard_channel_to_node[ch_b.encode()],
+            }
+            replica_names = {node.name for node in slot_nodes[1:]}
+            assert subscribed_nodes & replica_names, (
+                "expected at least one shard subscription on a replica"
+            )
+
+            await r.spublish(ch_a, "message-a")
+            await r.spublish(ch_b, "message-b")
+
+            messages = {}
+            for _ in range(2):
+                msg = await self._wait_for_sharded_message(p)
+                assert msg is not None
+                assert msg["type"] == "smessage"
+                messages[msg["channel"]] = msg["data"]
+
+            assert messages == {
+                ch_a.encode(): b"message-a",
+                ch_b.encode(): b"message-b",
+            }
+        finally:
+            await p.aclose()
+
+
 @pytest.mark.fixed_client
 class TestClusterPubSubSlotMigration:
     """

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2864,15 +2864,20 @@ class TestClusterPubSubSlotMigration:
 
     def test_sunsubscribe_fallback_considers_all_slot_nodes(self):
         """
-        When the reverse index has no entry, the fallback must consider
-        every node serving the slot (the subscription may live on a replica
-        when replica routing is enabled), not only the primary.
+        When the reverse index has no entry, the fallback must route to the
+        node whose pubsub actually holds the subscription (which may be a
+        replica when replica routing is enabled), not simply the first
+        slot-serving node that has a per-node pubsub.
         """
         pubsub = self._make_cluster_pubsub()
         pubsub.cluster.read_from_replicas = True
         primary = self._make_node("127.0.0.1:7000")
         replica = self._make_node("127.0.0.1:7001")
+        # The primary also has a per-node pubsub (for other channels), but
+        # only the replica's pubsub holds the target subscription.
+        primary_ps = self._make_node_pubsub({b"other": None})
         replica_ps = self._make_node_pubsub({b"foo": None})
+        pubsub.node_pubsub_mapping[primary.name] = primary_ps
         pubsub.node_pubsub_mapping[replica.name] = replica_ps
         pubsub.shard_channels = {b"foo": None}
         pubsub.cluster.keyslot.return_value = 42
@@ -2881,6 +2886,7 @@ class TestClusterPubSubSlotMigration:
         pubsub.sunsubscribe(b"foo")
 
         replica_ps.sunsubscribe.assert_called_once_with(b"foo")
+        primary_ps.sunsubscribe.assert_not_called()
 
     def test_migration_driven_sunsubscribe_drops_empty_pubsub(self):
         """

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2546,6 +2546,9 @@ class TestClusterPubSubSlotMigration:
         pubsub.ignore_subscribe_messages = False
         # ClusterPubSub-specific state.
         pubsub.cluster = mock.MagicMock()
+        pubsub.cluster.read_from_replicas = False
+        pubsub.cluster.load_balancing_strategy = None
+        pubsub.cluster.nodes_manager.slots_cache = {}
         pubsub.node_pubsub_mapping = {}
         pubsub._shard_channel_to_node = {}
         pubsub._shard_state_lock = threading.RLock()
@@ -2578,7 +2581,9 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[new_node.name] = new_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: old_node.name}
-        pubsub.cluster.get_node_from_key.return_value = new_node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [new_node]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_node
 
         pubsub.reinitialize_shard_subscriptions()
 
@@ -2594,12 +2599,14 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[owner.name] = owner_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: owner.name}
-        pubsub.cluster.get_node_from_key.return_value = owner
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [owner]}
 
         pubsub.reinitialize_shard_subscriptions()
 
         owner_ps.sunsubscribe.assert_not_called()
         owner_ps.ssubscribe.assert_not_called()
+        pubsub.cluster.nodes_manager.get_node_from_slot.assert_not_called()
         assert pubsub._shard_channel_to_node[channel] == owner.name
 
     def test_reinitialize_tolerates_old_node_disconnect(self):
@@ -2622,7 +2629,9 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[new_node.name] = new_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: old_node.name}
-        pubsub.cluster.get_node_from_key.return_value = new_node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [new_node]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_node
         # Old node is still known to the cluster (transient error).
         pubsub.cluster.get_node.return_value = old_node
 
@@ -2657,7 +2666,9 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[new_node.name] = new_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: old_node.name}
-        pubsub.cluster.get_node_from_key.return_value = new_node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [new_node]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_node
         # Old node was removed from topology.
         pubsub.cluster.get_node.return_value = None
 
@@ -2671,8 +2682,8 @@ class TestClusterPubSubSlotMigration:
         """
         After a slot migration, sunsubscribe must hit the node that currently
         holds the subscription (tracked in ``_shard_channel_to_node``) rather
-        than re-resolving via ``cluster.get_node_from_key``, which by then
-        points to the new owner and would miss the actual subscription.
+        than re-resolving by slot, which by then points to the new owner and
+        would miss the actual subscription.
         """
         pubsub = self._make_cluster_pubsub()
         holding_node_name = "127.0.0.1:7000"
@@ -2684,7 +2695,6 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[new_owner.name] = new_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: holding_node_name}
-        pubsub.cluster.get_node_from_key.return_value = new_owner
 
         pubsub.sunsubscribe(channel)
 
@@ -2709,7 +2719,9 @@ class TestClusterPubSubSlotMigration:
         # Channel was previously subscribed with no handler.
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: old_node.name}
-        pubsub.cluster.get_node_from_key.return_value = new_node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [new_node]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_node
 
         new_handler = mock.Mock()
         pubsub.ssubscribe(foo=new_handler)
@@ -2728,7 +2740,9 @@ class TestClusterPubSubSlotMigration:
         pubsub.node_pubsub_mapping[new_node.name] = new_ps
         pubsub.shard_channels = {channel: None}
         pubsub._shard_channel_to_node = {channel: old_node.name}
-        pubsub.cluster.get_node_from_key.return_value = new_node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [new_node]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_node
 
         new_handler = mock.Mock()
         pubsub.ssubscribe(Subscription(channel, new_handler))
@@ -2738,14 +2752,14 @@ class TestClusterPubSubSlotMigration:
 
     def test_ssubscribe_skips_channel_when_node_resolution_returns_none(self):
         """
-        Regression: cluster.get_node_from_key may return None for channels
-        whose slot is transiently uncovered. ssubscribe must skip such
-        channels rather than dereference None (which would crash on
-        ``node.name`` either in the reverse-index comparison or inside
+        Regression: cluster.nodes_manager.get_node_from_slot may return None
+        for channels whose slot is transiently uncovered. ssubscribe must
+        skip such channels rather than dereference None (which would crash
+        on ``node.name`` either in the reverse-index comparison or inside
         ``_get_node_pubsub``). Mirrors the async counterpart's guard.
         """
         pubsub = self._make_cluster_pubsub()
-        pubsub.cluster.get_node_from_key.return_value = None
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = None
         # Stale reverse-index entry also present to exercise both crash paths:
         # the old_name != node.name comparison and the downstream fallthrough.
         pubsub._shard_channel_to_node = {b"foo": "127.0.0.1:7000"}
@@ -2755,6 +2769,118 @@ class TestClusterPubSubSlotMigration:
         # No migration, no per-node pubsub creation, no mapping mutation.
         assert pubsub.node_pubsub_mapping == {}
         assert pubsub._shard_channel_to_node == {b"foo": "127.0.0.1:7000"}
+
+    def test_ssubscribe_routes_to_replica_when_read_from_replicas(self):
+        """
+        Regression for #3266: shard subscriptions must honor the cluster's
+        read_from_replicas / load_balancing_strategy routing instead of
+        always resolving the slot's primary.
+        """
+        pubsub = self._make_cluster_pubsub()
+        pubsub.cluster.read_from_replicas = True
+        replica = self._make_node("127.0.0.1:7001")
+        replica_ps = self._make_node_pubsub()
+        pubsub.node_pubsub_mapping[replica.name] = replica_ps
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = replica
+
+        pubsub.ssubscribe(b"foo")
+
+        pubsub.cluster.nodes_manager.get_node_from_slot.assert_called_once_with(
+            42, True, None
+        )
+        replica_ps.ssubscribe.assert_called_once_with(b"foo")
+        assert pubsub._shard_channel_to_node[b"foo"] == replica.name
+
+    def test_ssubscribe_keeps_tracked_node_when_balancer_picks_sibling(self):
+        """
+        Re-subscribing must not bounce a channel between nodes of the same
+        shard: when the tracked node still serves the slot, the subscription
+        stays put even if the balancer would pick a sibling now.
+        """
+        pubsub = self._make_cluster_pubsub()
+        pubsub.cluster.read_from_replicas = True
+        primary = self._make_node("127.0.0.1:7000")
+        replica = self._make_node("127.0.0.1:7001")
+        replica_ps = self._make_node_pubsub({b"foo": None})
+        pubsub.node_pubsub_mapping[replica.name] = replica_ps
+        pubsub.shard_channels = {b"foo": None}
+        pubsub._shard_channel_to_node = {b"foo": replica.name}
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [primary, replica]}
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = primary
+
+        handler = mock.Mock()
+        pubsub.ssubscribe(Subscription(b"foo", handler))
+
+        replica_ps.sunsubscribe.assert_not_called()
+        replica_ps.ssubscribe.assert_called_once_with(Subscription(b"foo", handler))
+        assert pubsub._shard_channel_to_node[b"foo"] == replica.name
+
+    def test_reinitialize_keeps_channel_on_replica_still_serving_slot(self):
+        """
+        With replica routing enabled, a topology refresh must not migrate a
+        shard subscription off a node that still serves the channel's slot.
+        """
+        pubsub = self._make_cluster_pubsub()
+        pubsub.cluster.read_from_replicas = True
+        primary = self._make_node("127.0.0.1:7000")
+        replica = self._make_node("127.0.0.1:7001")
+        replica_ps = self._make_node_pubsub({b"foo": None})
+        pubsub.node_pubsub_mapping[replica.name] = replica_ps
+        pubsub.shard_channels = {b"foo": None}
+        pubsub._shard_channel_to_node = {b"foo": replica.name}
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [primary, replica]}
+
+        pubsub.reinitialize_shard_subscriptions()
+
+        replica_ps.sunsubscribe.assert_not_called()
+        pubsub.cluster.nodes_manager.get_node_from_slot.assert_not_called()
+        assert pubsub._shard_channel_to_node[b"foo"] == replica.name
+
+    def test_reinitialize_migrates_channel_when_node_stops_serving_slot(self):
+        pubsub = self._make_cluster_pubsub()
+        pubsub.cluster.read_from_replicas = True
+        old_replica = self._make_node("127.0.0.1:7001")
+        new_replica = self._make_node("127.0.0.1:7003")
+        old_ps = self._make_node_pubsub({b"foo": None})
+        new_ps = self._make_node_pubsub()
+        pubsub.node_pubsub_mapping[old_replica.name] = old_ps
+        pubsub.node_pubsub_mapping[new_replica.name] = new_ps
+        pubsub.shard_channels = {b"foo": None}
+        pubsub._shard_channel_to_node = {b"foo": old_replica.name}
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {
+            42: [self._make_node("127.0.0.1:7002"), new_replica]
+        }
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = new_replica
+
+        pubsub.reinitialize_shard_subscriptions()
+
+        old_ps.sunsubscribe.assert_called_once_with(b"foo")
+        new_ps.ssubscribe.assert_called_once_with(b"foo")
+        assert pubsub._shard_channel_to_node[b"foo"] == new_replica.name
+
+    def test_sunsubscribe_fallback_considers_all_slot_nodes(self):
+        """
+        When the reverse index has no entry, the fallback must consider
+        every node serving the slot (the subscription may live on a replica
+        when replica routing is enabled), not only the primary.
+        """
+        pubsub = self._make_cluster_pubsub()
+        pubsub.cluster.read_from_replicas = True
+        primary = self._make_node("127.0.0.1:7000")
+        replica = self._make_node("127.0.0.1:7001")
+        replica_ps = self._make_node_pubsub({b"foo": None})
+        pubsub.node_pubsub_mapping[replica.name] = replica_ps
+        pubsub.shard_channels = {b"foo": None}
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.slots_cache = {42: [primary, replica]}
+
+        pubsub.sunsubscribe(b"foo")
+
+        replica_ps.sunsubscribe.assert_called_once_with(b"foo")
 
     def test_migration_driven_sunsubscribe_drops_empty_pubsub(self):
         """
@@ -2817,12 +2943,18 @@ class TestClusterPubSubSlotMigration:
             uncovered_channel: old_node.name,
         }
 
-        def _resolve(channel, *args, **kwargs):
-            if channel == uncovered_channel:
-                raise SlotNotCoveredError('Slot "0" is not covered by the cluster.')
+        pubsub.cluster.keyslot.side_effect = lambda ch: {
+            covered_channel: 1,
+            uncovered_channel: 2,
+        }[ch]
+        pubsub.cluster.nodes_manager.slots_cache = {1: [new_node]}
+
+        def _resolve(slot, *args, **kwargs):
+            if slot == 2:
+                raise SlotNotCoveredError('Slot "2" is not covered by the cluster.')
             return new_node
 
-        pubsub.cluster.get_node_from_key.side_effect = _resolve
+        pubsub.cluster.nodes_manager.get_node_from_slot.side_effect = _resolve
 
         with pytest.raises(SlotNotCoveredError):
             pubsub.reinitialize_shard_subscriptions()
@@ -2941,7 +3073,8 @@ class TestClusterPubSubSlotMigration:
         node = self._make_node("127.0.0.1:7000")
         node_ps = self._make_node_pubsub()
         pubsub.node_pubsub_mapping[node.name] = node_ps
-        pubsub.cluster.get_node_from_key.return_value = node
+        pubsub.cluster.keyslot.return_value = 42
+        pubsub.cluster.nodes_manager.get_node_from_slot.return_value = node
 
         holder_acquired = threading.Event()
         release_holder = threading.Event()

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2517,6 +2517,64 @@ class TestClusterPubSubResubscribe:
             p.close()
 
 
+class TestClusterPubSubReplicaRouting:
+    """
+    Cluster-only end-to-end tests for shard pubsub honoring the cluster's
+    replica routing configuration (#3266).
+    """
+
+    @pytest.mark.onlycluster
+    @skip_if_server_version_lt("7.0.0")
+    def test_ssubscribe_with_read_from_replicas_receives_spublish(self, request):
+        """
+        With read_from_replicas enabled, shard subscriptions are round-robined
+        across a slot's primary and replicas; SPUBLISH-ed messages must reach
+        the subscription wherever it was placed.
+        """
+        r = _get_client(redis.RedisCluster, request, read_from_replicas=True)
+        # Same slot via hash tag: two consecutive round-robin resolutions land
+        # on different shard nodes, so with a replica present at least one
+        # subscription lives on a replica and its delivery path is exercised.
+        ch_a, ch_b = "{replica-routed}a", "{replica-routed}b"
+        slot_nodes = r.nodes_manager.slots_cache[r.keyslot(ch_a)]
+        if len(slot_nodes) < 2:
+            pytest.skip("cluster has no replica for the channels' shard")
+
+        p = r.pubsub()
+        try:
+            p.ssubscribe(ch_a, ch_b)
+            for _ in range(2):
+                msg = wait_for_message(p, timeout=2.0, func=p.get_sharded_message)
+                assert msg is not None
+                assert msg["type"] == "ssubscribe"
+
+            subscribed_nodes = {
+                p._shard_channel_to_node[ch_a.encode()],
+                p._shard_channel_to_node[ch_b.encode()],
+            }
+            replica_names = {node.name for node in slot_nodes[1:]}
+            assert subscribed_nodes & replica_names, (
+                "expected at least one shard subscription on a replica"
+            )
+
+            r.spublish(ch_a, "message-a")
+            r.spublish(ch_b, "message-b")
+
+            messages = {}
+            for _ in range(2):
+                msg = wait_for_message(p, timeout=2.0, func=p.get_sharded_message)
+                assert msg is not None
+                assert msg["type"] == "smessage"
+                messages[msg["channel"]] = msg["data"]
+
+            assert messages == {
+                ch_a.encode(): b"message-a",
+                ch_b.encode(): b"message-b",
+            }
+        finally:
+            p.close()
+
+
 @pytest.mark.fixed_client
 class TestClusterPubSubSlotMigration:
     """

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import platform
 import queue
@@ -13,7 +14,7 @@ import redis
 from redis import Subscription
 from redis._parsers import Encoder
 from redis.client import PubSub
-from redis.cluster import ClusterPubSub
+from redis.cluster import ClusterPubSub, NodesManager
 from redis.crc import key_slot
 from redis.event import EventDispatcher
 from redis.exceptions import ConnectionError, SlotNotCoveredError, TimeoutError
@@ -2770,6 +2771,22 @@ class TestClusterPubSubSlotMigration:
         assert pubsub.node_pubsub_mapping == {}
         assert pubsub._shard_channel_to_node == {b"foo": "127.0.0.1:7000"}
 
+    def test_ssubscribe_raises_slot_not_covered_for_uncovered_slot(self):
+        """
+        Subscribing to a channel whose slot is missing from the slots cache
+        must surface SlotNotCoveredError from the real nodes-manager
+        resolution — not a bare KeyError — matching the async client.
+        """
+        pubsub = self._make_cluster_pubsub()
+        nodes_manager = pubsub.cluster.nodes_manager
+        nodes_manager.get_node_from_slot = functools.partial(
+            NodesManager.get_node_from_slot, nodes_manager
+        )
+        pubsub.cluster.keyslot.return_value = 42
+
+        with pytest.raises(SlotNotCoveredError):
+            pubsub.ssubscribe(b"foo")
+
     def test_ssubscribe_routes_to_replica_when_read_from_replicas(self):
         """
         Regression for #3266: shard subscriptions must honor the cluster's
@@ -2943,24 +2960,27 @@ class TestClusterPubSubSlotMigration:
         new_ps = self._make_node_pubsub()
         pubsub.node_pubsub_mapping[old_node.name] = old_ps
         pubsub.node_pubsub_mapping[new_node.name] = new_ps
-        pubsub.shard_channels = {covered_channel: None, uncovered_channel: None}
+        # The uncovered channel is iterated FIRST: an implementation that
+        # aborts the pass on SlotNotCoveredError instead of deferring would
+        # never reach the coverable sibling and fail the assertions below.
+        pubsub.shard_channels = {uncovered_channel: None, covered_channel: None}
         pubsub._shard_channel_to_node = {
-            covered_channel: old_node.name,
             uncovered_channel: old_node.name,
+            covered_channel: old_node.name,
         }
 
         pubsub.cluster.keyslot.side_effect = lambda ch: {
             covered_channel: 1,
             uncovered_channel: 2,
         }[ch]
-        pubsub.cluster.nodes_manager.slots_cache = {1: [new_node]}
-
-        def _resolve(slot, *args, **kwargs):
-            if slot == 2:
-                raise SlotNotCoveredError('Slot "2" is not covered by the cluster.')
-            return new_node
-
-        pubsub.cluster.nodes_manager.get_node_from_slot.side_effect = _resolve
+        # Resolve through the real NodesManager.get_node_from_slot with slot 2
+        # genuinely absent from slots_cache, so the test proves the uncovered
+        # slot surfaces as SlotNotCoveredError (not a bare KeyError) here.
+        nodes_manager = pubsub.cluster.nodes_manager
+        nodes_manager.slots_cache = {1: [new_node]}
+        nodes_manager.get_node_from_slot = functools.partial(
+            NodesManager.get_node_from_slot, nodes_manager
+        )
 
         with pytest.raises(SlotNotCoveredError):
             pubsub.reinitialize_shard_subscriptions()


### PR DESCRIPTION
### Description of change

Fixes #3266

`ClusterPubSub` routes every sharded subscription to the slot's primary: `ssubscribe`, the `sunsubscribe` fallback, and `reinitialize_shard_subscriptions` resolve nodes via `get_node_from_key()`, which ignores `read_from_replicas` and `load_balancing_strategy` — unlike regular pub/sub node selection in `ClusterPubSub.execute_command`, which honors both.

Shard-channel resolution now goes through the same `nodes_manager.get_node_from_slot(slot, read_from_replicas, load_balancing_strategy)` in the sync and async clients. Since a shard subscription may now live on a replica, the keep-vs-migrate decisions (slot-migration reconciliation and the lazy re-route in `ssubscribe`) check whether the tracked node still serves the channel's slot instead of comparing against a fresh pick, so subscriptions don't bounce between shard siblings on topology refreshes.

With the default configuration (`read_from_replicas=False`, no load balancing strategy) behavior is unchanged: subscriptions resolve to and strictly follow the slot primary, and `SlotNotCoveredError` is still raised for uncovered slots.

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [N/A] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [N/A] Is there an example added to the examples folder (if applicable)?



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster pub/sub routing and migration/reconcile paths in both sync and async clients; behavior changes only when replica reads or load balancing is enabled, but mistakes could drop or duplicate shard subscriptions during failover.
> 
> **Overview**
> Fixes **#3266** by aligning **shard pub/sub** node selection in sync and async `ClusterPubSub` with regular cluster routing: `ssubscribe`, `sunsubscribe` fallback, and `reinitialize_shard_subscriptions` now use `nodes_manager.get_node_from_slot(slot, read_from_replicas, load_balancing_strategy)` instead of `get_node_from_key()` (primary-only).
> 
> A new **`_eligible_subscription_nodes`** helper defines which nodes may hold a subscription for a slot (replicas included only when replica reads or load balancing is enabled). **Keep-vs-migrate** logic no longer compares the tracked node to a fresh balancer pick; it skips migration when the tracked node still serves the slot, avoiding churn between primary and replica on re-subscribe or topology refresh. **`sunsubscribe`** without a reverse-index entry scans eligible slot nodes for the pubsub that actually holds the channel.
> 
> Default config (`read_from_replicas=False`) behavior is unchanged. Tests are updated for the new resolution path and extended for replica routing, sibling stability, and unsubscribe fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f60eef1f34b233cf60cc28a84997cccbcedb21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->