### PR TITLE
fix: allow EVALSHA in ClusterPipeline (#2914)

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -132,6 +132,7 @@ gmail
 himport
 hiredis
 http
+idempotent
 idx
 iff
 ini
@@ -182,6 +183,7 @@ redismodules
 reinitialization
 replicaof
 repo
+resharding
 runtime
 sedrik
 serializers

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -164,6 +164,7 @@ opentelemetry
 oss
 parsers
 performant
+pipelined
 pmessage
 png
 positionally

--- a/docs/lua_scripting.rst
+++ b/docs/lua_scripting.rst
@@ -114,8 +114,11 @@ The following commands are not supported:
 
 ``EVALSHA`` can be used inside a ``ClusterPipeline``. Keys must still map to
 the same hash slot (or ``numkeys`` may be ``0``, in which case the command is
-routed to a random primary). The script must already be loaded on the target
-node, for example via ``SCRIPT LOAD`` on the cluster client, which loads the
-script on all primaries. Other scripting helpers such as ``EVAL``,
-``load_scripts``, and ``script_load_for_pipeline`` remain unsupported on
-cluster pipelines.
+routed to a random primary). In a transactional pipeline
+(``pipeline(transaction=True)``), zero-key ``EVALSHA`` reuses the
+transaction's existing slot when one is already chosen so multiple zero-key
+scripts (or a mix with keyed commands) stay single-slot. The script must
+already be loaded on the target node, for example via ``SCRIPT LOAD`` on the
+cluster client, which loads the script on all primaries. Other scripting
+helpers such as ``EVAL``, ``load_scripts``, and ``script_load_for_pipeline``
+remain unsupported on cluster pipelines.

--- a/docs/lua_scripting.rst
+++ b/docs/lua_scripting.rst
@@ -112,4 +112,10 @@ The following commands are not supported:
 - ``EVAL_RO``
 - ``EVALSHA_RO``
 
-Using scripting within pipelines in cluster mode is **not supported**.
+``EVALSHA`` can be used inside a ``ClusterPipeline``. Keys must still map to
+the same hash slot (or ``numkeys`` may be ``0``, in which case the command is
+routed to a random primary). The script must already be loaded on the target
+node, for example via ``SCRIPT LOAD`` on the cluster client, which loads the
+script on all primaries. Other scripting helpers such as ``EVAL``,
+``load_scripts``, and ``script_load_for_pipeline`` remain unsupported on
+cluster pipelines.

--- a/docs/lua_scripting.rst
+++ b/docs/lua_scripting.rst
@@ -119,8 +119,9 @@ transactional pipeline (``pipeline(transaction=True)``), zero-key ``EVALSHA``
 reuses the transaction's existing slot when one is already chosen, so multiple
 zero-key scripts (or a mix with keyed commands) stay single-slot.
 
-``EVAL``, ``load_scripts``, and ``script_load_for_pipeline`` remain
-**not supported** on cluster pipelines.
+``load_scripts`` and ``script_load_for_pipeline`` remain **not supported**
+on cluster pipelines. On the sync client, ``ClusterPipeline.eval()`` is also
+blocked; the async cluster pipeline has no ``eval`` override.
 
 Important caveats when using ``EVALSHA`` in a cluster pipeline:
 

--- a/docs/lua_scripting.rst
+++ b/docs/lua_scripting.rst
@@ -153,9 +153,9 @@ Important caveats when using ``EVALSHA`` in a cluster pipeline:
    ...     with rc.pipeline() as pipe:
    ...         pipe.evalsha(sha, 1, "{user}:1")
    ...         return pipe.execute()
->>> try:
-...     result = run()
-... except NoScriptError:
-...     # single-command pipeline: safe to reload and retry
-...     sha = rc.script_load(lua)  # reload on current primaries
-...     result = run()
+   >>> try:
+   ...     result = run()
+   ... except NoScriptError:
+   ...     # single-command pipeline: safe to reload and retry
+   ...     sha = rc.script_load(lua)  # reload on current primaries
+   ...     result = run()

--- a/docs/lua_scripting.rst
+++ b/docs/lua_scripting.rst
@@ -134,8 +134,12 @@ Important caveats when using ``EVALSHA`` in a cluster pipeline:
   fails with ``NOSCRIPT`` (``redis.exceptions.NoScriptError``).
 - Unlike the non-pipelined ``Script`` object, **a cluster pipeline performs no
   automatic reload or retry** on ``NOSCRIPT``. Recovery is the caller's
-  responsibility: catch ``NoScriptError``, re-run ``SCRIPT LOAD``, and
-  re-execute the pipeline. Because zero-key ``EVALSHA`` is routed to a random
+  responsibility: catch ``NoScriptError``, re-run ``SCRIPT LOAD``, then retry
+  only when replay is safe (for example an idempotent or single-command
+  pipeline). Blindly re-executing a multi-command pipeline can duplicate
+  side effects: Redis still runs the rest of a non-transactional batch when
+  one ``EVALSHA`` returns ``NOSCRIPT``, and the client raises only after
+  reading every response. Because zero-key ``EVALSHA`` is routed to a random
   primary, the script must be present on **all** primaries.
 - In a **transactional** pipeline, a ``NOSCRIPT`` from ``EVALSHA`` is raised at
   ``EXEC`` time and does **not** roll back the other commands (this follows
@@ -149,9 +153,9 @@ Important caveats when using ``EVALSHA`` in a cluster pipeline:
    ...     with rc.pipeline() as pipe:
    ...         pipe.evalsha(sha, 1, "{user}:1")
    ...         return pipe.execute()
-   >>> try:
-   ...     result = run()
-   ... except NoScriptError:
-   ...     # a node was missing the script (e.g. after failover/upgrade)
-   ...     sha = rc.script_load(lua)  # reload on current primaries
-   ...     result = run()
+>>> try:
+...     result = run()
+... except NoScriptError:
+...     # single-command pipeline: safe to reload and retry
+...     sha = rc.script_load(lua)  # reload on current primaries
+...     result = run()

--- a/docs/lua_scripting.rst
+++ b/docs/lua_scripting.rst
@@ -112,13 +112,45 @@ The following commands are not supported:
 - ``EVAL_RO``
 - ``EVALSHA_RO``
 
-``EVALSHA`` can be used inside a ``ClusterPipeline``. Keys must still map to
-the same hash slot (or ``numkeys`` may be ``0``, in which case the command is
-routed to a random primary). In a transactional pipeline
-(``pipeline(transaction=True)``), zero-key ``EVALSHA`` reuses the
-transaction's existing slot when one is already chosen so multiple zero-key
-scripts (or a mix with keyed commands) stay single-slot. The script must
-already be loaded on the target node, for example via ``SCRIPT LOAD`` on the
-cluster client, which loads the script on all primaries. Other scripting
-helpers such as ``EVAL``, ``load_scripts``, and ``script_load_for_pipeline``
-remain unsupported on cluster pipelines.
+``EVALSHA`` can be used inside a ``ClusterPipeline``. Keys must map to the
+same hash slot (or ``numkeys`` may be ``0``, in which case the command is
+routed to a random primary, exactly as in the non-pipelined case above). In a
+transactional pipeline (``pipeline(transaction=True)``), zero-key ``EVALSHA``
+reuses the transaction's existing slot when one is already chosen, so multiple
+zero-key scripts (or a mix with keyed commands) stay single-slot.
+
+``EVAL``, ``load_scripts``, and ``script_load_for_pipeline`` remain
+**not supported** on cluster pipelines.
+
+Important caveats when using ``EVALSHA`` in a cluster pipeline:
+
+- The Lua script cache in Redis is **per-node and is not replicated**.
+  ``SCRIPT LOAD`` loads the script onto the *current* primaries only, at the
+  moment it is called.
+- Any topology change -- a failover that promotes a replica, a rolling
+  upgrade that replaces nodes, resharding, or adding a new shard -- can route
+  an ``EVALSHA`` to a node whose cache does not contain the script, which
+  fails with ``NOSCRIPT`` (``redis.exceptions.NoScriptError``).
+- Unlike the non-pipelined ``Script`` object, **a cluster pipeline performs no
+  automatic reload or retry** on ``NOSCRIPT``. Recovery is the caller's
+  responsibility: catch ``NoScriptError``, re-run ``SCRIPT LOAD``, and
+  re-execute the pipeline. Because zero-key ``EVALSHA`` is routed to a random
+  primary, the script must be present on **all** primaries.
+- In a **transactional** pipeline, a ``NOSCRIPT`` from ``EVALSHA`` is raised at
+  ``EXEC`` time and does **not** roll back the other commands (this follows
+  Redis ``MULTI``/``EXEC`` semantics), so partial application is possible.
+
+.. code:: python
+
+   >>> from redis.exceptions import NoScriptError
+   >>> sha = rc.script_load(lua)  # loads on all current primaries
+   >>> def run():
+   ...     with rc.pipeline() as pipe:
+   ...         pipe.evalsha(sha, 1, "{user}:1")
+   ...         return pipe.execute()
+   >>> try:
+   ...     result = run()
+   ... except NoScriptError:
+   ...     # a node was missing the script (e.g. after failover/upgrade)
+   ...     sha = rc.script_load(lua)  # reload on current primaries
+   ...     result = run()

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -75,6 +75,7 @@ from redis.cluster import (
     LoadBalancingStrategy,
     block_pipeline_command,
     get_node_name,
+    is_zero_key_eval_command,
     parse_cluster_shards,
     parse_cluster_shards_unified,
     parse_cluster_shards_with_str_keys,
@@ -2917,6 +2918,8 @@ class TransactionStrategy(AbstractStrategy):
         self._explicit_transaction = False
         self._watching = False
         self._pipeline_slots: Set[int] = set()
+        # True once a keyed (non-slot-agnostic) command has fixed the slot
+        self._transaction_has_keyed_slot = False
         self._transaction_node: Optional[ClusterNode] = None
         self._transaction_connection: Optional[Connection] = None
         self._executing = False
@@ -2924,6 +2927,34 @@ class TransactionStrategy(AbstractStrategy):
         self._retry.update_supported_errors(
             RedisCluster.ERRORS_ALLOW_RETRY + self.SLOT_REDIRECT_ERRORS
         )
+
+    async def _resolve_transaction_slot(self, *args) -> Optional[int]:
+        """
+        Pick a slot for a transactional pipeline command.
+
+        Zero-key EVAL/EVALSHA can run on any primary. Reuse an existing
+        transaction slot when present so multiple zero-key scripts (or a
+        mix with keyed commands) stay single-slot.
+        """
+        if args[0] in self.NO_SLOTS_COMMANDS:
+            return None
+
+        if is_zero_key_eval_command(*args):
+            if self._pipeline_slots:
+                return next(iter(self._pipeline_slots))
+            return await self._pipe.cluster_client._determine_slot(*args)
+
+        slot_number = await self._pipe.cluster_client._determine_slot(*args)
+        if (
+            slot_number is not None
+            and self._pipeline_slots
+            and slot_number not in self._pipeline_slots
+            and not self._transaction_has_keyed_slot
+        ):
+            # Prior slots came only from zero-key EVAL/EVALSHA; retarget.
+            self._pipeline_slots.clear()
+        self._transaction_has_keyed_slot = True
+        return slot_number
 
     def _get_client_and_connection_for_transaction(
         self,
@@ -2982,7 +3013,7 @@ class TransactionStrategy(AbstractStrategy):
 
         slot_number: Optional[int] = None
         if args[0] not in self.NO_SLOTS_COMMANDS:
-            slot_number = await self._pipe.cluster_client._determine_slot(*args)
+            slot_number = await self._resolve_transaction_slot(*args)
 
         if (
             self._watching or args[0] in self.IMMEDIATE_EXECUTE_COMMANDS
@@ -3327,6 +3358,7 @@ class TransactionStrategy(AbstractStrategy):
             self._watching = False
             self._explicit_transaction = False
             self._pipeline_slots = set()
+            self._transaction_has_keyed_slot = False
             self._executing = False
 
     def multi(self):

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2932,9 +2932,9 @@ class TransactionStrategy(AbstractStrategy):
         """
         Pick a slot for a transactional pipeline command.
 
-        Zero-key EVAL/EVALSHA can run on any primary. Reuse an existing
-        transaction slot when present so multiple zero-key scripts (or a
-        mix with keyed commands) stay single-slot.
+        Zero-key EVAL/EVALSHA/FCALL/FCALL_RO can run on any primary. Reuse
+        an existing transaction slot when present so multiple zero-key
+        scripts/functions (or a mix with keyed commands) stay single-slot.
         """
         if args[0] in self.NO_SLOTS_COMMANDS:
             return None
@@ -2951,7 +2951,7 @@ class TransactionStrategy(AbstractStrategy):
             and slot_number not in self._pipeline_slots
             and not self._transaction_has_keyed_slot
         ):
-            # Prior slots came only from zero-key EVAL/EVALSHA; retarget.
+            # Prior slots came only from zero-key scripts/functions; retarget.
             self._pipeline_slots.clear()
         if slot_number is not None:
             self._transaction_has_keyed_slot = True

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2932,9 +2932,9 @@ class TransactionStrategy(AbstractStrategy):
         """
         Pick a slot for a transactional pipeline command.
 
-        Zero-key EVAL/EVALSHA/FCALL/FCALL_RO can run on any primary. Reuse
-        an existing transaction slot when present so multiple zero-key
-        scripts/functions (or a mix with keyed commands) stay single-slot.
+        Zero-key EVAL/EVALSHA can run on any primary. Reuse an existing
+        transaction slot when present so multiple zero-key scripts (or a
+        mix with keyed commands) stay single-slot.
         """
         if args[0] in self.NO_SLOTS_COMMANDS:
             return None
@@ -2951,7 +2951,7 @@ class TransactionStrategy(AbstractStrategy):
             and slot_number not in self._pipeline_slots
             and not self._transaction_has_keyed_slot
         ):
-            # Prior slots came only from zero-key scripts/functions; retarget.
+            # Prior slots came only from zero-key scripts; retarget.
             self._pipeline_slots.clear()
         if slot_number is not None:
             self._transaction_has_keyed_slot = True

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2953,7 +2953,8 @@ class TransactionStrategy(AbstractStrategy):
         ):
             # Prior slots came only from zero-key EVAL/EVALSHA; retarget.
             self._pipeline_slots.clear()
-        self._transaction_has_keyed_slot = True
+        if slot_number is not None:
+            self._transaction_has_keyed_slot = True
         return slot_number
 
     def _get_client_and_connection_for_transaction(

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3623,6 +3623,20 @@ def block_pipeline_command(name: str) -> Callable[..., Any]:
     return inner
 
 
+def is_zero_key_eval_command(*args) -> bool:
+    """
+    True for EVAL/EVALSHA with numkeys=0 (may run on any primary).
+    """
+    if len(args) < 3:
+        return False
+    if str(args[0]).upper() not in ("EVAL", "EVALSHA"):
+        return False
+    try:
+        return int(args[2]) == 0
+    except (TypeError, ValueError):
+        return False
+
+
 # Blocked pipeline commands
 PIPELINE_BLOCKED_COMMANDS = (
     "BGREWRITEAOF",
@@ -4112,20 +4126,26 @@ class PipelineStrategy(AbstractStrategy):
                         command_flag = self.command_flags.get(command)
                         if not command_flag:
                             # Fallback to default policy.
-                            # Use determine_slot (not _get_command_keys) so EVAL /
-                            # EVALSHA with numkeys=0 work on Redis <7, matching
-                            # the async ClusterPipeline path.
-                            if not self._pipe.get_default_node():
-                                slot = None
-                            else:
-                                slot = self._pipe.determine_slot(*c.args)
-                            if slot is None:
-                                command_policies = CommandPolicies()
-                            else:
+                            # EVAL/EVALSHA must not use _get_command_keys(): Redis
+                            # <7 breaks on COMMAND GETKEYS when numkeys is 0.
+                            # Other unflagged commands keep the keyless fallback.
+                            if command in ("EVAL", "EVALSHA"):
                                 command_policies = CommandPolicies(
                                     request_policy=RequestPolicy.DEFAULT_KEYED,
                                     response_policy=ResponsePolicy.DEFAULT_KEYED,
                                 )
+                            else:
+                                if not self._pipe.get_default_node():
+                                    keys = None
+                                else:
+                                    keys = self._pipe._get_command_keys(*c.args)
+                                if not keys or len(keys) == 0:
+                                    command_policies = CommandPolicies()
+                                else:
+                                    command_policies = CommandPolicies(
+                                        request_policy=RequestPolicy.DEFAULT_KEYED,
+                                        response_policy=ResponsePolicy.DEFAULT_KEYED,
+                                    )
                         else:
                             if command_flag in self._pipe._command_flags_mapping:
                                 command_policies = CommandPolicies(
@@ -4419,12 +4439,42 @@ class TransactionStrategy(AbstractStrategy):
         self._explicit_transaction = False
         self._watching = False
         self._pipeline_slots: Set[int] = set()
+        # True once a keyed (non-slot-agnostic) command has fixed the slot
+        self._transaction_has_keyed_slot = False
         self._transaction_connection: Optional[Connection] = None
         self._executing = False
         self._retry = copy(self._pipe.retry)
         self._retry.update_supported_errors(
             RedisCluster.ERRORS_ALLOW_RETRY + self.SLOT_REDIRECT_ERRORS
         )
+
+    def _resolve_transaction_slot(self, *args) -> Optional[int]:
+        """
+        Pick a slot for a transactional pipeline command.
+
+        Zero-key EVAL/EVALSHA can run on any primary. Reuse an existing
+        transaction slot when present so multiple zero-key scripts (or a
+        mix with keyed commands) stay single-slot.
+        """
+        if args[0] in ClusterPipeline.NO_SLOTS_COMMANDS:
+            return None
+
+        if is_zero_key_eval_command(*args):
+            if self._pipeline_slots:
+                return next(iter(self._pipeline_slots))
+            return self._pipe.determine_slot(*args)
+
+        slot_number = self._pipe.determine_slot(*args)
+        if (
+            slot_number is not None
+            and self._pipeline_slots
+            and slot_number not in self._pipeline_slots
+            and not self._transaction_has_keyed_slot
+        ):
+            # Prior slots came only from zero-key EVAL/EVALSHA; retarget.
+            self._pipeline_slots.clear()
+        self._transaction_has_keyed_slot = True
+        return slot_number
 
     def _get_client_and_connection_for_transaction(self) -> Tuple[Redis, Connection]:
         """
@@ -4462,7 +4512,7 @@ class TransactionStrategy(AbstractStrategy):
     def execute_command(self, *args, **kwargs):
         slot_number: Optional[int] = None
         if args[0] not in ClusterPipeline.NO_SLOTS_COMMANDS:
-            slot_number = self._pipe.determine_slot(*args)
+            slot_number = self._resolve_transaction_slot(*args)
 
         if (
             self._watching or args[0] in self.IMMEDIATE_EXECUTE_COMMANDS
@@ -4787,6 +4837,7 @@ class TransactionStrategy(AbstractStrategy):
         self._watching = False
         self._explicit_transaction = False
         self._pipeline_slots = set()
+        self._transaction_has_keyed_slot = False
         self._executing = False
 
     def send_cluster_commands(

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -4111,12 +4111,15 @@ class PipelineStrategy(AbstractStrategy):
                         # in a list of pre-defined request policies
                         command_flag = self.command_flags.get(command)
                         if not command_flag:
-                            # Fallback to default policy
+                            # Fallback to default policy.
+                            # Use determine_slot (not _get_command_keys) so EVAL /
+                            # EVALSHA with numkeys=0 work on Redis <7, matching
+                            # the async ClusterPipeline path.
                             if not self._pipe.get_default_node():
-                                keys = None
+                                slot = None
                             else:
-                                keys = self._pipe._get_command_keys(*c.args)
-                            if not keys or len(keys) == 0:
+                                slot = self._pipe.determine_slot(*c.args)
+                            if slot is None:
                                 command_policies = CommandPolicies()
                             else:
                                 command_policies = CommandPolicies(

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3641,7 +3641,6 @@ PIPELINE_BLOCKED_COMMANDS = (
     "CONFIG",
     "DBSIZE",
     "ECHO",
-    "EVALSHA",
     "FLUSHALL",
     "FLUSHDB",
     "INFO",

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -4473,7 +4473,8 @@ class TransactionStrategy(AbstractStrategy):
         ):
             # Prior slots came only from zero-key EVAL/EVALSHA; retarget.
             self._pipeline_slots.clear()
-        self._transaction_has_keyed_slot = True
+        if slot_number is not None:
+            self._transaction_has_keyed_slot = True
         return slot_number
 
     def _get_client_and_connection_for_transaction(self) -> Tuple[Redis, Connection]:

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3625,11 +3625,11 @@ def block_pipeline_command(name: str) -> Callable[..., Any]:
 
 def is_zero_key_eval_command(*args) -> bool:
     """
-    True for EVAL/EVALSHA/FCALL/FCALL_RO with numkeys=0 (any primary).
+    True for EVAL/EVALSHA with numkeys=0 (any primary).
     """
     if len(args) < 3:
         return False
-    if str(args[0]).upper() not in ("EVAL", "EVALSHA", "FCALL", "FCALL_RO"):
+    if str(args[0]).upper() not in ("EVAL", "EVALSHA"):
         return False
     try:
         return int(args[2]) == 0
@@ -4452,9 +4452,9 @@ class TransactionStrategy(AbstractStrategy):
         """
         Pick a slot for a transactional pipeline command.
 
-        Zero-key EVAL/EVALSHA/FCALL/FCALL_RO can run on any primary. Reuse
-        an existing transaction slot when present so multiple zero-key
-        scripts/functions (or a mix with keyed commands) stay single-slot.
+        Zero-key EVAL/EVALSHA can run on any primary. Reuse an existing
+        transaction slot when present so multiple zero-key scripts (or a
+        mix with keyed commands) stay single-slot.
         """
         if args[0] in ClusterPipeline.NO_SLOTS_COMMANDS:
             return None
@@ -4471,7 +4471,7 @@ class TransactionStrategy(AbstractStrategy):
             and slot_number not in self._pipeline_slots
             and not self._transaction_has_keyed_slot
         ):
-            # Prior slots came only from zero-key scripts/functions; retarget.
+            # Prior slots came only from zero-key scripts; retarget.
             self._pipeline_slots.clear()
         if slot_number is not None:
             self._transaction_has_keyed_slot = True

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3625,11 +3625,11 @@ def block_pipeline_command(name: str) -> Callable[..., Any]:
 
 def is_zero_key_eval_command(*args) -> bool:
     """
-    True for EVAL/EVALSHA with numkeys=0 (may run on any primary).
+    True for EVAL/EVALSHA/FCALL/FCALL_RO with numkeys=0 (any primary).
     """
     if len(args) < 3:
         return False
-    if str(args[0]).upper() not in ("EVAL", "EVALSHA"):
+    if str(args[0]).upper() not in ("EVAL", "EVALSHA", "FCALL", "FCALL_RO"):
         return False
     try:
         return int(args[2]) == 0
@@ -4452,9 +4452,9 @@ class TransactionStrategy(AbstractStrategy):
         """
         Pick a slot for a transactional pipeline command.
 
-        Zero-key EVAL/EVALSHA can run on any primary. Reuse an existing
-        transaction slot when present so multiple zero-key scripts (or a
-        mix with keyed commands) stay single-slot.
+        Zero-key EVAL/EVALSHA/FCALL/FCALL_RO can run on any primary. Reuse
+        an existing transaction slot when present so multiple zero-key
+        scripts/functions (or a mix with keyed commands) stay single-slot.
         """
         if args[0] in ClusterPipeline.NO_SLOTS_COMMANDS:
             return None
@@ -4471,7 +4471,7 @@ class TransactionStrategy(AbstractStrategy):
             and slot_number not in self._pipeline_slots
             and not self._transaction_has_keyed_slot
         ):
-            # Prior slots came only from zero-key EVAL/EVALSHA; retarget.
+            # Prior slots came only from zero-key scripts/functions; retarget.
             self._pipeline_slots.clear()
         if slot_number is not None:
             self._transaction_has_keyed_slot = True

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -10928,10 +10928,15 @@ class Script:
         args = tuple(keys) + tuple(args)
         # make sure the Redis server knows about the script
         from redis.client import Pipeline
+        from redis.cluster import ClusterPipeline
 
         if isinstance(client, Pipeline):
             # Make sure the pipeline can register the script before executing.
             client.scripts.add(self)
+        if isinstance(client, ClusterPipeline):
+            # ClusterPipeline does not support script_load. Queue EVALSHA and
+            # leave NOSCRIPT recovery to the caller (same as AsyncScript).
+            return client.evalsha(self.sha, len(keys), *args)
         try:
             return client.evalsha(self.sha, len(keys), *args)
         except NoScriptError:

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -10862,10 +10862,15 @@ class AsyncScript:
         args = tuple(keys) + tuple(args)
         # make sure the Redis server knows about the script
         from redis.asyncio.client import Pipeline
+        from redis.asyncio.cluster import ClusterPipeline
 
         if isinstance(client, Pipeline):
             # Make sure the pipeline can register the script before executing.
             client.scripts.add(self)
+        if isinstance(client, ClusterPipeline):
+            # ClusterPipeline.evalsha queues synchronously. Awaiting the
+            # pipeline would call initialize() and drop the queued command.
+            return client.evalsha(self.sha, len(keys), *args)
         try:
             return await client.evalsha(self.sha, len(keys), *args)
         except NoScriptError:

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3863,6 +3863,74 @@ class TestClusterPipeline:
                 "when running redis in cluster mode..."
             )
 
+    async def test_evalsha_not_blocked_on_cluster_pipeline(self) -> None:
+        """EVALSHA must be usable on async ClusterPipeline (see #2914)."""
+        assert "EVALSHA" not in PIPELINE_BLOCKED_COMMANDS
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            pipe = r.pipeline()
+            sha = "a" * 40
+            returned = pipe.evalsha(sha, 1, "foo", "bar")
+            assert returned is pipe
+            queue = pipe._execution_strategy._command_queue
+            assert len(queue) == 1
+            assert queue[0].args == ("EVALSHA", sha, 1, "foo", "bar")
+        finally:
+            await r.aclose()
+
+    async def test_evalsha_zero_keys_pipeline_execute(self) -> None:
+        """Async ClusterPipeline must execute EVALSHA with numkeys=0."""
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            mock_all_nodes_resp(r, 42)
+            sha = "a" * 40
+            async with r.pipeline() as pipe:
+                pipe.evalsha(sha, 0)
+                assert await pipe.execute() == [42]
+        finally:
+            await r.aclose()
+
+    async def test_evalsha_zero_keys_reuses_slot_in_transaction(self) -> None:
+        """Zero-key EVALSHA in a transactional async pipeline reuses one slot."""
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            sha = "a" * 40
+            async with r.pipeline(transaction=True) as pipe:
+                pipe.evalsha(sha, 0)
+                pipe.evalsha(sha, 0)
+                slots = pipe._execution_strategy._pipeline_slots
+                assert len(slots) == 1
+
+                keyed_slot = key_slot(b"foo")
+
+                async def _fake_determine_slot(*_args, **_kwargs):
+                    return keyed_slot
+
+                with mock.patch.object(
+                    pipe.cluster_client,
+                    "_determine_slot",
+                    side_effect=_fake_determine_slot,
+                ):
+                    pipe.set("foo", "bar")
+                assert pipe._execution_strategy._pipeline_slots == {keyed_slot}
+                assert pipe._execution_strategy._transaction_has_keyed_slot is True
+        finally:
+            await r.aclose()
+
+    async def test_evalsha_zero_keys_follows_keyed_slot_in_transaction(self) -> None:
+        """Zero-key EVALSHA after a keyed slot is fixed reuses that slot."""
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            sha = "a" * 40
+            async with r.pipeline(transaction=True) as pipe:
+                strategy = pipe._execution_strategy
+                strategy._pipeline_slots = {key_slot(b"foo")}
+                strategy._transaction_has_keyed_slot = True
+                pipe.evalsha(sha, 0)
+                assert strategy._pipeline_slots == {key_slot(b"foo")}
+        finally:
+            await r.aclose()
+
     async def test_empty_stack(self, r: RedisCluster) -> None:
         """If a pipeline is executed with no commands it should return a empty list."""
         p = r.pipeline()

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -43,6 +43,7 @@ from redis.exceptions import (
     AskError,
     ClusterDownError,
     ConnectionError,
+    CrossSlotTransactionError,
     DataError,
     MaxConnectionsError,
     MovedError,
@@ -3967,37 +3968,40 @@ class TestClusterPipeline:
         finally:
             await r.aclose()
 
-    async def test_zero_key_fcall_allows_keyed_retarget(self) -> None:
-        """Zero-key FCALL must not lock the slot so a later keyed command can retarget."""
+    async def test_evalsha_zero_keys_then_cross_slot_raises_at_execute(self) -> None:
+        """
+        Zero-key EVALSHA retarget must not swallow a later true cross-slot
+        conflict: two keyed commands on different slots still raise at execute().
+        """
         r = await get_mocked_redis_client(host=default_host, port=default_port)
         try:
+            sha = "a" * 40
+            slot_a = key_slot(b"{foo}a")
+            slot_b = key_slot(b"{bar}b")
+            assert slot_a != slot_b
             async with r.pipeline(transaction=True) as pipe:
-
-                async def _fcall_slot(*_args, **_kwargs):
-                    return 111
-
-                with mock.patch.object(
-                    pipe.cluster_client,
-                    "_determine_slot",
-                    side_effect=_fcall_slot,
-                ):
-                    pipe.execute_command("FCALL", "myfunc", 0)
-                assert pipe._execution_strategy._pipeline_slots == {111}
-                assert pipe._execution_strategy._transaction_has_keyed_slot is False
-
-                keyed_slot = key_slot(b"foo")
+                slots = iter([111, slot_a, slot_b])
 
                 async def _fake_determine_slot(*_args, **_kwargs):
-                    return keyed_slot
+                    return next(slots)
 
                 with mock.patch.object(
                     pipe.cluster_client,
                     "_determine_slot",
                     side_effect=_fake_determine_slot,
                 ):
-                    pipe.set("foo", "bar")
-                assert pipe._execution_strategy._pipeline_slots == {keyed_slot}
-                assert pipe._execution_strategy._transaction_has_keyed_slot is True
+                    pipe.evalsha(sha, 0)
+                    pipe.set("{foo}a", "1")
+                    pipe.set("{bar}b", "2")
+                assert pipe._execution_strategy._pipeline_slots == {slot_a, slot_b}
+                with pytest.raises(
+                    CrossSlotTransactionError,
+                    match=(
+                        "All keys involved in a cluster transaction "
+                        "must map to the same slot"
+                    ),
+                ):
+                    await pipe.execute()
         finally:
             await r.aclose()
 
@@ -4014,6 +4018,41 @@ class TestClusterPipeline:
                 assert queue[0].args[1] == script.sha
         finally:
             await r.aclose()
+
+    async def test_evalsha_in_pipeline(self, r: RedisCluster) -> None:
+        """
+        EVALSHA is allowed in ClusterPipeline when keys map to one slot
+        and the script is already loaded on cluster primaries (#2914).
+        """
+        multiply = "return redis.call('GET', KEYS[1]) * ARGV[1]"
+        sha = await r.script_load(multiply)
+        await r.set("{user}a", 2)
+        async with r.pipeline() as pipe:
+            pipe.evalsha(sha, 1, "{user}a", 3)
+            assert await pipe.execute() == [6]
+
+    async def test_evalsha_zero_keys_in_pipeline(self, r: RedisCluster) -> None:
+        """
+        EVALSHA with numkeys=0 must execute in ClusterPipeline without
+        calling COMMAND GETKEYS (broken on Redis <7 for this case).
+        """
+        sha = await r.script_load("return 42")
+        async with r.pipeline() as pipe:
+            pipe.evalsha(sha, 0)
+            assert await pipe.execute() == [42]
+
+    async def test_evalsha_zero_keys_in_transaction_pipeline(
+        self, r: RedisCluster
+    ) -> None:
+        """
+        Multiple zero-key EVALSHA calls in a transactional pipeline share
+        one slot and execute successfully.
+        """
+        sha = await r.script_load("return 42")
+        async with r.pipeline(transaction=True) as pipe:
+            pipe.evalsha(sha, 0)
+            pipe.evalsha(sha, 0)
+            assert await pipe.execute() == [42, 42]
 
     async def test_empty_stack(self, r: RedisCluster) -> None:
         """If a pipeline is executed with no commands it should return a empty list."""

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3931,6 +3931,42 @@ class TestClusterPipeline:
         finally:
             await r.aclose()
 
+    async def test_slotless_command_does_not_lock_keyed_slot_flag(self) -> None:
+        """Slotless commands must not block later keyed retargeting."""
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            sha = "a" * 40
+            async with r.pipeline(transaction=True) as pipe:
+                pipe.evalsha(sha, 0)
+                assert pipe._execution_strategy._transaction_has_keyed_slot is False
+
+                async def _no_slot(*_args, **_kwargs):
+                    return None
+
+                with mock.patch.object(
+                    pipe.cluster_client,
+                    "_determine_slot",
+                    side_effect=_no_slot,
+                ):
+                    pipe.execute_command("CLIENT TRACKING", "ON")
+                assert pipe._execution_strategy._transaction_has_keyed_slot is False
+
+                keyed_slot = key_slot(b"foo")
+
+                async def _fake_determine_slot(*_args, **_kwargs):
+                    return keyed_slot
+
+                with mock.patch.object(
+                    pipe.cluster_client,
+                    "_determine_slot",
+                    side_effect=_fake_determine_slot,
+                ):
+                    pipe.set("foo", "bar")
+                assert pipe._execution_strategy._pipeline_slots == {keyed_slot}
+                assert pipe._execution_strategy._transaction_has_keyed_slot is True
+        finally:
+            await r.aclose()
+
     async def test_empty_stack(self, r: RedisCluster) -> None:
         """If a pipeline is executed with no commands it should return a empty list."""
         p = r.pipeline()

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3967,6 +3967,54 @@ class TestClusterPipeline:
         finally:
             await r.aclose()
 
+    async def test_zero_key_fcall_allows_keyed_retarget(self) -> None:
+        """Zero-key FCALL must not lock the slot so a later keyed command can retarget."""
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            async with r.pipeline(transaction=True) as pipe:
+
+                async def _fcall_slot(*_args, **_kwargs):
+                    return 111
+
+                with mock.patch.object(
+                    pipe.cluster_client,
+                    "_determine_slot",
+                    side_effect=_fcall_slot,
+                ):
+                    pipe.execute_command("FCALL", "myfunc", 0)
+                assert pipe._execution_strategy._pipeline_slots == {111}
+                assert pipe._execution_strategy._transaction_has_keyed_slot is False
+
+                keyed_slot = key_slot(b"foo")
+
+                async def _fake_determine_slot(*_args, **_kwargs):
+                    return keyed_slot
+
+                with mock.patch.object(
+                    pipe.cluster_client,
+                    "_determine_slot",
+                    side_effect=_fake_determine_slot,
+                ):
+                    pipe.set("foo", "bar")
+                assert pipe._execution_strategy._pipeline_slots == {keyed_slot}
+                assert pipe._execution_strategy._transaction_has_keyed_slot is True
+        finally:
+            await r.aclose()
+
+    async def test_async_script_queues_evalsha_on_cluster_pipeline(self) -> None:
+        """AsyncScript must queue EVALSHA on ClusterPipeline without dropping it."""
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            script = r.register_script("return 1")
+            async with r.pipeline() as pipe:
+                await script(client=pipe)
+                queue = pipe._execution_strategy._command_queue
+                assert len(queue) == 1
+                assert queue[0].args[0] == "EVALSHA"
+                assert queue[0].args[1] == script.sha
+        finally:
+            await r.aclose()
+
     async def test_empty_stack(self, r: RedisCluster) -> None:
         """If a pipeline is executed with no commands it should return a empty list."""
         p = r.pipeline()

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -21,6 +21,7 @@ from redis.backoff import (
 )
 from redis.cluster import (
     PRIMARY,
+    PIPELINE_BLOCKED_COMMANDS,
     REDIS_CLUSTER_HASH_SLOTS,
     REPLICA,
     ClusterNode,
@@ -3835,6 +3836,35 @@ class TestClusterPubSubObject:
         mock_node_conn.disconnect.assert_called_once()
 
 
+def test_evalsha_not_in_pipeline_blocked_commands():
+    """EVALSHA must be usable in ClusterPipeline (see #2914)."""
+    assert "EVALSHA" not in PIPELINE_BLOCKED_COMMANDS
+
+
+def test_evalsha_can_be_queued_on_cluster_pipeline():
+    """
+    Queuing EVALSHA on a ClusterPipeline must not raise the historical
+    'blocked when running redis in cluster mode' error. Slot selection for
+    EVALSHA is already handled by RedisCluster.determine_slot().
+    """
+    r = get_mocked_redis_client(host=default_host, port=default_port)
+    try:
+        pipe = r.pipeline()
+        sha = "a" * 40
+        returned = pipe.evalsha(sha, 1, "foo", "bar")
+        assert returned is pipe
+
+        queue = pipe._execution_strategy.command_queue
+        assert len(queue) == 1
+        assert queue[0].args == ("EVALSHA", sha, 1, "foo", "bar")
+
+        assert r.determine_slot("EVALSHA", sha, 1, "foo", "bar") == key_slot(b"foo")
+        zero_key_slot = r.determine_slot("EVALSHA", sha, 0)
+        assert 0 <= zero_key_slot < REDIS_CLUSTER_HASH_SLOTS
+    finally:
+        r.close()
+
+
 @pytest.mark.onlycluster
 class TestClusterPipeline:
     """
@@ -3869,6 +3899,19 @@ class TestClusterPipeline:
         assert (
             str(ex.value).startswith("shard_hint is deprecated in cluster mode") is True
         )
+
+    def test_evalsha_in_pipeline(self, r):
+        """
+        EVALSHA is allowed in ClusterPipeline when keys map to one slot
+        and the script is already loaded on cluster primaries (#2914).
+        """
+        multiply = "return redis.call('GET', KEYS[1]) * ARGV[1]"
+        sha = r.script_load(multiply)
+        # hash tag keeps the key on a known slot for the pipeline
+        r.set("{user}a", 2)
+        with r.pipeline() as pipe:
+            pipe.evalsha(sha, 1, "{user}a", 3)
+            assert pipe.execute() == [6]
 
     def test_redis_cluster_pipeline(self, r):
         """

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3886,6 +3886,45 @@ def test_evalsha_zero_keys_pipeline_execute_skips_get_command_keys():
         r.close()
 
 
+def test_evalsha_zero_keys_reuses_slot_in_transaction():
+    """
+    Zero-key EVALSHA in a transactional pipeline must reuse one slot so
+    execute() does not raise CrossSlotTransactionError.
+    """
+    r = get_mocked_redis_client(host=default_host, port=default_port)
+    try:
+        sha = "a" * 40
+        with r.pipeline(transaction=True) as pipe:
+            pipe.evalsha(sha, 0)
+            pipe.evalsha(sha, 0)
+            slots = pipe._execution_strategy._pipeline_slots
+            assert len(slots) == 1
+
+            # Keyed follow-up must retarget without needing a live COMMAND map.
+            keyed_slot = key_slot(b"foo")
+            with patch.object(pipe, "determine_slot", return_value=keyed_slot):
+                pipe.set("foo", "bar")
+            assert pipe._execution_strategy._pipeline_slots == {keyed_slot}
+            assert pipe._execution_strategy._transaction_has_keyed_slot is True
+    finally:
+        r.close()
+
+
+def test_evalsha_zero_keys_follows_keyed_slot_in_transaction():
+    """Zero-key EVALSHA after a keyed slot is fixed reuses that slot."""
+    r = get_mocked_redis_client(host=default_host, port=default_port)
+    try:
+        sha = "a" * 40
+        with r.pipeline(transaction=True) as pipe:
+            strategy = pipe._execution_strategy
+            strategy._pipeline_slots = {key_slot(b"foo")}
+            strategy._transaction_has_keyed_slot = True
+            pipe.evalsha(sha, 0)
+            assert strategy._pipeline_slots == {key_slot(b"foo")}
+    finally:
+        r.close()
+
+
 @pytest.mark.onlycluster
 class TestClusterPipeline:
     """
@@ -3943,6 +3982,17 @@ class TestClusterPipeline:
         with r.pipeline() as pipe:
             pipe.evalsha(sha, 0)
             assert pipe.execute() == [42]
+
+    def test_evalsha_zero_keys_in_transaction_pipeline(self, r):
+        """
+        Multiple zero-key EVALSHA calls in a transactional pipeline share
+        one slot and execute successfully.
+        """
+        sha = r.script_load("return 42")
+        with r.pipeline(transaction=True) as pipe:
+            pipe.evalsha(sha, 0)
+            pipe.evalsha(sha, 0)
+            assert pipe.execute() == [42, 42]
 
     def test_redis_cluster_pipeline(self, r):
         """

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3859,8 +3859,29 @@ def test_evalsha_can_be_queued_on_cluster_pipeline():
         assert queue[0].args == ("EVALSHA", sha, 1, "foo", "bar")
 
         assert r.determine_slot("EVALSHA", sha, 1, "foo", "bar") == key_slot(b"foo")
-        zero_key_slot = r.determine_slot("EVALSHA", sha, 0)
-        assert 0 <= zero_key_slot < REDIS_CLUSTER_HASH_SLOTS
+    finally:
+        r.close()
+
+
+def test_evalsha_zero_keys_pipeline_execute_skips_get_command_keys():
+    """
+    Sync ClusterPipeline must route EVALSHA via determine_slot, not
+    COMMAND GETKEYS. Redis <7 fails on GETKEYS for EVALSHA with numkeys=0.
+    """
+    r = get_mocked_redis_client(host=default_host, port=default_port)
+    try:
+        mock_all_nodes_resp(r, 42)
+        sha = "a" * 40
+        with r.pipeline() as pipe:
+            pipe.evalsha(sha, 0)
+            with patch.object(
+                pipe,
+                "_get_command_keys",
+                side_effect=AssertionError(
+                    "COMMAND GETKEYS must not be used for EVALSHA"
+                ),
+            ):
+                assert pipe.execute() == [42]
     finally:
         r.close()
 
@@ -3912,6 +3933,16 @@ class TestClusterPipeline:
         with r.pipeline() as pipe:
             pipe.evalsha(sha, 1, "{user}a", 3)
             assert pipe.execute() == [6]
+
+    def test_evalsha_zero_keys_in_pipeline(self, r):
+        """
+        EVALSHA with numkeys=0 must execute in ClusterPipeline without
+        calling COMMAND GETKEYS (broken on Redis <7 for this case).
+        """
+        sha = r.script_load("return 42")
+        with r.pipeline() as pipe:
+            pipe.evalsha(sha, 0)
+            assert pipe.execute() == [42]
 
     def test_redis_cluster_pipeline(self, r):
         """

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -42,6 +42,7 @@ from redis.exceptions import (
     AskError,
     ClusterDownError,
     ConnectionError,
+    CrossSlotTransactionError,
     DataError,
     MovedError,
     NoPermissionError,
@@ -3836,11 +3837,13 @@ class TestClusterPubSubObject:
         mock_node_conn.disconnect.assert_called_once()
 
 
+@pytest.mark.onlycluster
 def test_evalsha_not_in_pipeline_blocked_commands():
     """EVALSHA must be usable in ClusterPipeline (see #2914)."""
     assert "EVALSHA" not in PIPELINE_BLOCKED_COMMANDS
 
 
+@pytest.mark.onlycluster
 def test_evalsha_can_be_queued_on_cluster_pipeline():
     """
     Queuing EVALSHA on a ClusterPipeline must not raise the historical
@@ -3863,6 +3866,7 @@ def test_evalsha_can_be_queued_on_cluster_pipeline():
         r.close()
 
 
+@pytest.mark.onlycluster
 def test_evalsha_zero_keys_pipeline_execute_skips_get_command_keys():
     """
     Sync ClusterPipeline must route EVALSHA via determine_slot, not
@@ -3886,6 +3890,7 @@ def test_evalsha_zero_keys_pipeline_execute_skips_get_command_keys():
         r.close()
 
 
+@pytest.mark.onlycluster
 def test_evalsha_zero_keys_reuses_slot_in_transaction():
     """
     Zero-key EVALSHA in a transactional pipeline must reuse one slot so
@@ -3910,6 +3915,7 @@ def test_evalsha_zero_keys_reuses_slot_in_transaction():
         r.close()
 
 
+@pytest.mark.onlycluster
 def test_evalsha_zero_keys_follows_keyed_slot_in_transaction():
     """Zero-key EVALSHA after a keyed slot is fixed reuses that slot."""
     r = get_mocked_redis_client(host=default_host, port=default_port)
@@ -3925,6 +3931,7 @@ def test_evalsha_zero_keys_follows_keyed_slot_in_transaction():
         r.close()
 
 
+@pytest.mark.onlycluster
 def test_slotless_command_does_not_lock_keyed_slot_flag():
     """Slotless commands must not block later keyed retargeting."""
     r = get_mocked_redis_client(host=default_host, port=default_port)
@@ -3947,21 +3954,34 @@ def test_slotless_command_does_not_lock_keyed_slot_flag():
         r.close()
 
 
-def test_zero_key_fcall_allows_keyed_retarget():
-    """Zero-key FCALL must not lock the slot so a later keyed command can retarget."""
+@pytest.mark.onlycluster
+def test_evalsha_zero_keys_then_cross_slot_raises_at_execute():
+    """
+    Zero-key EVALSHA retarget must not swallow a later true cross-slot
+    conflict: two keyed commands on different slots still raise at execute().
+    """
     r = get_mocked_redis_client(host=default_host, port=default_port)
     try:
+        sha = "a" * 40
+        slot_a = key_slot(b"{foo}a")
+        slot_b = key_slot(b"{bar}b")
+        assert slot_a != slot_b
         with r.pipeline(transaction=True) as pipe:
-            with patch.object(pipe, "determine_slot", return_value=111):
-                pipe.execute_command("FCALL", "myfunc", 0)
-            assert pipe._execution_strategy._pipeline_slots == {111}
-            assert pipe._execution_strategy._transaction_has_keyed_slot is False
-
-            keyed_slot = key_slot(b"foo")
-            with patch.object(pipe, "determine_slot", return_value=keyed_slot):
-                pipe.set("foo", "bar")
-            assert pipe._execution_strategy._pipeline_slots == {keyed_slot}
-            assert pipe._execution_strategy._transaction_has_keyed_slot is True
+            with patch.object(
+                pipe, "determine_slot", side_effect=[111, slot_a, slot_b]
+            ):
+                pipe.evalsha(sha, 0)
+                pipe.set("{foo}a", "1")
+                pipe.set("{bar}b", "2")
+            assert pipe._execution_strategy._pipeline_slots == {slot_a, slot_b}
+            with pytest.raises(
+                CrossSlotTransactionError,
+                match=(
+                    "All keys involved in a cluster transaction "
+                    "must map to the same slot"
+                ),
+            ):
+                pipe.execute()
     finally:
         r.close()
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3947,6 +3947,25 @@ def test_slotless_command_does_not_lock_keyed_slot_flag():
         r.close()
 
 
+def test_zero_key_fcall_allows_keyed_retarget():
+    """Zero-key FCALL must not lock the slot so a later keyed command can retarget."""
+    r = get_mocked_redis_client(host=default_host, port=default_port)
+    try:
+        with r.pipeline(transaction=True) as pipe:
+            with patch.object(pipe, "determine_slot", return_value=111):
+                pipe.execute_command("FCALL", "myfunc", 0)
+            assert pipe._execution_strategy._pipeline_slots == {111}
+            assert pipe._execution_strategy._transaction_has_keyed_slot is False
+
+            keyed_slot = key_slot(b"foo")
+            with patch.object(pipe, "determine_slot", return_value=keyed_slot):
+                pipe.set("foo", "bar")
+            assert pipe._execution_strategy._pipeline_slots == {keyed_slot}
+            assert pipe._execution_strategy._transaction_has_keyed_slot is True
+    finally:
+        r.close()
+
+
 @pytest.mark.onlycluster
 class TestClusterPipeline:
     """

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3925,6 +3925,28 @@ def test_evalsha_zero_keys_follows_keyed_slot_in_transaction():
         r.close()
 
 
+def test_slotless_command_does_not_lock_keyed_slot_flag():
+    """Slotless commands must not block later keyed retargeting."""
+    r = get_mocked_redis_client(host=default_host, port=default_port)
+    try:
+        sha = "a" * 40
+        with r.pipeline(transaction=True) as pipe:
+            pipe.evalsha(sha, 0)
+            assert pipe._execution_strategy._transaction_has_keyed_slot is False
+
+            with patch.object(pipe, "determine_slot", return_value=None):
+                pipe.execute_command("CLIENT TRACKING", "ON")
+            assert pipe._execution_strategy._transaction_has_keyed_slot is False
+
+            keyed_slot = key_slot(b"foo")
+            with patch.object(pipe, "determine_slot", return_value=keyed_slot):
+                pipe.set("foo", "bar")
+            assert pipe._execution_strategy._pipeline_slots == {keyed_slot}
+            assert pipe._execution_strategy._transaction_has_keyed_slot is True
+    finally:
+        r.close()
+
+
 @pytest.mark.onlycluster
 class TestClusterPipeline:
     """

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3918,6 +3918,22 @@ def test_evalsha_can_be_queued_on_cluster_pipeline():
 
 
 @pytest.mark.onlycluster
+def test_script_queues_evalsha_on_cluster_pipeline():
+    """Script must queue EVALSHA on ClusterPipeline without calling script_load."""
+    r = get_mocked_redis_client(host=default_host, port=default_port)
+    try:
+        script = r.register_script("return 1")
+        with r.pipeline() as pipe:
+            script(client=pipe)
+            queue = pipe._execution_strategy.command_queue
+            assert len(queue) == 1
+            assert queue[0].args[0] == "EVALSHA"
+            assert queue[0].args[1] == script.sha
+    finally:
+        r.close()
+
+
+@pytest.mark.onlycluster
 def test_evalsha_zero_keys_pipeline_execute_skips_get_command_keys():
     """
     Sync ClusterPipeline must route EVALSHA via determine_slot, not


### PR DESCRIPTION
### Description of change

Fixes #2914

`EVALSHA` was listed in `PIPELINE_BLOCKED_COMMANDS`, so `ClusterPipeline.evalsha()` always raised even though `RedisCluster.determine_slot()` already routes `EVAL`/`EVALSHA` by keys (including the 0-key random-slot case).

This removes `EVALSHA` from the blocked list so cluster pipelines can queue `EVALSHA` like other keyed commands. Callers must still:
- load the script on the target node(s) first (e.g. cluster `SCRIPT LOAD`, which loads on all primaries)
- keep all script keys on the same hash slot

Also updates `docs/lua_scripting.rst` and adds regression coverage:
- mock tests that `EVALSHA` is no longer blocked and can be queued on `ClusterPipeline`
- a cluster integration test (`test_evalsha_in_pipeline`) for CI with a live cluster

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster pipeline command routing and transactional slot selection for Lua scripts; incorrect caller retry after NOSCRIPT could duplicate side effects, though behavior is documented and heavily tested.
> 
> **Overview**
> **Enables `EVALSHA` on sync and async `ClusterPipeline`** by removing it from `PIPELINE_BLOCKED_COMMANDS`, so pipelined scripts can be queued and routed like other keyed commands (same-slot keys, or `numkeys=0` to a random primary).
> 
> **Routing fixes:** Unflagged `EVAL`/`EVALSHA` in cluster pipelines no longer fall through to `COMMAND GETKEYS` (which breaks on Redis &lt;7 when `numkeys=0`); they use keyed default routing instead. **Transactional pipelines** get `_resolve_transaction_slot` so zero-key `EVALSHA` reuses an existing transaction slot (or retargets when the first real keyed command arrives), keeping multi-script / mixed pipelines single-slot without hiding true cross-slot errors.
> 
> **`Script` / `AsyncScript`:** When the client is a `ClusterPipeline`, calls queue `evalsha` directly—no automatic `SCRIPT LOAD` / `NOSCRIPT` retry (callers must reload and retry safely, as documented).
> 
> **Docs** (`lua_scripting.rst`) now describe cluster-pipeline `EVALSHA` behavior, per-node script cache, and `NOSCRIPT` recovery caveats; regression tests cover mocking and live cluster cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6c167c892a4b28a18503845f17b303acfba3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->