### PR TITLE
Add opt-in latency-aware cluster read balancing

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -123,3 +123,20 @@ Stop the example stack when finished:
 ```shell
 docker compose -f docs/examples/opentelemetry/docker-compose.yml down
 ```
+
+## Cluster Latency-Aware Read Balancing
+
+`cluster_latency_load_balancing.py` compares round-robin reads with
+`LoadBalancingStrategy.LATENCY_BASED` on one fixed key slot. It adds a
+configurable delay to one replica's async client command path, then reports
+that replica's selection share and the measured p99 latency:
+
+```shell
+python -m benchmarks.cluster_latency_load_balancing \
+  --host 127.0.0.1 --port 7000 --delay-ms 10 \
+  --requests 2000 --concurrency 32
+```
+
+The cluster must expose at least one replica for the selected key slot and
+must permit read-only connections. Pass `--delayed-node HOST:PORT` to choose a
+specific replica; otherwise the last replica in the slot's topology is used.

--- a/benchmarks/cluster_latency_load_balancing.py
+++ b/benchmarks/cluster_latency_load_balancing.py
@@ -1,0 +1,138 @@
+"""Compare round-robin and latency-aware reads on a Redis cluster.
+
+The benchmark injects delay into one replica's client-side command path. This
+keeps the setup small and repeatable while exercising the same async
+``RedisCluster`` selection and measurement paths used in production.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import math
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+
+from redis.asyncio.cluster import ClusterNode, RedisCluster
+from redis.cluster import LoadBalancingStrategy
+
+
+@dataclass
+class Measurements:
+    counts: Counter[str] = field(default_factory=Counter)
+    latencies: list[float] = field(default_factory=list)
+
+    @property
+    def p99_ms(self) -> float:
+        if not self.latencies:
+            return 0.0
+        ordered = sorted(self.latencies)
+        index = min(len(ordered) - 1, math.ceil(len(ordered) * 0.99) - 1)
+        return ordered[index] * 1000
+
+
+async def run_mode(
+    host: str,
+    port: int,
+    key: str,
+    requests: int,
+    concurrency: int,
+    delay_ms: float,
+    strategy: LoadBalancingStrategy,
+    delayed_node_name: str | None,
+) -> tuple[str, Measurements, str]:
+    client = await RedisCluster(
+        host=host,
+        port=port,
+        load_balancing_strategy=strategy,
+    )
+    slot_nodes = client.nodes_manager.slots_cache[client.keyslot(key)]
+    replicas = slot_nodes[1:]
+    if not replicas:
+        await client.aclose()
+        raise RuntimeError("the selected key slot must have at least one replica")
+
+    delayed_node = next(
+        (node for node in replicas if node.name == delayed_node_name),
+        replicas[-1] if delayed_node_name is None else None,
+    )
+    if delayed_node is None:
+        await client.aclose()
+        raise ValueError(
+            f"node {delayed_node_name!r} is not a replica for key slot "
+            f"{client.keyslot(key)}"
+        )
+
+    measurements = Measurements()
+    original_execute_command = ClusterNode.execute_command
+
+    async def delayed_execute_command(node, *args, **kwargs):
+        started = time.perf_counter()
+        if args and args[0] == "GET":
+            measurements.counts[node.name] += 1
+            if node.name == delayed_node.name:
+                await asyncio.sleep(delay_ms / 1000)
+        try:
+            return await original_execute_command(node, *args, **kwargs)
+        finally:
+            if args and args[0] == "GET":
+                measurements.latencies.append(time.perf_counter() - started)
+
+    ClusterNode.execute_command = delayed_execute_command
+    try:
+        requests_per_worker, remainder = divmod(requests, concurrency)
+
+        async def worker(worker_index: int) -> None:
+            worker_requests = requests_per_worker + (worker_index < remainder)
+            for _ in range(worker_requests):
+                await client.get(key)
+
+        await asyncio.gather(*(worker(i) for i in range(concurrency)))
+    finally:
+        ClusterNode.execute_command = original_execute_command
+        await client.aclose()
+
+    return strategy.value, measurements, delayed_node.name
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=6379)
+    parser.add_argument("--key", default="{latency-benchmark}:key")
+    parser.add_argument("--requests", type=int, default=2000)
+    parser.add_argument("--concurrency", type=int, default=32)
+    parser.add_argument("--delay-ms", type=float, default=10.0)
+    parser.add_argument("--delayed-node")
+    return parser.parse_args()
+
+
+async def main(args: argparse.Namespace) -> None:
+    if args.requests < args.concurrency:
+        raise ValueError("--requests must be at least --concurrency")
+
+    for strategy in (
+        LoadBalancingStrategy.ROUND_ROBIN,
+        LoadBalancingStrategy.LATENCY_BASED,
+    ):
+        name, measurements, delayed_node = await run_mode(
+            host=args.host,
+            port=args.port,
+            key=args.key,
+            requests=args.requests,
+            concurrency=args.concurrency,
+            delay_ms=args.delay_ms,
+            strategy=strategy,
+            delayed_node_name=args.delayed_node,
+        )
+        total = sum(measurements.counts.values())
+        delayed_share = measurements.counts[delayed_node] / total * 100
+        print(
+            f"strategy={name:<14} delayed_node={delayed_node:<24} "
+            f"delayed_share={delayed_share:6.2f}% p99={measurements.p99_ms:8.3f}ms"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main(parse_args()))

--- a/docs/clustering.rst
+++ b/docs/clustering.rst
@@ -223,6 +223,20 @@ the primary and its replications in a Round-Robin manner.
 With load_balancing_strategy you can define a custom strategy for
 assigning read commands to the replicas and primary nodes.
 
+``LoadBalancingStrategy.LATENCY_BASED`` uses power-of-two choices and a
+peak-sensitive latency estimate to prefer the less busy of two sampled
+nodes.  The strategy is opt-in; existing round-robin and random strategies
+are unchanged.  Latency measurements are collected separately for each
+cluster node and are shared by regular commands and pipelines.
+
+.. code:: python
+
+   >>> from redis.cluster import LoadBalancingStrategy, RedisCluster
+   >>> rc = RedisCluster(
+   ...     startup_nodes=startup_nodes,
+   ...     load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+   ... )
+
 READONLY mode can be set at runtime by calling the readonly() method
 with target_nodes=‘replicas’, and read-write access can be restored by
 calling the readwrite() method.

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1205,6 +1205,8 @@ class RedisCluster(
 
         while ttl > 0:
             ttl -= 1
+            tracked_node_name = None
+            attempt_start_time = None
             try:
                 if asking:
                     target_node = self.get_node(node_name=redirect_addr)
@@ -1223,6 +1225,15 @@ class RedisCluster(
                     )
                     moved = False
 
+                if (
+                    self.load_balancing_strategy == LoadBalancingStrategy.LATENCY_BASED
+                    and command in READ_COMMANDS
+                ):
+                    tracked_node_name = target_node.name
+                    attempt_start_time = time.monotonic()
+                    self.nodes_manager.read_load_balancer.start_request(
+                        tracked_node_name
+                    )
                 response = await target_node.execute_command(*args, **kwargs)
                 await self._record_command_metric(
                     command_name=command,
@@ -1370,6 +1381,11 @@ class RedisCluster(
                     error=e,
                 )
                 raise
+            finally:
+                if tracked_node_name is not None and attempt_start_time is not None:
+                    self.nodes_manager.read_load_balancer.record_latency(
+                        tracked_node_name, time.monotonic() - attempt_start_time
+                    )
 
         e = ClusterError("TTL exhausted.")
         e.connection = target_node
@@ -2066,7 +2082,10 @@ class NodesManager:
                 # get the server index using the strategy defined in load_balancing_strategy
                 primary_name = self.slots_cache[slot][0].name
                 node_idx = self.read_load_balancer.get_server_index(
-                    primary_name, len(self.slots_cache[slot]), load_balancing_strategy
+                    primary_name,
+                    len(self.slots_cache[slot]),
+                    load_balancing_strategy,
+                    nodes=self.slots_cache[slot],
                 )
                 return self.slots_cache[slot][node_idx]
             return self.slots_cache[slot][0]
@@ -2793,10 +2812,27 @@ class PipelineStrategy(AbstractStrategy):
         # Start timing for observability
         start_time = time.monotonic()
 
+        async def execute_node_pipeline(node, commands):
+            track_latency = (
+                client.load_balancing_strategy == LoadBalancingStrategy.LATENCY_BASED
+                and any(command.args[0] in READ_COMMANDS for command in commands)
+            )
+            if not track_latency:
+                return await node.execute_pipeline(commands)
+
+            client.nodes_manager.read_load_balancer.start_request(node.name)
+            start_time = time.monotonic()
+            try:
+                return await node.execute_pipeline(commands)
+            finally:
+                client.nodes_manager.read_load_balancer.record_latency(
+                    node.name, time.monotonic() - start_time
+                )
+
         errors = await asyncio.gather(
             *(
-                asyncio.create_task(node[0].execute_pipeline(node[1]))
-                for node in nodes.values()
+                asyncio.create_task(execute_node_pipeline(node, commands))
+                for node, commands in nodes.values()
             )
         )
 

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from copy import copy
+from dataclasses import dataclass
 from enum import Enum
 from itertools import chain
 from types import MethodType
@@ -20,6 +21,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -1644,6 +1646,8 @@ class RedisCluster(
 
         while ttl > 0:
             ttl -= 1
+            tracked_node_name = None
+            attempt_start_time = None
             try:
                 if asking:
                     target_node = self.get_node(node_name=redirect_addr)
@@ -1662,6 +1666,15 @@ class RedisCluster(
 
                 redis_node = self.get_redis_connection(target_node)
                 connection = get_connection(redis_node)
+                if (
+                    self.load_balancing_strategy == LoadBalancingStrategy.LATENCY_BASED
+                    and command in READ_COMMANDS
+                ):
+                    tracked_node_name = target_node.name
+                    attempt_start_time = time.monotonic()
+                    self.nodes_manager.read_load_balancer.start_request(
+                        tracked_node_name
+                    )
                 if asking:
                     connection.send_command("ASKING")
                     redis_node.parse_response(connection, "ASKING", **kwargs)
@@ -1883,6 +1896,10 @@ class RedisCluster(
                 )
                 raise e
             finally:
+                if tracked_node_name is not None and attempt_start_time is not None:
+                    self.nodes_manager.read_load_balancer.record_latency(
+                        tracked_node_name, time.monotonic() - attempt_start_time
+                    )
                 if connection is not None:
                     redis_node.connection_pool.release(connection)
 
@@ -2051,25 +2068,44 @@ class LoadBalancingStrategy(Enum):
     ROUND_ROBIN_REPLICAS = "round_robin_replicas"
     RANDOM = "random"
     RANDOM_REPLICA = "random_replica"
+    LATENCY_BASED = "latency_based"
+
+
+_LATENCY_EWMA_ALPHA = 0.2
+_LATENCY_PEAK_DECAY = 0.9
+
+
+@dataclass
+class _NodeLatencyState:
+    in_flight: int = 0
+    ewma: float | None = None
+    peak_ewma: float | None = None
 
 
 class LoadBalancer:
     """
-    Round-Robin Load Balancing
+    Select nodes according to a configured load-balancing strategy.
     """
 
     def __init__(self, start_index: int = 0) -> None:
         self.primary_to_idx: dict[str, int] = {}
         self.start_index: int = start_index
         self._lock: threading.Lock = threading.Lock()
+        self._latency_state: dict[str, _NodeLatencyState] = {}
 
     def get_server_index(
         self,
         primary: str,
         list_size: int,
         load_balancing_strategy: LoadBalancingStrategy = LoadBalancingStrategy.ROUND_ROBIN,
+        nodes: Optional[Sequence["ClusterNode"]] = None,
     ) -> int:
-        if load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA:
+        if load_balancing_strategy == LoadBalancingStrategy.LATENCY_BASED:
+            if nodes is None or len(nodes) != list_size:
+                raise ValueError("nodes are required for latency-based load balancing")
+            with self._lock:
+                return self._get_latency_based_index(nodes)
+        elif load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA:
             return self._get_random_server_index(
                 list_size,
                 replicas_only=True,
@@ -2086,9 +2122,57 @@ class LoadBalancer:
                 load_balancing_strategy == LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
             )
 
+    def start_request(self, node_name: str) -> None:
+        """Mark a node as handling one more request."""
+        with self._lock:
+            state = self._latency_state.setdefault(node_name, _NodeLatencyState())
+            state.in_flight += 1
+
+    def record_latency(self, node_name: str, duration_seconds: float) -> None:
+        """Record a completed request and update its latency estimate."""
+        duration_seconds = max(0.0, float(duration_seconds))
+        with self._lock:
+            state = self._latency_state.setdefault(node_name, _NodeLatencyState())
+            state.in_flight = max(0, state.in_flight - 1)
+
+            if state.ewma is None:
+                state.ewma = duration_seconds
+            else:
+                state.ewma = (
+                    _LATENCY_EWMA_ALPHA * duration_seconds
+                    + (1 - _LATENCY_EWMA_ALPHA) * state.ewma
+                )
+
+            previous_peak = (
+                duration_seconds if state.peak_ewma is None else state.peak_ewma
+            )
+            state.peak_ewma = max(
+                duration_seconds,
+                state.ewma,
+                _LATENCY_PEAK_DECAY * previous_peak,
+            )
+
     def reset(self) -> None:
         with self._lock:
             self.primary_to_idx.clear()
+            self._latency_state.clear()
+
+    def _get_latency_based_index(self, nodes: Sequence["ClusterNode"]) -> int:
+        if len(nodes) <= 2:
+            candidate_indices = range(len(nodes))
+        else:
+            candidate_indices = random.sample(range(len(nodes)), 2)
+
+        return min(
+            candidate_indices,
+            key=lambda index: self._latency_score(nodes[index].name),
+        )
+
+    def _latency_score(self, node_name: str) -> float:
+        state = self._latency_state.get(node_name)
+        if state is None or state.peak_ewma is None:
+            return 0.0
+        return state.peak_ewma * (state.in_flight + 1)
 
     def _get_random_server_index(self, list_size: int, replicas_only: bool) -> int:
         return random.randint(1 if replicas_only else 0, list_size - 1)
@@ -2282,7 +2366,10 @@ class NodesManager:
                 # get the server index using the strategy defined in load_balancing_strategy
                 primary_name = self.slots_cache[slot][0].name
                 node_idx = self.read_load_balancer.get_server_index(
-                    primary_name, len(self.slots_cache[slot]), load_balancing_strategy
+                    primary_name,
+                    len(self.slots_cache[slot]),
+                    load_balancing_strategy,
+                    nodes=self.slots_cache[slot],
                 )
             elif (
                 server_type is None
@@ -3721,12 +3808,17 @@ class NodeCommands:
     """ """
 
     def __init__(
-        self, parse_response, connection_pool: ConnectionPool, connection: Connection
+        self,
+        parse_response,
+        connection_pool: ConnectionPool,
+        connection: Connection,
+        node_name: Optional[str] = None,
     ):
         """ """
         self.parse_response = parse_response
         self.connection_pool = connection_pool
         self.connection = connection
+        self.node_name = node_name
         self.commands = []
 
     def append(self, c):
@@ -4079,6 +4171,7 @@ class PipelineStrategy(AbstractStrategy):
         nodes: dict[str, NodeCommands] = {}
         nodes_written = 0
         nodes_read = 0
+        latency_start_times: dict[str, float] = {}
 
         try:
             # as we move through each command that still needs to be processed,
@@ -4176,6 +4269,7 @@ class PipelineStrategy(AbstractStrategy):
                         redis_node.parse_response,
                         redis_node.connection_pool,
                         connection,
+                        node_name=node_name,
                     )
                 nodes[node_name].append(c)
 
@@ -4191,7 +4285,19 @@ class PipelineStrategy(AbstractStrategy):
             # Start timing for observability
             start_time = time.monotonic()
 
-            node_commands = nodes.values()
+            node_commands = list(nodes.values())
+            latency_balancing = (
+                self._pipe.load_balancing_strategy
+                == LoadBalancingStrategy.LATENCY_BASED
+            )
+            if latency_balancing:
+                for n in node_commands:
+                    if any(c.args[0] in READ_COMMANDS for c in n.commands):
+                        self._nodes_manager.read_load_balancer.start_request(
+                            n.node_name
+                        )
+                        latency_start_times[n.node_name] = time.monotonic()
+
             for n in node_commands:
                 nodes_written += 1
                 n.write()
@@ -4216,6 +4322,10 @@ class PipelineStrategy(AbstractStrategy):
                 )
                 nodes_read += 1
         finally:
+            for node_name, start_time in latency_start_times.items():
+                self._nodes_manager.read_load_balancer.record_latency(
+                    node_name, time.monotonic() - start_time
+                )
             # release all the redis connections we allocated earlier
             # back into the connection pool.
             # if the connection is dirty (that is: we've written

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -14,6 +14,7 @@ from _pytest.fixtures import FixtureRequest
 from redis._parsers import AsyncCommandsParser
 from redis.asyncio.cluster import (
     ClusterNode,
+    LoadBalancer,
     NodesManager,
     PipelineCommand,
     RedisCluster,
@@ -75,6 +76,71 @@ default_cluster_slots = [
     [0, 8191, ["127.0.0.1", 7000, "node_0"], ["127.0.0.1", 7003, "node_3"]],
     [8192, 16383, ["127.0.0.1", 7001, "node_1"], ["127.0.0.1", 7002, "node_2"]],
 ]
+
+
+def test_nodes_manager_provides_nodes_to_latency_based_selection():
+    nodes = [
+        ClusterNode("node-a", 7000),
+        ClusterNode("node-b", 7001),
+    ]
+    manager = object.__new__(NodesManager)
+    manager.slots_cache = {0: nodes}
+    manager.read_load_balancer = LoadBalancer()
+
+    manager.read_load_balancer.start_request(nodes[0].name)
+    manager.read_load_balancer.record_latency(nodes[0].name, 0.1)
+    manager.read_load_balancer.start_request(nodes[1].name)
+    manager.read_load_balancer.record_latency(nodes[1].name, 0.01)
+
+    with mock.patch("redis.cluster.random.sample", return_value=[0, 1]):
+        assert (
+            manager.get_node_from_slot(
+                0,
+                read_from_replicas=True,
+                load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+            )
+            is nodes[1]
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_cluster_command_records_latency_when_read_fails():
+    node = ClusterNode("node-a", 7000)
+    execute_command = mock.AsyncMock(side_effect=ValueError("response failure"))
+    load_balancer = mock.Mock()
+    client = object.__new__(RedisCluster)
+    client.RedisClusterRequestTTL = 1
+    client.load_balancing_strategy = LoadBalancingStrategy.LATENCY_BASED
+    client.nodes_manager = mock.Mock(read_load_balancer=load_balancer)
+    client._record_command_metric = mock.AsyncMock()
+
+    with mock.patch.object(ClusterNode, "execute_command", execute_command):
+        with pytest.raises(ValueError, match="response failure"):
+            await client._execute_command(node, "GET", "key")
+
+    load_balancer.start_request.assert_called_once_with(node.name)
+    load_balancer.record_latency.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_cluster_pipeline_records_one_latency_sample_per_read_node():
+    client = await get_mocked_redis_client(
+        host=default_host,
+        port=default_port,
+        load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+    )
+
+    async def execute_pipeline(node, commands):
+        for command in commands:
+            command.result = b"value"
+        return False
+
+    pipeline = client.pipeline()
+    pipeline.get("foo")
+    with mock.patch.object(ClusterNode, "execute_pipeline", execute_pipeline):
+        assert await pipeline.execute() == [b"value"]
+
+    assert len(client.nodes_manager.read_load_balancer._latency_state) == 1
 
 
 class NodeProxy:

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -4,6 +4,7 @@ import select
 import socket
 import socketserver
 import threading
+from types import SimpleNamespace
 from typing import List
 import warnings
 from queue import LifoQueue, Queue
@@ -24,7 +25,9 @@ from redis.cluster import (
     REDIS_CLUSTER_HASH_SLOTS,
     REPLICA,
     ClusterNode,
+    LoadBalancer,
     LoadBalancingStrategy,
+    NodeCommands,
     NodesManager,
     RedisCluster,
     get_node_name,
@@ -73,6 +76,203 @@ default_cluster_slots = [
     [0, 8191, ["127.0.0.1", 7000, "node_0"], ["127.0.0.1", 7003, "node_3"]],
     [8192, 16383, ["127.0.0.1", 7001, "node_1"], ["127.0.0.1", 7002, "node_2"]],
 ]
+
+
+def test_latency_based_load_balancer_prefers_lower_score():
+    nodes = [
+        ClusterNode("node-a", 7000),
+        ClusterNode("node-b", 7001),
+    ]
+    load_balancer = LoadBalancer()
+
+    load_balancer.start_request(nodes[0].name)
+    load_balancer.record_latency(nodes[0].name, 0.1)
+    load_balancer.start_request(nodes[1].name)
+    load_balancer.record_latency(nodes[1].name, 0.01)
+
+    with patch("redis.cluster.random.sample", return_value=[0, 1]):
+        assert (
+            load_balancer.get_server_index(
+                "primary",
+                len(nodes),
+                LoadBalancingStrategy.LATENCY_BASED,
+                nodes,
+            )
+            == 1
+        )
+
+
+def test_latency_based_load_balancer_accounts_for_in_flight_requests():
+    nodes = [
+        ClusterNode("node-a", 7000),
+        ClusterNode("node-b", 7001),
+    ]
+    load_balancer = LoadBalancer()
+
+    for node in nodes:
+        load_balancer.start_request(node.name)
+        load_balancer.record_latency(node.name, 0.01)
+
+    load_balancer.start_request(nodes[0].name)
+    load_balancer.start_request(nodes[0].name)
+
+    with patch("redis.cluster.random.sample", return_value=[0, 1]):
+        assert (
+            load_balancer.get_server_index(
+                "primary",
+                len(nodes),
+                LoadBalancingStrategy.LATENCY_BASED,
+                nodes,
+            )
+            == 1
+        )
+
+    load_balancer.record_latency(nodes[0].name, 0.01)
+    load_balancer.record_latency(nodes[0].name, 0.01)
+
+
+def test_latency_based_load_balancer_penalizes_peak_latency():
+    nodes = [
+        ClusterNode("node-a", 7000),
+        ClusterNode("node-b", 7001),
+    ]
+    load_balancer = LoadBalancer()
+
+    for node in nodes:
+        load_balancer.start_request(node.name)
+        load_balancer.record_latency(node.name, 0.01)
+    load_balancer.start_request(nodes[1].name)
+    load_balancer.record_latency(nodes[1].name, 1.0)
+
+    with patch("redis.cluster.random.sample", return_value=[0, 1]):
+        assert (
+            load_balancer.get_server_index(
+                "primary",
+                len(nodes),
+                LoadBalancingStrategy.LATENCY_BASED,
+                nodes,
+            )
+            == 0
+        )
+
+
+def test_latency_based_load_balancer_decays_peak_latency():
+    node = ClusterNode("node-a", 7000)
+    load_balancer = LoadBalancer()
+
+    load_balancer.start_request(node.name)
+    load_balancer.record_latency(node.name, 1.0)
+    initial_peak = load_balancer._latency_state[node.name].peak_ewma
+
+    for _ in range(4):
+        load_balancer.start_request(node.name)
+        load_balancer.record_latency(node.name, 0.01)
+
+    assert load_balancer._latency_state[node.name].peak_ewma < initial_peak
+
+
+def test_nodes_manager_provides_nodes_to_latency_based_selection():
+    nodes = [
+        ClusterNode("node-a", 7000),
+        ClusterNode("node-b", 7001),
+    ]
+    manager = object.__new__(NodesManager)
+    manager._lock = threading.RLock()
+    manager._require_full_coverage = True
+    manager.slots_cache = {0: nodes}
+    manager.read_load_balancer = LoadBalancer()
+
+    manager.read_load_balancer.start_request(nodes[0].name)
+    manager.read_load_balancer.record_latency(nodes[0].name, 0.1)
+    manager.read_load_balancer.start_request(nodes[1].name)
+    manager.read_load_balancer.record_latency(nodes[1].name, 0.01)
+
+    with patch("redis.cluster.random.sample", return_value=[0, 1]):
+        assert (
+            manager.get_node_from_slot(
+                0,
+                read_from_replicas=True,
+                load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+            )
+            is nodes[1]
+        )
+
+
+@pytest.mark.parametrize("command,tracks_latency", [("GET", True), ("SET", False)])
+def test_cluster_command_tracks_latency_only_for_reads(command, tracks_latency):
+    node = ClusterNode("node-a", 7000)
+    redis_node = Mock()
+    redis_node.parse_response.return_value = b"value"
+    connection = Mock()
+    load_balancer = Mock()
+    client = object.__new__(RedisCluster)
+    client.RedisClusterRequestTTL = 1
+    client.load_balancing_strategy = LoadBalancingStrategy.LATENCY_BASED
+    client.nodes_manager = SimpleNamespace(read_load_balancer=load_balancer)
+    client.cluster_response_callbacks = {}
+    client.get_redis_connection = Mock(return_value=redis_node)
+    client._record_command_metric = Mock()
+
+    with patch("redis.cluster.get_connection", return_value=connection):
+        assert client._execute_command(node, command, "key") == b"value"
+
+    if tracks_latency:
+        load_balancer.start_request.assert_called_once_with(node.name)
+        load_balancer.record_latency.assert_called_once()
+        assert load_balancer.record_latency.call_args.args[0] == node.name
+    else:
+        load_balancer.start_request.assert_not_called()
+        load_balancer.record_latency.assert_not_called()
+
+
+def test_cluster_command_records_latency_when_read_fails():
+    node = ClusterNode("node-a", 7000)
+    redis_node = Mock()
+    redis_node.parse_response.side_effect = ValueError("response failure")
+    connection = Mock()
+    load_balancer = Mock()
+    client = object.__new__(RedisCluster)
+    client.RedisClusterRequestTTL = 1
+    client.load_balancing_strategy = LoadBalancingStrategy.LATENCY_BASED
+    client.nodes_manager = SimpleNamespace(read_load_balancer=load_balancer)
+    client.cluster_response_callbacks = {}
+    client.get_redis_connection = Mock(return_value=redis_node)
+    client._record_command_metric = Mock()
+
+    with patch("redis.cluster.get_connection", return_value=connection):
+        with pytest.raises(ValueError, match="response failure"):
+            client._execute_command(node, "GET", "key")
+
+    load_balancer.start_request.assert_called_once_with(node.name)
+    load_balancer.record_latency.assert_called_once()
+
+
+def test_cluster_pipeline_records_one_latency_sample_per_read_node():
+    client = get_mocked_redis_client(
+        host=default_host,
+        port=default_port,
+        load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+    )
+
+    def write_without_network(self):
+        for command in self.commands:
+            command.result = None
+
+    def read_response(self):
+        for command in self.commands:
+            command.result = b"value"
+
+    pipeline = client.pipeline()
+    pipeline.get("foo")
+    connection = Mock(host=default_host, port=default_port, db=0)
+    with (
+        patch.object(NodeCommands, "write", write_without_network),
+        patch.object(NodeCommands, "read", read_response),
+        patch("redis.cluster.get_connection", return_value=connection),
+    ):
+        assert pipeline.execute() == [b"value"]
+
+    assert len(client.nodes_manager.read_load_balancer._latency_state) == 1
 
 
 class ProxyRequestHandler(socketserver.BaseRequestHandler):


### PR DESCRIPTION
Fixes #4185

## Summary

- Add opt-in `LoadBalancingStrategy.LATENCY_BASED` for cluster reads.
- Select two eligible nodes with power-of-two choices and prefer the lower peak-sensitive EWMA score:
  `peak_ewma * (in_flight + 1)`.
- Keep existing round-robin and random strategies unchanged.
- Record per-node latency and in-flight state for sync and asyncio commands.
- Record MOVED/ASK attempts against the node that handled each attempt.
- Record one node-level sample for grouped pipeline execution when the batch contains reads.
- Document the strategy and add a small cluster benchmark.

## Implementation notes

The latency state is implemented once in the shared `LoadBalancer`, so sync and asyncio clients use the same selection and update logic. The selection path is protected by the existing bounded lock; no await is introduced into asyncio selection.

Latency instrumentation is enabled only for the new strategy. Existing strategies do not pay for request timing or state updates.

## Verification

- TDD RED: node-manager tests initially failed because the candidate node list was not supplied to `LoadBalancer`.
- TDD GREEN: focused sync tests: 8 passed.
- Focused asyncio tests: 3 passed.
- `invoke linters`: passed.
- `python -m compileall`: passed.
- `git diff --check`: passed.

The full cluster test files require local Redis cluster services. They were attempted, but this environment has no Redis cluster listening on the test ports, so connection-dependent tests could not complete.

The benchmark is available at `benchmarks/cluster_latency_load_balancing.py`; it requires a Redis cluster with at least one replica for the selected key slot and reports delayed-replica selection share and p99 latency against round-robin.