### PR TITLE
Normalize asyncio writer close races

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1143,8 +1143,14 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             )
 
     async def _send_packed_command(self, command: Iterable[bytes]) -> None:
-        self._writer.writelines(command)
-        await self._writer.drain()
+        writer = self._writer
+        if writer is None:
+            raise ConnectionError("Connection closed while writing")
+        try:
+            writer.writelines(command)
+            await writer.drain()
+        except (AttributeError, TypeError) as error:
+            raise ConnectionError("Connection closed while writing") from error
 
     async def send_packed_command(
         self, command: Union[bytes, str, Iterable[bytes]], check_health: bool = True
@@ -1164,8 +1170,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
                     self._send_packed_command(command), self.socket_timeout
                 )
             else:
-                self._writer.writelines(command)
-                await self._writer.drain()
+                await self._send_packed_command(command)
         except asyncio.TimeoutError:
             await self.disconnect(nowait=True)
             raise TimeoutError("Timeout writing to socket") from None

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1398,7 +1398,13 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
 
     def _socket_is_empty(self):
         """Check if the socket is empty"""
-        return len(self._reader._buffer) == 0
+        reader = self._reader
+        if reader is None:
+            raise ConnectionError("Connection closed while reading")
+        try:
+            return len(reader._buffer) == 0
+        except AttributeError as error:
+            raise ConnectionError("Connection closed while reading") from error
 
     async def process_invalidation_messages(self):
         while not self._socket_is_empty():

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1151,6 +1151,10 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             await writer.drain()
         except AttributeError as error:
             raise ConnectionError("Connection closed while writing") from error
+        except TypeError as error:
+            if str(error) != "'NoneType' object is not callable":
+                raise
+            raise ConnectionError("Connection closed while writing") from error
 
     async def send_packed_command(
         self, command: Union[bytes, str, Iterable[bytes]], check_health: bool = True

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1150,6 +1150,8 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             writer.writelines(command)
             await writer.drain()
         except AttributeError as error:
+            if str(error) != "'NoneType' object has no attribute 'writelines'":
+                raise
             raise ConnectionError("Connection closed while writing") from error
         except TypeError as error:
             if str(error) != "'NoneType' object is not callable":

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1149,7 +1149,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         try:
             writer.writelines(command)
             await writer.drain()
-        except (AttributeError, TypeError) as error:
+        except AttributeError as error:
             raise ConnectionError("Connection closed while writing") from error
 
     async def send_packed_command(

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -116,6 +116,21 @@ async def test_invalid_packed_command_type_error_is_not_connection_error():
     conn._writer = None
 
 
+async def test_closed_writer_type_error_is_connection_error():
+    conn = Connection()
+    conn._reader = mock.Mock()
+    conn._writer = mock.Mock()
+    conn._writer.writelines.side_effect = TypeError("'NoneType' object is not callable")
+    conn.disconnect = mock.AsyncMock()
+
+    with pytest.raises(ConnectionError, match="Connection closed while writing"):
+        await conn.send_packed_command([b"PING\r\n"], check_health=False)
+
+    conn.disconnect.assert_awaited_once_with(nowait=True)
+    conn._reader = None
+    conn._writer = None
+
+
 async def test_closed_reader_during_invalidation_processing_is_connection_error():
     conn = Connection()
     conn._reader = None

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -88,10 +88,27 @@ async def test_closed_writer_during_write_is_connection_error(socket_timeout):
     conn = Connection(socket_timeout=socket_timeout)
     conn._reader = mock.Mock()
     conn._writer = mock.Mock()
-    conn._writer.writelines.side_effect = TypeError("'NoneType' object is not callable")
+    conn._writer.writelines.side_effect = AttributeError(
+        "'NoneType' object has no attribute 'writelines'"
+    )
     conn.disconnect = mock.AsyncMock()
 
     with pytest.raises(ConnectionError, match="Connection closed while writing"):
+        await conn.send_packed_command([b"PING\r\n"], check_health=False)
+
+    conn.disconnect.assert_awaited_once_with(nowait=True)
+    conn._reader = None
+    conn._writer = None
+
+
+async def test_invalid_packed_command_type_error_is_not_connection_error():
+    conn = Connection()
+    conn._reader = mock.Mock()
+    conn._writer = mock.Mock()
+    conn._writer.writelines.side_effect = TypeError("invalid packed command")
+    conn.disconnect = mock.AsyncMock()
+
+    with pytest.raises(TypeError, match="invalid packed command"):
         await conn.send_packed_command([b"PING\r\n"], check_health=False)
 
     conn.disconnect.assert_awaited_once_with(nowait=True)

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -83,6 +83,22 @@ def test_connection_default_parser_matches_default_protocol():
     assert conn.protocol == 3
 
 
+@pytest.mark.parametrize("socket_timeout", [None, 1])
+async def test_closed_writer_during_write_is_connection_error(socket_timeout):
+    conn = Connection(socket_timeout=socket_timeout)
+    conn._reader = mock.Mock()
+    conn._writer = mock.Mock()
+    conn._writer.writelines.side_effect = TypeError("'NoneType' object is not callable")
+    conn.disconnect = mock.AsyncMock()
+
+    with pytest.raises(ConnectionError, match="Connection closed while writing"):
+        await conn.send_packed_command([b"PING\r\n"], check_health=False)
+
+    conn.disconnect.assert_awaited_once_with(nowait=True)
+    conn._reader = None
+    conn._writer = None
+
+
 @pytest.mark.parametrize(
     ("buffer", "eof", "expected"),
     [

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -116,6 +116,14 @@ async def test_invalid_packed_command_type_error_is_not_connection_error():
     conn._writer = None
 
 
+async def test_closed_reader_during_invalidation_processing_is_connection_error():
+    conn = Connection()
+    conn._reader = None
+
+    with pytest.raises(ConnectionError, match="Connection closed while reading"):
+        await conn.process_invalidation_messages()
+
+
 @pytest.mark.parametrize(
     ("buffer", "eof", "expected"),
     [

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -116,6 +116,25 @@ async def test_invalid_packed_command_type_error_is_not_connection_error():
     conn._writer = None
 
 
+async def test_invalid_packed_command_attribute_error_is_not_connection_error():
+    class InvalidCommand:
+        def __iter__(self):
+            raise AttributeError("invalid packed command")
+
+    conn = Connection()
+    conn._reader = mock.Mock()
+    conn._writer = mock.Mock()
+    conn._writer.writelines.side_effect = lambda command: list(command)
+    conn.disconnect = mock.AsyncMock()
+
+    with pytest.raises(AttributeError, match="invalid packed command"):
+        await conn.send_packed_command(InvalidCommand(), check_health=False)
+
+    conn.disconnect.assert_awaited_once_with(nowait=True)
+    conn._reader = None
+    conn._writer = None
+
+
 async def test_closed_writer_type_error_is_connection_error():
     conn = Connection()
     conn._reader = mock.Mock()


### PR DESCRIPTION
Fixes #3546

## Problem

When an asyncio transport is closed concurrently with a write, Python can raise a low-level `TypeError` from `StreamWriter.writelines()` after its internal `_write_ready` callback has been cleared. redis-py currently lets that raw `TypeError` escape, so the existing retry policy cannot recognize the broken connection as retryable.

## Solution

- Keep a local writer reference for the complete write/drain operation.
- Convert writer-close `AttributeError`/`TypeError` failures into redis-py's `ConnectionError`.
- Reuse the existing disconnect path, so the connection is discarded and configured retries can handle the failure.
- Route both timeout and no-timeout writes through the same helper to keep behavior consistent.

## Tests

- Add a deterministic async regression test for the closed-writer race.
- Cover both `socket_timeout=None` and finite `socket_timeout` paths.
- Full async connection suite: 65 passed, 2 skipped.
- Async client suite: 7 passed.
- `invoke linters`, `compileall`, and `git diff --check` passed.

The local integration skips are unchanged and are unrelated to this focused writer error path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused error normalization in asyncio connection I/O with targeted regression tests; behavior change is limited to exception type mapping on close races.
> 
> **Overview**
> Fixes concurrent-close races where `StreamWriter.writelines()` could raise raw `AttributeError`/`TypeError` instead of a retryable connection failure.
> 
> **Write path:** Adds `_send_packed_command()` with a local writer reference, maps known close-race exceptions to `ConnectionError("Connection closed while writing")`, and routes both timed and untimed `send_packed_command()` through that helper.
> 
> **Read path:** `_socket_is_empty()` now guards a missing reader and maps buffer access failures to `ConnectionError("Connection closed while reading")`, including during invalidation processing.
> 
> **Tests:** New async tests cover closed-writer races (with/without `socket_timeout`), closed reader during invalidation, and that unrelated `TypeError`/`AttributeError` from bad commands still propagate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3a84066f319d101a0892e9f4971b992fe915ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->