### PR TITLE
fix: release async cluster transaction connections to their real owner

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1763,6 +1763,10 @@ class ClusterNode:
             return
         self._free.append(connection)
 
+    def owns_connection(self, connection: Connection) -> bool:
+        """Return True if this node created and still tracks ``connection``."""
+        return connection in self._connections
+
     async def _disconnect_and_release(self, connection: Connection) -> None:
         try:
             await connection.disconnect()
@@ -2050,6 +2054,17 @@ class NodesManager:
             raise DataError(
                 "get_node requires one of the following: 1. node name 2. host and port"
             )
+
+    def find_connection_owner(self, connection: Connection) -> Optional["ClusterNode"]:
+        """
+        Return the ClusterNode that owns ``connection``, matched by host/port.
+
+        Used when releasing a transaction connection after a topology change so
+        the connection is returned to its real owner rather than the currently
+        resolved slot node.
+        """
+        node_name = get_node_name(connection.host, connection.port)
+        return self.nodes_cache.get(node_name)
 
     def set_nodes(
         self,
@@ -3124,20 +3139,33 @@ class TransactionStrategy(AbstractStrategy):
         altered as long as the watch commands for those keys were sent over the same
         connection. So once we start watching a key, we fetch a connection to the
         node that owns that slot and reuse it.
+
+        If the slot map changed while a connection is held (e.g. concurrent MOVED
+        refresh), release the previous connection to its real owner and acquire
+        a new one from the newly resolved node — matching sync TransactionStrategy.
         """
         if not self._pipeline_slots:
             raise RedisClusterException(
                 "At least a command with a key is needed to identify a node"
             )
 
-        node: ClusterNode = self._pipe.cluster_client.nodes_manager.get_node_from_slot(
+        nodes_manager = self._pipe.cluster_client.nodes_manager
+        node: ClusterNode = nodes_manager.get_node_from_slot(
             list(self._pipeline_slots)[0], False
         )
         self._transaction_node = node
 
+        if self._transaction_connection:
+            if not node.owns_connection(self._transaction_connection):
+                previous_node = nodes_manager.find_connection_owner(
+                    self._transaction_connection
+                )
+                if previous_node:
+                    previous_node.release(self._transaction_connection)
+                self._transaction_connection = None
+
         if not self._transaction_connection:
-            connection: Connection = self._transaction_node.acquire_connection()
-            self._transaction_connection = connection
+            self._transaction_connection = self._transaction_node.acquire_connection()
 
         return self._transaction_node, self._transaction_connection
 
@@ -3306,10 +3334,14 @@ class TransactionStrategy(AbstractStrategy):
             type(error) in self.SLOT_REDIRECT_ERRORS
             or type(error) in self.CONNECTION_ERRORS
         ):
-            if self._transaction_connection and self._transaction_node:
-                # Disconnect and release back to pool
+            if self._transaction_connection:
+                # Disconnect and release back to the connection's real owner
                 await self._transaction_connection.disconnect()
-                self._transaction_node.release(self._transaction_connection)
+                node = self._pipe.cluster_client.nodes_manager.find_connection_owner(
+                    self._transaction_connection
+                )
+                if node:
+                    node.release(self._transaction_connection)
                 self._transaction_connection = None
 
             self._pipe.cluster_client.reinitialize_counter += 1
@@ -3497,6 +3529,7 @@ class TransactionStrategy(AbstractStrategy):
 
     async def reset(self):
         self._command_queue = []
+        nodes_manager = self._pipe.cluster_client.nodes_manager
 
         try:
             # make sure to reset the connection state in the event that we
@@ -3520,21 +3553,33 @@ class TransactionStrategy(AbstractStrategy):
                     raise
                 else:
                     # On the happy path, honor lazy reconnect before release.
-                    await self._transaction_node.disconnect_if_needed(
+                    owner = nodes_manager.find_connection_owner(
                         self._transaction_connection
                     )
+                    if owner:
+                        await owner.disconnect_if_needed(self._transaction_connection)
+                    elif self._transaction_node:
+                        await self._transaction_node.disconnect_if_needed(
+                            self._transaction_connection
+                        )
         finally:
-            # Always return the connection to the node's free queue, even on
-            # cancellation, so cancelled resets do not leak pooled
-            # connections. Detach the reference before releasing so the
-            # strategy never holds a pointer to a returned connection.
-            # ClusterNode.release is synchronous, so no shield is required.
-            if self._transaction_connection and self._transaction_node:
+            # Always return the connection to its real owner's free queue,
+            # even on cancellation, so cancelled resets do not leak pooled
+            # connections. Resolve the owner explicitly: self._transaction_node
+            # may already point at a different node after a topology change.
+            # Detach the reference before releasing so the strategy never holds
+            # a pointer to a returned connection. ClusterNode.release is
+            # synchronous, so no shield is required.
+            if self._transaction_connection:
                 connection, self._transaction_connection = (
                     self._transaction_connection,
                     None,
                 )
-                self._transaction_node.release(connection)
+                owner = nodes_manager.find_connection_owner(connection)
+                if owner:
+                    owner.release(connection)
+                elif self._transaction_node:
+                    self._transaction_node.release(connection)
             # clean up the other instance attributes
             self._transaction_connection = None
             self._transaction_node = None

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1762,6 +1762,10 @@ class ClusterNode:
             return
         self._free.append(connection)
 
+    def owns_connection(self, connection: Connection) -> bool:
+        """Return True if this node created and still tracks ``connection``."""
+        return connection in self._connections
+
     async def _disconnect_and_release(self, connection: Connection) -> None:
         try:
             await connection.disconnect()
@@ -2049,6 +2053,17 @@ class NodesManager:
             raise DataError(
                 "get_node requires one of the following: 1. node name 2. host and port"
             )
+
+    def find_connection_owner(self, connection: Connection) -> Optional["ClusterNode"]:
+        """
+        Return the ClusterNode that owns ``connection``, matched by host/port.
+
+        Used when releasing a transaction connection after a topology change so
+        the connection is returned to its real owner rather than the currently
+        resolved slot node.
+        """
+        node_name = get_node_name(connection.host, connection.port)
+        return self.nodes_cache.get(node_name)
 
     def set_nodes(
         self,
@@ -3092,20 +3107,33 @@ class TransactionStrategy(AbstractStrategy):
         altered as long as the watch commands for those keys were sent over the same
         connection. So once we start watching a key, we fetch a connection to the
         node that owns that slot and reuse it.
+
+        If the slot map changed while a connection is held (e.g. concurrent MOVED
+        refresh), release the previous connection to its real owner and acquire
+        a new one from the newly resolved node — matching sync TransactionStrategy.
         """
         if not self._pipeline_slots:
             raise RedisClusterException(
                 "At least a command with a key is needed to identify a node"
             )
 
-        node: ClusterNode = self._pipe.cluster_client.nodes_manager.get_node_from_slot(
+        nodes_manager = self._pipe.cluster_client.nodes_manager
+        node: ClusterNode = nodes_manager.get_node_from_slot(
             list(self._pipeline_slots)[0], False
         )
         self._transaction_node = node
 
+        if self._transaction_connection:
+            if not node.owns_connection(self._transaction_connection):
+                previous_node = nodes_manager.find_connection_owner(
+                    self._transaction_connection
+                )
+                if previous_node:
+                    previous_node.release(self._transaction_connection)
+                self._transaction_connection = None
+
         if not self._transaction_connection:
-            connection: Connection = self._transaction_node.acquire_connection()
-            self._transaction_connection = connection
+            self._transaction_connection = self._transaction_node.acquire_connection()
 
         return self._transaction_node, self._transaction_connection
 
@@ -3274,10 +3302,14 @@ class TransactionStrategy(AbstractStrategy):
             type(error) in self.SLOT_REDIRECT_ERRORS
             or type(error) in self.CONNECTION_ERRORS
         ):
-            if self._transaction_connection and self._transaction_node:
-                # Disconnect and release back to pool
+            if self._transaction_connection:
+                # Disconnect and release back to the connection's real owner
                 await self._transaction_connection.disconnect()
-                self._transaction_node.release(self._transaction_connection)
+                node = self._pipe.cluster_client.nodes_manager.find_connection_owner(
+                    self._transaction_connection
+                )
+                if node:
+                    node.release(self._transaction_connection)
                 self._transaction_connection = None
 
             self._pipe.cluster_client.reinitialize_counter += 1
@@ -3465,6 +3497,7 @@ class TransactionStrategy(AbstractStrategy):
 
     async def reset(self):
         self._command_queue = []
+        nodes_manager = self._pipe.cluster_client.nodes_manager
 
         try:
             # make sure to reset the connection state in the event that we
@@ -3488,21 +3521,33 @@ class TransactionStrategy(AbstractStrategy):
                     raise
                 else:
                     # On the happy path, honor lazy reconnect before release.
-                    await self._transaction_node.disconnect_if_needed(
+                    owner = nodes_manager.find_connection_owner(
                         self._transaction_connection
                     )
+                    if owner:
+                        await owner.disconnect_if_needed(self._transaction_connection)
+                    elif self._transaction_node:
+                        await self._transaction_node.disconnect_if_needed(
+                            self._transaction_connection
+                        )
         finally:
-            # Always return the connection to the node's free queue, even on
-            # cancellation, so cancelled resets do not leak pooled
-            # connections. Detach the reference before releasing so the
-            # strategy never holds a pointer to a returned connection.
-            # ClusterNode.release is synchronous, so no shield is required.
-            if self._transaction_connection and self._transaction_node:
+            # Always return the connection to its real owner's free queue,
+            # even on cancellation, so cancelled resets do not leak pooled
+            # connections. Resolve the owner explicitly: self._transaction_node
+            # may already point at a different node after a topology change.
+            # Detach the reference before releasing so the strategy never holds
+            # a pointer to a returned connection. ClusterNode.release is
+            # synchronous, so no shield is required.
+            if self._transaction_connection:
                 connection, self._transaction_connection = (
                     self._transaction_connection,
                     None,
                 )
-                self._transaction_node.release(connection)
+                owner = nodes_manager.find_connection_owner(connection)
+                if owner:
+                    owner.release(connection)
+                elif self._transaction_node:
+                    self._transaction_node.release(connection)
             # clean up the other instance attributes
             self._transaction_connection = None
             self._transaction_node = None

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -4109,6 +4109,76 @@ class TestClusterPipeline:
             pipe.evalsha(sha, 0)
             assert await pipe.execute() == [42, 42]
 
+    async def test_transaction_releases_connection_when_slot_owner_changes(
+        self,
+    ) -> None:
+        """
+        If the slot map changes while a transaction holds a connection (without
+        this pipeline seeing MOVED), the next acquisition must release the old
+        connection to its real owner and take one from the new node. reset()
+        must also release via find_connection_owner, not a stale
+        _transaction_node reference (#4253).
+        """
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            original_node = r.get_node(host=default_host, port=7000)
+            new_node = r.get_node(host=default_host, port=7001)
+            assert original_node is not None and new_node is not None
+            assert original_node.name != new_node.name
+
+            def _seed_owned_connection(node: ClusterNode) -> Connection:
+                while node._free:
+                    node._free.pop()
+                conn = mock.AsyncMock(spec=Connection)
+                conn.host = node.host
+                conn.port = node.port
+                conn.db = 0
+                conn.is_connected = True
+                conn.should_reconnect.return_value = False
+                node._connections.append(conn)
+                node._free.append(conn)
+                return conn
+
+            original_conn = _seed_owned_connection(original_node)
+            new_conn = _seed_owned_connection(new_node)
+
+            slot = 0
+            r.nodes_manager.slots_cache[slot] = [original_node]
+
+            pipe = r.pipeline(transaction=True)
+            strategy = pipe._execution_strategy
+            # Simulate a mid-WATCH hold without talking to Redis
+            strategy._pipeline_slots = {slot}
+            strategy._watching = True
+            strategy._transaction_node = original_node
+            strategy._transaction_connection = original_node.acquire_connection()
+            assert strategy._transaction_connection is original_conn
+            assert original_conn not in original_node._free
+
+            # Concurrent topology refresh retargets the slot
+            r.nodes_manager.slots_cache[slot] = [new_node]
+
+            node, conn = strategy._get_client_and_connection_for_transaction()
+
+            assert node is new_node
+            assert strategy._transaction_node is new_node
+            assert conn is new_conn
+            assert conn is strategy._transaction_connection
+            assert conn is not original_conn
+            assert new_node.owns_connection(conn)
+            assert original_conn in original_node._free
+
+            # Prove reset() uses find_connection_owner even if _transaction_node
+            # still points at the previous owner.
+            strategy._watching = False
+            strategy._transaction_node = original_node
+            await pipe.reset()
+            assert strategy._transaction_connection is None
+            assert new_conn in new_node._free
+            assert new_conn not in original_node._free
+        finally:
+            await r.aclose()
+
     async def test_empty_stack(self, r: RedisCluster) -> None:
         """If a pipeline is executed with no commands it should return a empty list."""
         p = r.pipeline()

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3918,6 +3918,76 @@ class TestClusterPipeline:
                 "when running redis in cluster mode..."
             )
 
+    async def test_transaction_releases_connection_when_slot_owner_changes(
+        self,
+    ) -> None:
+        """
+        If the slot map changes while a transaction holds a connection (without
+        this pipeline seeing MOVED), the next acquisition must release the old
+        connection to its real owner and take one from the new node. reset()
+        must also release via find_connection_owner, not a stale
+        _transaction_node reference (#4253).
+        """
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            original_node = r.get_node(host=default_host, port=7000)
+            new_node = r.get_node(host=default_host, port=7001)
+            assert original_node is not None and new_node is not None
+            assert original_node.name != new_node.name
+
+            def _seed_owned_connection(node: ClusterNode) -> Connection:
+                while node._free:
+                    node._free.pop()
+                conn = mock.AsyncMock(spec=Connection)
+                conn.host = node.host
+                conn.port = node.port
+                conn.db = 0
+                conn.is_connected = True
+                conn.should_reconnect.return_value = False
+                node._connections.append(conn)
+                node._free.append(conn)
+                return conn
+
+            original_conn = _seed_owned_connection(original_node)
+            new_conn = _seed_owned_connection(new_node)
+
+            slot = 0
+            r.nodes_manager.slots_cache[slot] = [original_node]
+
+            pipe = r.pipeline(transaction=True)
+            strategy = pipe._execution_strategy
+            # Simulate a mid-WATCH hold without talking to Redis
+            strategy._pipeline_slots = {slot}
+            strategy._watching = True
+            strategy._transaction_node = original_node
+            strategy._transaction_connection = original_node.acquire_connection()
+            assert strategy._transaction_connection is original_conn
+            assert original_conn not in original_node._free
+
+            # Concurrent topology refresh retargets the slot
+            r.nodes_manager.slots_cache[slot] = [new_node]
+
+            node, conn = strategy._get_client_and_connection_for_transaction()
+
+            assert node is new_node
+            assert strategy._transaction_node is new_node
+            assert conn is new_conn
+            assert conn is strategy._transaction_connection
+            assert conn is not original_conn
+            assert new_node.owns_connection(conn)
+            assert original_conn in original_node._free
+
+            # Prove reset() uses find_connection_owner even if _transaction_node
+            # still points at the previous owner.
+            strategy._watching = False
+            strategy._transaction_node = original_node
+            await pipe.reset()
+            assert strategy._transaction_connection is None
+            assert new_conn in new_node._free
+            assert new_conn not in original_node._free
+        finally:
+            await r.aclose()
+
     async def test_empty_stack(self, r: RedisCluster) -> None:
         """If a pipeline is executed with no commands it should return a empty list."""
         p = r.pipeline()


### PR DESCRIPTION
When the slot map changes while an async `TransactionStrategy` holds a connection, release it to its actual `ClusterNode` owner before acquiring from the newly resolved node. Apply the same ownership resolution in `reset()` and `_reinitialize_on_error()` for sync/async parity (#4253 item 1).

### Description of change

Addresses https://github.com/redis/redis-py/issues/4253 (item 1). Follow-up from the review of #4206.

Sync `TransactionStrategy` already checks pool ownership before reusing a held transaction connection and releases via `find_connection_owner`. Async did not: `_get_client_and_connection_for_transaction()` recomputed `_transaction_node` from the current slot map but reused `_transaction_connection` unconditionally, and `reset()` / `_reinitialize_on_error()` released through `_transaction_node`. If another operation refreshed the shared `nodes_manager` topology while this pipeline held a connection during `WATCH` (without this pipeline itself raising `MOVED`/`ASK`), the next command could send on a stale connection and `reset()` could push that connection onto the wrong node's free queue.

This PR brings async in line with sync:

- `ClusterNode.owns_connection()` / `NodesManager.find_connection_owner()`
- ownership check + release-to-real-owner before reuse in `_get_client_and_connection_for_transaction()`
- `reset()` and `_reinitialize_on_error()` resolve the owner explicitly before release

No public API changes. Sync is unchanged (already correct). Item 2 of #4253 (sync `Script` → cluster pipeline `EVALSHA` coverage) stays in #4206 and is not included here.

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection-pool lifecycle for async cluster transactions during topology churn; wrong ownership could leak or mis-route connections, but behavior aligns with existing sync logic and is covered by a targeted test.
> 
> **Overview**
> Fixes async cluster **transactional pipelines** returning pooled connections to the wrong `ClusterNode` when the slot map changes while a `WATCH`/transaction connection is held (e.g. another coroutine refreshes topology without this pipeline seeing `MOVED`).
> 
> Adds **`ClusterNode.owns_connection()`** and **`NodesManager.find_connection_owner()`** (lookup by connection host/port). **`TransactionStrategy`** now mirrors sync: before reusing a held connection it releases to the real owner if the current slot node no longer owns it; **`reset()`** and **`_reinitialize_on_error()`** also resolve the owner via `find_connection_owner` instead of stale **`_transaction_node`**.
> 
> Includes a regression test for slot retargeting during WATCH and for **`reset()`** releasing to the correct pool (#4253).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a386439435f0be6e9086a940508b73f68c43aa02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->