### PR TITLE
Fix async cluster release race for closed connections

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1756,10 +1756,12 @@ class ClusterNode:
         returning it to the free queue.
         """
         if connection.should_reconnect():
-            task = asyncio.create_task(self._disconnect_and_release(connection))
-            self._background_tasks.add(task)
-            task.add_done_callback(self._background_tasks.discard)
-            return
+            if connection.is_connected:
+                task = asyncio.create_task(self._disconnect_and_release(connection))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+                return
+            connection.reset_should_reconnect()
         self._free.append(connection)
 
     async def _disconnect_and_release(self, connection: Connection) -> None:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1753,8 +1753,9 @@ class ClusterNode:
     def release(self, connection: Connection) -> None:
         """
         Release connection back to free queue.
-        If the connection is marked for reconnect, disconnect it before
-        returning it to the free queue.
+        If a connected connection is marked for reconnect, disconnect it before
+        returning it to the free queue. An already-closed connection can be
+        returned immediately after clearing its reconnect flag.
         """
         if connection.should_reconnect():
             if connection.is_connected:
@@ -1762,6 +1763,7 @@ class ClusterNode:
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
                 return
+            # It may have been re-marked while its own disconnect was in progress.
             connection.reset_should_reconnect()
         self._free.append(connection)
 

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3642,13 +3642,11 @@ class TestClusterNodeConnectionHandling:
             max_connections=1,
             connection_class=RaceConnection,
         )
+        connection = RaceConnection(host=default_host, port=7000)
+        node._connections = [connection]
+        node._free.append(connection)
 
         async def remark_during_disconnect() -> None:
-            while not node._connections:
-                await asyncio.sleep(0)
-
-            connection = node._connections[0]
-
             await connection.send_started.wait()
             node.update_active_connections_for_reconnect()
             connection.response_ready.set()
@@ -3661,8 +3659,6 @@ class TestClusterNodeConnectionHandling:
 
         assert await node.execute_command("GET", "key") == b"value"
         await remark_task
-
-        connection = node._connections[0]
 
         assert node.acquire_connection() is connection
         assert node._background_tasks == set()

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3589,6 +3589,85 @@ class TestClusterNodeConnectionHandling:
         # Should not raise
         await node.disconnect_free_connections()
 
+    async def test_execute_command_reuses_closed_remarked_connection_inline(
+        self,
+    ) -> None:
+        class RaceConnection:
+            def __init__(self, **kwargs: Any) -> None:
+                self.host = kwargs["host"]
+                self.port = kwargs["port"]
+                self.db = kwargs.get("db", 0)
+                self.is_connected = True
+                self._reconnect = False
+                self.send_started = asyncio.Event()
+                self.response_ready = asyncio.Event()
+                self.disconnect_started = asyncio.Event()
+                self.allow_disconnect = asyncio.Event()
+                self.disconnect_calls = 0
+
+            def pack_command(self, *args: Any) -> bytes:
+                return b"packed-command"
+
+            async def send_packed_command(self, command: Any) -> None:
+                self.send_started.set()
+
+            async def read_response(self, *args: Any, **kwargs: Any) -> bytes:
+                await self.response_ready.wait()
+                return b"value"
+
+            def mark_for_reconnect(self) -> None:
+                self._reconnect = True
+
+            def should_reconnect(self) -> bool:
+                return self._reconnect
+
+            def reset_should_reconnect(self) -> None:
+                self._reconnect = False
+
+            async def disconnect(self) -> None:
+                self.disconnect_calls += 1
+                self.reset_should_reconnect()
+
+                if not self.is_connected:
+                    return
+
+                self.disconnect_started.set()
+                await self.allow_disconnect.wait()
+                self.is_connected = False
+
+        node = ClusterNode(
+            default_host,
+            7000,
+            max_connections=1,
+            connection_class=RaceConnection,
+        )
+
+        async def remark_during_disconnect() -> None:
+            while not node._connections:
+                await asyncio.sleep(0)
+
+            connection = node._connections[0]
+
+            await connection.send_started.wait()
+            node.update_active_connections_for_reconnect()
+            connection.response_ready.set()
+
+            await connection.disconnect_started.wait()
+            node.update_active_connections_for_reconnect()
+            connection.allow_disconnect.set()
+
+        remark_task = asyncio.create_task(remark_during_disconnect())
+
+        assert await node.execute_command("GET", "key") == b"value"
+        await remark_task
+
+        connection = node._connections[0]
+
+        assert node.acquire_connection() is connection
+        assert node._background_tasks == set()
+        assert connection.should_reconnect() is False
+        assert connection.disconnect_calls == 1
+
     async def test_release_with_reconnect_flag(self) -> None:
         """
         Test that release() disconnects a connection marked for reconnect before
@@ -3656,6 +3735,8 @@ class TestClusterNodeConnectionHandling:
         """
 
         class FakeConnection:
+            is_connected = True
+
             def should_reconnect(self) -> bool:
                 return True
 


### PR DESCRIPTION
### Description of change

Fixes #4247.

An async cluster connection can be marked for reconnect while its first disconnect is still waiting for the socket to close. That leaves the connection closed but marked again. `release()` previously treated every marked connection as needing another background disconnect, so at `max_connections=1` the only connection stayed outside `_free` for another event-loop turn. A concurrent acquire could then raise a false `MaxConnectionsError`.

This change keeps the existing background disconnect for marked connections that are still open. If the connection is already closed, it clears the stale reconnect flag and returns the connection to `_free` immediately.

The regression test drives the real `execute_command()` path with a deterministic interleaving, then verifies that the next acquire reuses the same connection without a second disconnect.

### Validation

- `TestClusterNodeConnectionHandling`: 13 passed on Windows and Ubuntu WSL
- `invoke linters`: passed
- Ruff check, format, and vulture: passed on Ubuntu WSL
- `git diff --check`: passed
- The complete integration matrix requires the repository's Redis Cluster services and will be covered by CI

### Pull Request check-list

- [x] Relevant tests and lints pass with this change
- [ ] CI tests pass with this change
- [x] The changed behavior has regression coverage
- [x] No public API or documentation changes are needed
- [x] No example is needed for this internal connection-pool fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async cluster connection-pool release logic on a hot path; behavior change is narrow (closed + reconnect-flagged) but incorrect pooling can cause false MaxConnectionsError or connection leaks under concurrency.
> 
> **Overview**
> Fixes a race in async `ClusterNode.release()` where a connection could be **re-marked for reconnect** while its first background disconnect was still in flight. The connection was already closed but still flagged, so `release()` always scheduled another async disconnect and withheld it from `_free` for an extra event-loop turn. At **`max_connections=1`**, a concurrent acquire could hit a false **`MaxConnectionsError`**.
> 
> **`release()`** now only spawns the background disconnect when the connection is still **`is_connected`**. If it is already closed, it clears the stale reconnect flag via **`reset_should_reconnect()`** and appends the connection to **`_free`** synchronously.
> 
> Adds a regression test that drives **`execute_command()`** with a deterministic interleaving (remark during in-flight disconnect) and asserts the next acquire reuses the same connection without a second disconnect or stray background tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39addac7a61ce8fa7c8e964f834999bb068e43ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->