### PR TITLE
docs: add sliding window rate limiter example to lua_scripting.rst

### DIFF
--- a/docs/lua_scripting.rst
+++ b/docs/lua_scripting.rst
@@ -113,3 +113,59 @@ The following commands are not supported:
 - ``EVALSHA_RO``
 
 Using scripting within pipelines in cluster mode is **not supported**.
+
+Practical Example: Sliding Window Rate Limiter
+-----------------------------------------------
+
+The ``register_script`` API is well-suited for operations that must be
+atomic across multiple Redis commands. A sliding window rate limiter is
+a good example: checking the request count and conditionally inserting
+a new entry must happen in a single round trip to avoid race conditions
+when multiple clients share the same key.
+
+This script removes entries older than the window, counts the remaining
+entries, and either adds the new request or rejects it — all atomically.
+
+.. code:: python
+
+   >>> import time, uuid
+   >>> SLIDING_WINDOW = """
+   ... local key = KEYS[1]
+   ... local now = tonumber(ARGV[1])
+   ... local window = tonumber(ARGV[2])
+   ... local limit = tonumber(ARGV[3])
+   ... local member = ARGV[4]
+   ... redis.call('ZREMRANGEBYSCORE', key, '-inf', now - window)
+   ... local count = redis.call('ZCARD', key)
+   ... if count < limit then
+   ...     redis.call('ZADD', key, now, member)
+   ...     redis.call('EXPIRE', key, window * 2)
+   ...     return 1
+   ... end
+   ... return 0
+   ... """
+   >>> sliding_window = r.register_script(SLIDING_WINDOW)
+   >>> def is_allowed(client, key, limit, window_seconds):
+   ...     result = sliding_window(
+   ...         keys=[key],
+   ...         args=[time.time(), window_seconds, limit, str(uuid.uuid4())],
+   ...         client=client,
+   ...     )
+   ...     return bool(result)
+
+The ``client=client`` argument ensures the script executes on the
+provided connection rather than the one used during registration.
+This matters when working with multiple databases, test fixtures, or
+any client other than the one that called ``register_script``.
+
+.. code:: python
+
+   >>> r.delete('rate:demo')
+   0
+   >>> [is_allowed(r, 'rate:demo', limit=3, window_seconds=60) for _ in range(5)]
+   [True, True, True, False, False]
+
+The first three calls are allowed; the fourth and fifth are rejected
+because three entries already exist within the 60-second window. The
+key expires automatically after the window duration so no manual
+cleanup is needed.


### PR DESCRIPTION
Follows up on the feedback from @petyaslavova in #4248.

The previous PR used a standalone notebook. This version adds a focused
section to docs/lua_scripting.rst instead — the home the maintainer
suggested for application-level Lua patterns.

Changes:
- New section "Practical Example: Sliding Window Rate Limiter" at the
  end of lua_scripting.rst
- Uses the same .. code:: python doctest format as the rest of the file
- Fixes the client argument bug from #4248: client=client is now passed
  to the Script call so the script executes on the provided connection
- No notebook, no unexecuted cells, no CI build dependency on Redis

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a **Practical Example: Sliding Window Rate Limiter** section at the end of `docs/lua_scripting.rst`, showing how `register_script` can atomically trim a sorted set, count in-window requests, and accept or reject a new entry in one round trip.
> 
> The new content uses the same `.. code:: python` doctest style as the rest of the page, including a helper that passes **`client=client`** into the script invocation so execution uses the caller’s connection (called out explicitly after feedback on #4248). A short demo asserts a limit of 3 per 60 seconds and automatic key expiry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64113c22c5419b7d05ae0f1088d025319ae9a09b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->