### PR TITLE
fix(lock): preserve token when sync Lock.release() fails

### DIFF
--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -279,11 +279,16 @@ class Lock:
         try:
             await self.do_release(expected_token)
         except LockNotOwnedError:
-            # Lock doesn't exist in Redis, safe to clear token
-            self.local.token = None
+            # Lock doesn't exist in Redis, so clear the token, but only if it is still
+            # ours. threading.local() is shared by every task on one event loop, so a
+            # Lock shared between tasks may already hold another acquirer's token;
+            # overwriting it would leave the new owner unable to release.
+            if self.local.token == expected_token:
+                self.local.token = None
             raise
-        # Only clear token after successful release
-        self.local.token = None
+        # Only clear token after successful release, and only if it is still ours.
+        if self.local.token == expected_token:
+            self.local.token = None
 
     async def do_release(self, expected_token: bytes) -> None:
         if not bool(

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -280,11 +280,16 @@ class Lock:
         try:
             self.do_release(expected_token)
         except LockNotOwnedError:
-            # Lock doesn't exist in Redis, safe to clear token
-            self.local.token = None
+            # Lock doesn't exist in Redis, so clear the token, but only if it is still
+            # ours. With thread_local=False the namespace is shared, so another acquirer
+            # may already have stored its own token; overwriting it would leave the new
+            # owner unable to release.
+            if self.local.token == expected_token:
+                self.local.token = None
             raise
-        # Only clear token after successful release
-        self.local.token = None
+        # Only clear token after successful release, and only if it is still ours.
+        if self.local.token == expected_token:
+            self.local.token = None
 
     def do_release(self, expected_token: str) -> None:
         if not bool(

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -265,6 +265,11 @@ class Lock:
     def release(self) -> None:
         """
         Releases the already acquired lock
+
+        The token is only cleared after the Redis release operation completes
+        successfully. If the release fails with a connection or timeout error
+        the lock may still exist in Redis, so the token is preserved and the
+        release can be retried.
         """
         expected_token = self.local.token
         if expected_token is None:
@@ -272,8 +277,14 @@ class Lock:
                 "Cannot release a lock that's not owned or is already unlocked.",
                 lock_name=self.name,
             )
+        try:
+            self.do_release(expected_token)
+        except LockNotOwnedError:
+            # Lock doesn't exist in Redis, safe to clear token
+            self.local.token = None
+            raise
+        # Only clear token after successful release
         self.local.token = None
-        self.do_release(expected_token)
 
     def do_release(self, expected_token: str) -> None:
         if not bool(

--- a/tests/test_asyncio/test_lock.py
+++ b/tests/test_asyncio/test_lock.py
@@ -212,6 +212,38 @@ class TestLock:
         # even though we errored, the token is still cleared
         assert lock.local.token is None
 
+    async def test_release_does_not_clear_another_acquirers_token(self, r, monkeypatch):
+        """
+        release() must only clear the token if it is still ours.
+
+        threading.local() is shared by every task on one event loop, so a Lock
+        shared between tasks can have another acquirer's token stored between
+        do_release() and the clear. Clearing unconditionally leaves that new
+        owner holding a lock it cannot release.
+        """
+        lock = self.get_lock(r, "foo")
+        await lock.acquire(blocking=False)
+
+        async def steal(expected_token):
+            lock.local.token = "another-acquirers-token"
+
+        monkeypatch.setattr(lock, "do_release", steal)
+        await lock.release()
+        assert lock.local.token == "another-acquirers-token"
+
+        async def steal_and_raise(expected_token):
+            lock.local.token = "another-acquirers-token"
+            raise LockNotOwnedError("Cannot release a lock that's no longer owned")
+
+        lock.local.token = "ours"
+        monkeypatch.setattr(lock, "do_release", steal_and_raise)
+        with pytest.raises(LockNotOwnedError):
+            await lock.release()
+        assert lock.local.token == "another-acquirers-token"
+
+        monkeypatch.undo()
+        await r.delete("foo")
+
     async def test_extend_lock(self, r):
         lock = self.get_lock(r, "foo", timeout=10)
         assert await lock.acquire(blocking=False)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -3,7 +3,7 @@ import time
 import pytest
 from redis import lock as lock_module
 from redis.client import Redis
-from redis.exceptions import LockError, LockNotOwnedError
+from redis.exceptions import ConnectionError, LockError, LockNotOwnedError
 from redis.lock import Lock
 
 from .conftest import _get_client
@@ -206,6 +206,37 @@ class TestLock:
             lock.release()
         # even though we errored, the token is still cleared
         assert lock.local.token is None
+
+    def test_release_connection_error_preserves_lock_state(self, r, monkeypatch):
+        """
+        A failed release must leave the lock retryable.
+
+        Same state as GitHub issue #3847, reached through a connection error
+        instead of a cancellation. Clearing the token before the round trip
+        left owned() False while the Redis key survived, so the caller could
+        neither retry the release nor extend the lock.
+        """
+        lock = self.get_lock(r, "foo")
+        lock.acquire(blocking=False)
+        original_token = lock.local.token
+        assert original_token is not None
+
+        def fail(expected_token):
+            raise ConnectionError("Connection closed by server.")
+
+        monkeypatch.setattr(lock, "do_release", fail)
+        with pytest.raises(ConnectionError):
+            lock.release()
+
+        # the lock is still held in Redis, so the token must survive
+        assert lock.local.token == original_token
+        assert lock.owned()
+        assert lock.locked()
+
+        # and the release can now be retried
+        monkeypatch.undo()
+        lock.release()
+        assert lock.locked() is False
 
     def test_extend_lock(self, r):
         lock = self.get_lock(r, "foo", timeout=10)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -238,6 +238,38 @@ class TestLock:
         lock.release()
         assert lock.locked() is False
 
+    def test_release_does_not_clear_another_acquirers_token(self, r, monkeypatch):
+        """
+        release() must only clear the token if it is still ours.
+
+        With thread_local=False the token namespace is shared, so another
+        acquirer can store its token between our do_release() and the clear.
+        Clearing unconditionally there is the overwrite #489 fixed in 2014, and
+        it leaves the new owner holding a lock it cannot release.
+        """
+        lock = self.get_lock(r, "foo")
+        lock.acquire(blocking=False)
+
+        def steal(expected_token):
+            lock.local.token = "another-acquirers-token"
+
+        monkeypatch.setattr(lock, "do_release", steal)
+        lock.release()
+        assert lock.local.token == "another-acquirers-token"
+
+        def steal_and_raise(expected_token):
+            lock.local.token = "another-acquirers-token"
+            raise LockNotOwnedError("Cannot release a lock that's no longer owned")
+
+        lock.local.token = "ours"
+        monkeypatch.setattr(lock, "do_release", steal_and_raise)
+        with pytest.raises(LockNotOwnedError):
+            lock.release()
+        assert lock.local.token == "another-acquirers-token"
+
+        monkeypatch.undo()
+        r.delete("foo")
+
     def test_extend_lock(self, r):
         lock = self.get_lock(r, "foo", timeout=10)
         assert lock.acquire(blocking=False)


### PR DESCRIPTION
`redis/lock.py` clears `self.local.token` before the release round trip, so any exception from `do_release` leaves the caller holding a lock in Redis with no token for it. `owned()` returns False, `locked()` returns True, and both `release()` and `extend()` then raise `LockError`, so the only way out is deleting the key by hand.

The async twin was fixed for this in #3900, closing #3847, and `redis/lock.py` was not touched by that commit. Case 3 of that commit message, "Network error: preserve token (lock might still exist)", is not asyncio specific. A `ConnectionError` or `TimeoutError` reaches the sync client the same way, once the retry layer has given up.

This mirrors #3900: clear after a successful release, still clear on `LockNotOwnedError` because the lock is gone from Redis anyway, preserve it otherwise.

Against a live Redis 7, `tests/test_lock.py` is 33 passed and `tests/test_asyncio/test_lock.py` 60 passed, with `ruff check` and `ruff format` clean. The added test fails without the `lock.py` change and passes with it, and `test_releasing_lock_no_longer_owned_raises_error` still passes.

#489 moved the clear ahead of the call in 2014 to stop a token overwrite, and its load bearing part, capturing `expected_token` into a local, is kept here. With `thread_local=False` a successful release can now be followed by another thread's acquire before the clear lands, blanking the new token. The async twin already behaves that way, so this makes them consistent, and clearing only when `self.local.token` is still `expected_token` would close it in both.

Not a security issue. The caller does see the exception, so what is silent here is only the state left behind, though a lock taken with the default `timeout=None` has no TTL and the key it leaks never expires on its own.

I did not test against a cluster or with hiredis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed lock release semantics used by many applications; behavior is more correct but callers relying on the old eager token clear could see different state after failed releases.
> 
> **Overview**
> Aligns **sync** `Lock.release()` with the async fix from #3847: the local token is no longer cleared before the Redis release round trip. On **connection/timeout failures**, the token stays set so `owned()` remains accurate, **release/extend can be retried**, and callers are not stuck with a Redis key they cannot unlock. On **`LockNotOwnedError`**, the token is still cleared because the lock is gone in Redis.
> 
> Both **sync and async** `release()` now clear `self.local.token` only when it still equals the captured **`expected_token`**. That avoids wiping another acquirer's token when the same lock instance shares one token namespace (`thread_local=False` or asyncio tasks on one event loop), matching the intent of the older #489 fix while clearing after success.
> 
> New tests cover **connection-error retry** (sync) and **non-destructive token clear** when another acquirer steals the slot during release (sync + async).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335be1a3d92d458be4d6f318f5496ffcbda663bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->