### PR TITLE
fix(cluster): make async pipeline unlink() stage without being awaited

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2631,8 +2631,8 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
         """Unwatches all previously specified keys"""
         await self._execution_strategy.unwatch()
 
-    async def unlink(self, *names):
-        await self._execution_strategy.unlink(*names)
+    def unlink(self, *names):
+        return self._execution_strategy.unlink(*names)
 
     def mset_nonatomic(
         self, mapping: Mapping[AnyKeyT, EncodableT]
@@ -2747,7 +2747,7 @@ class ExecutionStrategy(ABC):
         pass
 
     @abstractmethod
-    async def unlink(self, *names):
+    def unlink(self, *names):
         """
         "Unlink a key specified by ``names``"
 
@@ -2823,7 +2823,7 @@ class AbstractStrategy(ExecutionStrategy):
         pass
 
     @abstractmethod
-    async def unlink(self, *names):
+    def unlink(self, *names):
         pass
 
     def __len__(self) -> int:
@@ -3048,7 +3048,7 @@ class PipelineStrategy(AbstractStrategy):
             "method discard() is not supported outside of transactional context"
         )
 
-    async def unlink(self, *names):
+    def unlink(self, *names):
         if len(names) != 1:
             raise RedisClusterException(
                 "unlinking multiple keys is not implemented in pipeline command"
@@ -3535,7 +3535,7 @@ class TransactionStrategy(AbstractStrategy):
     async def discard(self):
         await self.reset()
 
-    async def unlink(self, *names):
+    def unlink(self, *names):
         return self.execute_command("UNLINK", *names)
 
 

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2632,7 +2632,15 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
         await self._execution_strategy.unwatch()
 
     def unlink(self, *names):
-        return self._execution_strategy.unlink(*names)
+        """Unlink a key, staging it like every other pipeline command.
+
+        Deliberately returns None rather than the pipeline. This was an ``async def`` in
+        released versions, so ``await pipe.unlink(key)`` was correct usage; returning the
+        pipeline would make that await run ``ClusterPipeline.__await__`` -> ``initialize()``,
+        which CLEARS the command queue and silently drops every staged command. Returning
+        None makes the removed API fail loudly at the call site instead.
+        """
+        self._execution_strategy.unlink(*names)
 
     def mset_nonatomic(
         self, mapping: Mapping[AnyKeyT, EncodableT]

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3945,6 +3945,22 @@ class TestClusterPipeline:
             pipe.get("a")
             assert await pipe.execute() == [1, None]
 
+    async def test_awaiting_unlink_fails_loudly(self, r: RedisCluster) -> None:
+        """The removed `await pipe.unlink(key)` must raise, not drop the queue.
+
+        unlink() used to be a coroutine function, so awaiting it was correct usage. If it
+        returned the pipeline, that await would run ClusterPipeline.__await__ -> initialize(),
+        which clears _command_queue and silently discards every staged command.
+        """
+        await r.set("a", 1)
+        async with r.pipeline(transaction=False) as pipe:
+            pipe.get("a")
+            with pytest.raises(TypeError):
+                await pipe.unlink("a")
+            # Nothing was lost: the UNLINK staged before the await raised, and the
+            # earlier GET survived because nothing reset the queue.
+            assert await pipe.execute() == [b"1", 1]
+
     async def test_multi_unlink_unsupported(self, r: RedisCluster) -> None:
         """Unlinking several keys at once is not supported in a pipeline."""
         async with r.pipeline(transaction=False) as pipe:

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3924,6 +3924,35 @@ class TestClusterPipeline:
         result = await p.execute()
         assert result == []
 
+    async def test_unlink_single(self, r: RedisCluster) -> None:
+        """
+        unlink() must stage like every other command, without being awaited.
+
+        It was a coroutine function, so `pipe.unlink(key)` written the way
+        `pipe.delete(key)` is written staged nothing and the key survived.
+        """
+        await r.set("a", 1)
+        async with r.pipeline(transaction=False) as pipe:
+            pipe.unlink("a")
+            assert await pipe.execute() == [1]
+        assert await r.exists("a") == 0
+
+    async def test_unlink_keeps_result_positions(self, r: RedisCluster) -> None:
+        """A dropped unlink also shifts every later result left."""
+        await r.set("a", 1)
+        async with r.pipeline(transaction=False) as pipe:
+            pipe.unlink("a")
+            pipe.get("a")
+            assert await pipe.execute() == [1, None]
+
+    async def test_multi_unlink_unsupported(self, r: RedisCluster) -> None:
+        """Unlinking several keys at once is not supported in a pipeline."""
+        async with r.pipeline(transaction=False) as pipe:
+            await r.set("a", 1)
+            await r.set("b", 2)
+            with pytest.raises(RedisClusterException):
+                pipe.unlink("a", "b")
+
     async def test_redis_cluster_pipeline(self, r: RedisCluster) -> None:
         """Test that we can use a pipeline with the RedisCluster class"""
         result = await (


### PR DESCRIPTION
This breaks an API on purpose. `await pipe.unlink(key)` becomes `pipe.unlink(key)`, and anyone already writing it the second way, which is how `delete` is written a few lines above, is silently losing the command.

Updated after review, and the bots were right. My first version returned the pipeline, so `await pipe.unlink(key)` ran `__await__` into `initialize()` and cleared `_command_queue`, dropping every staged command with no error. Worse than the bug. It now returns None, so that call shape raises `TypeError`. The UNLINK still stages before the raise and earlier commands survive, so nothing is lost. Tested.

On the async cluster pipeline `unlink` is the only staging command declared `async def`, and every `execute_command` it reaches is an ordinary function, so the keyword buys nothing while making this the one command that must be awaited. Written like its neighbour, `pipe.unlink(key)` returns an un-awaited coroutine and the key survives.

Later results shift left too. A pipeline of `unlink(k)` then `get(k)` returns one element, so `res[0]` is the GET result. Python prints "coroutine was never awaited", so not perfectly silent, but nothing fails at the call site.

Checked against released wheels on a six node cluster: 6.1.0 deletes the key, 6.2.0 and 8.1.0 do not. `git log -L` puts it on #3649. It survived because the async suite only ever calls `r.unlink` on the client.

The fix makes all five `unlink` definitions ordinary, matching the sync side.

The four added tests fail on master and pass here, and the existing client-level `test_unlink` passes both ways. The file goes 253 to 257, with the same 3 failures and 11 SSL errors before and after.

Two things I left alone: whether any published code awaits this today, and whether you would rather deprecate for a release instead of breaking it now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentional API break: `await pipe.unlink()` now raises, but fixes silent command loss in cluster pipelines—a behavior-sensitive area for anyone relying on the old coroutine shape.
> 
> **Overview**
> Fixes a bug where **`pipe.unlink(key)` on async `ClusterPipeline` never staged UNLINK** because it was the only pipeline staging helper declared as `async def`, unlike neighbors such as `delete`. Callers who mirrored sync-style usage got an un-awaited coroutine and keys were not removed; result positions could shift when later commands ran.
> 
> **`unlink` is now a normal synchronous method** across `ClusterPipeline` and all execution strategies (`ExecutionStrategy`, `AbstractStrategy`, `PipelineStrategy`, `TransactionStrategy`), matching the sync cluster pipeline.
> 
> **`ClusterPipeline.unlink` returns `None` on purpose** (not `self`). Returning the pipeline would make `await pipe.unlink(key)` invoke `__await__` → `initialize()`, which **clears `_command_queue` and drops staged commands**; returning `None` turns that old pattern into a **`TypeError`** while still staging UNLINK before the await fails.
> 
> Four asyncio cluster pipeline tests cover single-key unlink, result ordering, loud failure on `await pipe.unlink`, and rejection of multi-key unlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baabbd58b3857d43a4959d459f46b751fd87fa20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->