### PR TITLE
fix(asyncio): raise on EOF in can_read() so pools replace server-closed connections

### DIFF
--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -547,13 +547,16 @@ class _AsyncRESPBase(AsyncBaseParser):
         # connection state, not only whether application data can be read.
         if not self._connected:
             raise OSError("Buffer is closed.")
+        # buffered data wins over EOF, like the sync SocketBuffer: a pending
+        # response or push notification must stay readable even if the server
+        # has since closed the connection.
+        if self._buffer:
+            return True
         if self._stream.at_eof():
             # Raise like the sync SocketBuffer does on a server-closed
             # connection, so callers that tolerate pending data (push
             # notifications) can't mistake EOF for a readable connection.
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-        if self._buffer:
-            return True
         # asyncio.StreamReader has no public non-destructive API for checking
         # buffered bytes. Preserve dirty-connection detection for the Python
         # parser and fail loudly if the private buffer API changes.

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -547,12 +547,17 @@ class _AsyncRESPBase(AsyncBaseParser):
         # connection state, not only whether application data can be read.
         if not self._connected:
             raise OSError("Buffer is closed.")
+        if self._stream.at_eof():
+            # Raise like the sync SocketBuffer does on a server-closed
+            # connection, so callers that tolerate pending data (push
+            # notifications) can't mistake EOF for a readable connection.
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         if self._buffer:
             return True
         # asyncio.StreamReader has no public non-destructive API for checking
         # buffered bytes. Preserve dirty-connection detection for the Python
         # parser and fail loudly if the private buffer API changes.
-        return bool(self._stream._buffer) or self._stream.at_eof()
+        return bool(self._stream._buffer)
 
     async def _read(self, length: int) -> bytes:
         """

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -323,8 +323,12 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         # connection state, not only whether application data can be read.
         if not self._connected:
             raise OSError("Buffer is closed.")
-        # EOF means the connection is closed and not safe to reuse.
-        if self._reader.has_data() or self._stream.at_eof():
+        if self._stream.at_eof():
+            # Raise like the sync SocketBuffer does on a server-closed
+            # connection, so callers that tolerate pending data (push
+            # notifications) can't mistake EOF for a readable connection.
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+        if self._reader.has_data():
             return True
         # asyncio.StreamReader has no public non-destructive API for checking
         # buffered bytes. Preserve dirty-connection detection for hiredis; tests

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -323,13 +323,16 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         # connection state, not only whether application data can be read.
         if not self._connected:
             raise OSError("Buffer is closed.")
-        if self._stream.at_eof():
-            # Raise like the sync SocketBuffer does on a server-closed
-            # connection, so callers that tolerate pending data (push
-            # notifications) can't mistake EOF for a readable connection.
-            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+        # buffered data wins over EOF, like the sync parser: a pending
+        # response or push notification must stay readable even if the
+        # server has since closed the connection.
         if self._reader.has_data():
             return True
+        if self._stream.at_eof():
+            # Raise like the sync parser does on a server-closed connection,
+            # so callers that tolerate pending data (push notifications)
+            # can't mistake EOF for a readable connection.
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         # asyncio.StreamReader has no public non-destructive API for checking
         # buffered bytes. Preserve dirty-connection detection for hiredis; tests
         # with a real StreamReader guard this private buffer API in CI.

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -109,6 +109,18 @@ async def test_async_hiredis_can_read_raises_on_eof():
     assert stream.read_called is False
 
 
+async def test_async_hiredis_can_read_prefers_buffered_data_over_eof():
+    # a reply or push notification the reader already buffered must stay
+    # readable even if the server has since closed the connection,
+    # matching the sync parser's has_data-first ordering
+    stream = DummyAsyncStream(eof=True)
+    parser = make_async_hiredis_parser(stream, response=b"OK", has_data=True)
+
+    assert await parser.can_read() is True
+    assert await parser.read_response() == b"OK"
+    assert stream.read_called is False
+
+
 async def test_async_hiredis_can_read_detects_reader_response():
     stream = DummyAsyncStream()
     parser = make_async_hiredis_parser(stream, response=b"OK", has_data=True)
@@ -186,6 +198,21 @@ async def test_async_resp_can_read_raises_on_eof(parser_class):
 
     with pytest.raises(ConnectionError):
         await parser.can_read()
+    assert stream.read_called is False
+
+
+@pytest.mark.parametrize("parser_class", [_AsyncRESP2Parser, _AsyncRESP3Parser])
+async def test_async_resp_can_read_prefers_buffered_data_over_eof(parser_class):
+    # data the parser already buffered must stay readable even if the server
+    # has since closed the connection, matching the sync SocketBuffer's
+    # buffer-first ordering
+    stream = DummyAsyncStream(eof=True)
+    parser = parser_class(socket_read_size=65536)
+    parser._connected = True
+    parser._stream = stream
+    parser._buffer = b"+OK\r\n"
+
+    assert await parser.can_read() is True
     assert stream.read_called is False
 
 

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -613,6 +613,41 @@ async def test_pool_auto_close(request, from_url):
     await r1.aclose()
 
 
+@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
+@skip_if_server_version_lt("5.0.0")
+async def test_pool_replaces_connection_killed_while_idle(request):
+    """
+    Regression test for #4252: a pooled connection the server closed while
+    it sat idle (CLIENT KILL, idle timeout, server-side reap) must be
+    replaced at pool checkout instead of failing the next command.
+    Retries are disabled so recovery can only come from the pool.
+    """
+    url: str = request.config.getoption("--redis-url")
+    r = Redis.from_url(url, retry=Retry(NoBackoff(), 0))
+    killer = Redis.from_url(url)
+    try:
+        cid = await r.client_id()
+        conn = r.connection_pool._available_connections[0]
+        assert await killer.client_kill_filter(_id=str(cid))
+
+        # wait until the client's event loop has seen the server-side close
+        deadline = asyncio.get_running_loop().time() + 3
+        while not conn._parser._stream.at_eof():
+            assert asyncio.get_running_loop().time() < deadline, (
+                "server-side kill never surfaced on the client socket"
+            )
+            await asyncio.sleep(0.01)
+
+        # the next command must be served by a healthy replacement connection
+        assert await r.ping()
+    finally:
+        await r.aclose()
+        await r.connection_pool.disconnect()
+        await killer.aclose()
+        await killer.connection_pool.disconnect()
+
+
 async def test_close_is_aclose(request):
     """Verify close() calls aclose()"""
     calls = 0

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -84,20 +84,28 @@ def test_connection_default_parser_matches_default_protocol():
 
 
 @pytest.mark.parametrize(
-    ("buffer", "eof", "expected"),
+    ("buffer", "expected"),
     [
-        (b"", False, False),
-        (b"+OK\r\n", False, True),
-        (b"", True, True),
+        (b"", False),
+        (b"+OK\r\n", True),
     ],
 )
-async def test_async_hiredis_can_read_uses_buffer_without_reading(
-    buffer, eof, expected
-):
-    stream = DummyAsyncStream(buffer=buffer, eof=eof)
+async def test_async_hiredis_can_read_uses_buffer_without_reading(buffer, expected):
+    stream = DummyAsyncStream(buffer=buffer)
     parser = make_async_hiredis_parser(stream)
 
     assert await parser.can_read() is expected
+    assert stream.read_called is False
+
+
+async def test_async_hiredis_can_read_raises_on_eof():
+    # a server-closed connection must raise like the sync SocketBuffer does,
+    # not report readable data (#4252)
+    stream = DummyAsyncStream(eof=True)
+    parser = make_async_hiredis_parser(stream)
+
+    with pytest.raises(ConnectionError):
+        await parser.can_read()
     assert stream.read_called is False
 
 
@@ -164,6 +172,20 @@ async def test_async_resp_can_read_detects_stream_buffer(parser_class):
     parser._stream = stream
 
     assert await parser.can_read() is True
+    assert stream.read_called is False
+
+
+@pytest.mark.parametrize("parser_class", [_AsyncRESP2Parser, _AsyncRESP3Parser])
+async def test_async_resp_can_read_raises_on_eof(parser_class):
+    # a server-closed connection must raise like the sync SocketBuffer does,
+    # not report readable data (#4252)
+    stream = DummyAsyncStream(eof=True)
+    parser = parser_class(socket_read_size=65536)
+    parser._connected = True
+    parser._stream = stream
+
+    with pytest.raises(ConnectionError):
+        await parser.can_read()
     assert stream.read_called is False
 
 

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 import pytest_asyncio
 import redis.asyncio as redis
+from redis._parsers import _AsyncRESP3Parser
 from redis.asyncio.connection import (
     BlockingConnectionPool,
     Connection,
@@ -331,6 +332,58 @@ class TestConnectionPool:
             # Clean up
             for conn in connections:
                 await pool.release(conn)
+
+    @pytest.mark.fixed_client
+    @pytest.mark.parametrize("maint_notifications_enabled", [True, False])
+    async def test_get_connection_replaces_closed_idle_connection(
+        self, maint_notifications_enabled
+    ):
+        """
+        A pooled connection whose socket the server closed while it sat idle
+        must be reconnected at checkout. Regression test for #4252: with
+        maintenance notifications enabled, the pending-push-data exemption
+        must not swallow the EOF signal and hand out the dead connection.
+        """
+        async with self.get_pool(connection_class=redis.Connection) as pool:
+            conn = pool.make_connection()
+            conn.set_parser(_AsyncRESP3Parser)
+
+            # simulate a connection that was healthy when released to the
+            # pool but whose socket the server has since closed
+            eof_stream = asyncio.StreamReader()
+            eof_stream.feed_eof()
+            conn._parser._connected = True
+            conn._parser._stream = eof_stream
+            fake_writer = mock.Mock()
+            fake_writer.wait_closed = AsyncMock(return_value=None)
+            conn._reader = eof_stream
+            conn._writer = fake_writer
+
+            async def fake_connect():
+                # mirror the real connect(): a no-op unless disconnected
+                if conn.is_connected:
+                    return
+                conn._parser._connected = True
+                conn._parser._stream = asyncio.StreamReader()
+                conn._reader = conn._parser._stream
+                conn._writer = fake_writer
+
+            conn.connect = AsyncMock(side_effect=fake_connect)
+            pool._available_connections.append(conn)
+
+            with mock.patch.object(
+                pool,
+                "maint_notifications_enabled",
+                return_value=maint_notifications_enabled,
+            ):
+                checked_out = await pool.get_connection()
+
+            assert checked_out is conn
+            # ensure_connection() detected the EOF and reconnected: once for
+            # the initial ensure, once after discarding the dead socket
+            assert conn.connect.await_count == 2
+            assert conn._parser._stream is not eof_stream
+            await pool.release(conn)
 
 
 class TestBlockingConnectionPool:

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 import pytest
 import pytest_asyncio
 import redis.asyncio as redis
-from redis._parsers import _AsyncRESP3Parser
+from redis._parsers import _AsyncHiredisParser, _AsyncRESP3Parser
+from redis.utils import HIREDIS_AVAILABLE
 from redis.asyncio.connection import (
     BlockingConnectionPool,
     Connection,
@@ -334,9 +335,21 @@ class TestConnectionPool:
                 await pool.release(conn)
 
     @pytest.mark.fixed_client
+    @pytest.mark.parametrize(
+        "parser_class",
+        [
+            _AsyncRESP3Parser,
+            pytest.param(
+                _AsyncHiredisParser,
+                marks=pytest.mark.skipif(
+                    not HIREDIS_AVAILABLE, reason="hiredis is not installed"
+                ),
+            ),
+        ],
+    )
     @pytest.mark.parametrize("maint_notifications_enabled", [True, False])
     async def test_get_connection_replaces_closed_idle_connection(
-        self, maint_notifications_enabled
+        self, maint_notifications_enabled, parser_class
     ):
         """
         A pooled connection whose socket the server closed while it sat idle
@@ -346,7 +359,7 @@ class TestConnectionPool:
         """
         async with self.get_pool(connection_class=redis.Connection) as pool:
             conn = pool.make_connection()
-            conn.set_parser(_AsyncRESP3Parser)
+            conn.set_parser(parser_class)
 
             # simulate a connection that was healthy when released to the
             # pool but whose socket the server has since closed
@@ -354,6 +367,10 @@ class TestConnectionPool:
             eof_stream.feed_eof()
             conn._parser._connected = True
             conn._parser._stream = eof_stream
+            if parser_class is _AsyncHiredisParser:
+                # on_connect() normally creates the hiredis reader; the test
+                # never dials, so give it one with an empty buffer
+                conn._parser._reader = mock.Mock(has_data=mock.Mock(return_value=False))
             fake_writer = mock.Mock()
             fake_writer.wait_closed = AsyncMock(return_value=None)
             conn._reader = eof_stream

--- a/tests/test_asyncio/test_scenario/test_maint_notifications.py
+++ b/tests/test_asyncio/test_scenario/test_maint_notifications.py
@@ -1727,11 +1727,12 @@ class TestAsyncClusterClientCommandsExecutionWithPushNotificationsWithEffectTrig
                     except RedisConnectionError:
                         # remove/failover migrations close connections to the
                         # removed/failed-over node server-side. async can_read()
-                        # reports True on EOF (it also flags a closed/dirty
-                        # connection, not just buffered data), so the drain enters
-                        # read_response() and hits "Connection closed by server".
-                        # A closed connection has nothing left to drain — this is
-                        # expected during the migration, not an unconsumed push.
+                        # reports buffered data first, then raises on EOF (a
+                        # closed connection must not be reused), and
+                        # read_response() hits "Connection closed by server" if
+                        # the close lands mid-read. A closed connection has
+                        # nothing left to drain — this is expected during the
+                        # migration, not an unconsumed push.
                         pass
             logging.info(f"Consumed all buffers for node: {node.name}")
         logging.info("All buffers consumed.")


### PR DESCRIPTION
### Description of change

Fixes #4252.

In `redis.asyncio`, a pooled connection that the server closed while it sat idle (idle timeout, `CLIENT KILL`, server-side reap) is handed out to the next command instead of being replaced, and the command fails with `ConnectionError: Connection closed by server.`. Regression in 8.1.0 under RESP3 (the default); 8.0.1 recovers transparently.

Root cause: the `and not self.maint_notifications_enabled()` guard that #4177 added to `ensure_connection()`'s checkout probe. The async parsers' non-destructive `can_read()` (#4063, shipped in 8.0.1, which recovers correctly) reports a server-closed stream by returning `True` — EOF folded into "has readable data" — and in 8.0.1 that `True` unconditionally hits the `Connection has data` branch, which disconnects and reconnects. With RESP3 over TCP the pool auto-creates `MaintNotificationsConfig(enabled="auto")`, so since #4177 the exemption is on by default and the reconnect branch is never entered: the dead connection passes checkout. RESP2 connections get no maintenance-notifications handler, which is why RESP2 still recovers.

The sync side doesn't have this problem: `SocketBuffer.can_read()` raises `ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)` on EOF, which the pool's `except (ConnectionError, TimeoutError, OSError)` branch turns into disconnect + reconnect regardless of any exemption.

This change makes the async parsers (`_AsyncRESPBase`, `_AsyncHiredisParser`) behave the same way: raise `ConnectionError` on `at_eof()` instead of returning `True`, with already-buffered data still reported first (matching the sync parsers' buffer-first ordering, so a pending reply or push notification is delivered rather than discarded). `ensure_connection()`'s existing reconnect branch then replaces the dead connection whether or not the pending-push-data exemption applies — the closed-connection signal can no longer be swallowed by that guard, rather than only reordering the guard itself. The async `parser.can_read()` is reached only through `Connection.can_read()`, whose only caller is the pool checkout path, so the blast radius is that seam.

Verified with the reproduction from #4252 (server closes the idle pooled connection, health check due): before this change RESP3 raises and RESP2 recovers; after it both recover, and 8.0.1 behavior is restored.

One additional observation from the issue's repro, out of scope here: it passes the sync `redis.retry.Retry` into the async pool. Awaiting the sync `call_with_retry` silently degrades it to a single attempt with no failure callback, which is why the health-check `PING` failure surfaced unretried. With `redis.asyncio.retry.Retry` the client recovers even without this fix (at the cost of a failed attempt and reconnect churn). Filed separately as #4262.

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [N/A] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? 
- [N/A] Is there an example added to the examples folder (if applicable)? 
