### PR TITLE
fix(asyncio): convert synchronous retry policies

### DIFF
--- a/docs/retry.rst
+++ b/docs/retry.rst
@@ -34,6 +34,26 @@ If no ``retry`` is provided, a default one is created with  :class:`~.Exponentia
 and 3 retries.
 
 
+Retry with asyncio
+******************
+
+Async clients use ``redis.asyncio.retry.Retry`` so retry callbacks and backoff
+delays can be awaited:
+
+>>> from redis.asyncio import Redis
+>>> from redis.asyncio.retry import Retry
+>>> from redis.backoff import ExponentialBackoff
+>>>
+>>> retry = Retry(ExponentialBackoff(), 3)
+>>> r = Redis(host='localhost', port=6379, retry=retry)
+
+Passing :class:`redis.retry.Retry` to an async client is supported for
+compatibility, but it is converted to ``redis.asyncio.retry.Retry`` and emits a
+warning. Custom synchronous ``call_with_retry`` implementations cannot be
+preserved by that conversion, so async clients should be configured with an
+async retry policy directly.
+
+
 Retry in Redis Cluster
 **************************
 

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -63,7 +63,7 @@ from redis.asyncio.observability.recorder import (
     record_error_count,
     record_operation_duration,
 )
-from redis.asyncio.retry import Retry
+from redis.asyncio.retry import Retry, _to_async_retry
 from redis.auth.token import TokenInterface
 from redis.backoff import ExponentialWithJitterBackoff, NoBackoff
 from redis.client import EMPTY_RESPONSE, NEVER_DECODE, AbstractRedis
@@ -526,7 +526,7 @@ class RedisCluster(
             kwargs["redis_connect_func"] = self.on_connect
 
         if retry:
-            self.retry = retry
+            self.retry = _to_async_retry(retry)
         else:
             self.retry = Retry(
                 backoff=ExponentialWithJitterBackoff(
@@ -944,7 +944,7 @@ class RedisCluster(
         return self.connection_kwargs
 
     def set_retry(self, retry: Retry) -> None:
-        self.retry = retry
+        self.retry = _to_async_retry(retry)
 
     def set_response_callback(self, command: str, callback: ResponseCallbackT) -> None:
         """Set a custom response callback."""

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -72,7 +72,7 @@ from redis.asyncio.observability.recorder import (
     record_connection_wait_time,
     record_error_count,
 )
-from redis.asyncio.retry import Retry
+from redis.asyncio.retry import Retry, _to_async_retry
 from redis.backoff import NoBackoff
 from redis.credentials import CredentialProvider, UsernamePasswordCredentialProvider
 from redis.exceptions import (
@@ -675,7 +675,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
                 self.retry = Retry(NoBackoff(), 1)
             else:
                 # deep-copy the Retry object as it is mutable
-                self.retry = copy.deepcopy(retry)
+                self.retry = copy.deepcopy(_to_async_retry(retry))
             # Update the retry's supported errors with the specified errors
             self.retry.update_supported_errors(retry_on_error)
         else:
@@ -2629,6 +2629,10 @@ class ConnectionPool(
         if not isinstance(max_connections, int) or max_connections < 0:
             raise ValueError('"max_connections" must be a positive integer')
 
+        retry = connection_kwargs.get("retry")
+        if retry is not None:
+            connection_kwargs["retry"] = _to_async_retry(retry)
+
         self.connection_class = connection_class
         self._connection_kwargs = connection_kwargs
         self.max_connections = max_connections
@@ -2952,6 +2956,8 @@ class ConnectionPool(
         await self.aclose()
 
     def set_retry(self, retry: "Retry") -> None:
+        retry = _to_async_retry(retry)
+        self.connection_kwargs["retry"] = retry
         for conn in self._available_connections:
             conn.retry = retry
         for conn in self._in_use_connections:

--- a/redis/asyncio/multidb/client.py
+++ b/redis/asyncio/multidb/client.py
@@ -12,7 +12,7 @@ from redis.asyncio.multidb.config import (
 from redis.asyncio.multidb.database import AsyncDatabase, Database, Databases
 from redis.asyncio.multidb.failure_detector import AsyncFailureDetector
 from redis.asyncio.multidb.healthcheck import HealthCheck, HealthCheckPolicy
-from redis.asyncio.retry import Retry
+from redis.asyncio.retry import Retry, _to_async_retry
 from redis.background import BackgroundScheduler
 from redis.backoff import NoBackoff
 from redis.commands import AsyncCoreCommands, AsyncRedisModuleCommands
@@ -63,7 +63,7 @@ class MultiDBClient(AsyncRedisModuleCommands, AsyncCoreCommands):
         self._failover_strategy.set_databases(self._databases)
         self._auto_fallback_interval = config.auto_fallback_interval
         self._event_dispatcher = config.event_dispatcher
-        self._command_retry = config.command_retry
+        self._command_retry = _to_async_retry(config.command_retry)
         self._command_retry.update_supported_errors([ConnectionRefusedError])
         self.command_executor = DefaultCommandExecutor(
             failure_detectors=self._failure_detectors,

--- a/redis/asyncio/retry.py
+++ b/redis/asyncio/retry.py
@@ -1,5 +1,4 @@
 from asyncio import sleep
-from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -93,7 +92,7 @@ def _to_async_retry(retry: AbstractRetry) -> Retry:
         raise TypeError("retry must be an instance of redis.asyncio.retry.Retry")
 
     return Retry(
-        backoff=deepcopy(retry._backoff),
+        backoff=retry._backoff,
         retries=retry._retries,
         supported_errors=retry._supported_errors,
     )

--- a/redis/asyncio/retry.py
+++ b/redis/asyncio/retry.py
@@ -1,4 +1,6 @@
+import warnings
 from asyncio import sleep
+from inspect import iscoroutinefunction
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -84,12 +86,20 @@ class Retry(AbstractRetry[RedisError]):
                     await sleep(backoff)
 
 
-def _to_async_retry(retry: AbstractRetry) -> Retry:
-    """Return an async retry policy equivalent to ``retry``."""
-    if isinstance(retry, Retry):
+def _to_async_retry(retry: Any) -> Any:
+    """Convert a synchronous retry policy while preserving async-shaped ones."""
+    if iscoroutinefunction(getattr(type(retry), "call_with_retry", None)):
         return retry
     if not isinstance(retry, AbstractRetry):
-        raise TypeError("retry must be an instance of redis.asyncio.retry.Retry")
+        return retry
+
+    warnings.warn(
+        "A synchronous redis.retry.Retry was passed to an asyncio client and has "
+        "been converted to redis.asyncio.retry.Retry. A custom call_with_retry "
+        "implementation is not preserved - please use redis.asyncio.retry.Retry.",
+        UserWarning,
+        stacklevel=2,
+    )
 
     return Retry(
         backoff=retry._backoff,

--- a/redis/asyncio/retry.py
+++ b/redis/asyncio/retry.py
@@ -1,4 +1,5 @@
 from asyncio import sleep
+from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -82,3 +83,17 @@ class Retry(AbstractRetry[RedisError]):
                 backoff = self._backoff.compute(failures)
                 if backoff > 0:
                     await sleep(backoff)
+
+
+def _to_async_retry(retry: AbstractRetry) -> Retry:
+    """Return an async retry policy equivalent to ``retry``."""
+    if isinstance(retry, Retry):
+        return retry
+    if not isinstance(retry, AbstractRetry):
+        raise TypeError("retry must be an instance of redis.asyncio.retry.Retry")
+
+    return Retry(
+        backoff=deepcopy(retry._backoff),
+        retries=retry._retries,
+        supported_errors=retry._supported_errors,
+    )

--- a/tests/test_asyncio/test_multidb/test_client.py
+++ b/tests/test_asyncio/test_multidb/test_client.py
@@ -10,6 +10,8 @@ from redis.asyncio.multidb.database import AsyncDatabase
 from redis.asyncio.multidb.failover import WeightBasedFailoverStrategy
 from redis.asyncio.multidb.failure_detector import AsyncFailureDetector
 from redis.asyncio.multidb.healthcheck import HealthCheck
+from redis.asyncio.retry import Retry
+from redis.backoff import NoBackoff
 from redis.event import EventDispatcher, AsyncOnCommandsFailEvent
 from redis.multidb.circuit import State as CBState, PBCircuitBreakerAdapter
 from redis.multidb.config import DatabaseConfig
@@ -18,12 +20,24 @@ from redis.multidb.exception import (
     UnhealthyDatabaseException,
     InitialHealthCheckFailedError,
 )
+from redis.retry import Retry as SyncRetry
 from tests.test_asyncio.helpers import wait_for_condition
 from tests.test_asyncio.test_multidb.conftest import create_weighted_list
 
 
 @pytest.mark.fixed_client
 class TestMultiDbClient:
+    @pytest.mark.parametrize("mock_multi_db_config,mock_db", [({}, {})], indirect=True)
+    def test_sync_retry_is_converted(self, mock_multi_db_config, mock_db):
+        mock_multi_db_config.command_retry = SyncRetry(NoBackoff(), 2)
+        databases = create_weighted_list(mock_db)
+
+        with patch.object(mock_multi_db_config, "databases", return_value=databases):
+            client = MultiDBClient(mock_multi_db_config)
+
+        assert isinstance(client._command_retry, Retry)
+        assert client._command_retry.get_retries() == 2
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "mock_multi_db_config,mock_db, mock_db1, mock_db2",

--- a/tests/test_asyncio/test_multidb/test_client.py
+++ b/tests/test_asyncio/test_multidb/test_client.py
@@ -32,8 +32,11 @@ class TestMultiDbClient:
         mock_multi_db_config.command_retry = SyncRetry(NoBackoff(), 2)
         databases = create_weighted_list(mock_db)
 
-        with patch.object(mock_multi_db_config, "databases", return_value=databases):
-            client = MultiDBClient(mock_multi_db_config)
+        with pytest.warns(UserWarning, match="synchronous redis.retry.Retry"):
+            with patch.object(
+                mock_multi_db_config, "databases", return_value=databases
+            ):
+                client = MultiDBClient(mock_multi_db_config)
 
         assert isinstance(client._command_retry, Retry)
         assert client._command_retry.get_retries() == 2

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -1,3 +1,5 @@
+from threading import Lock
+
 import pytest
 from redis.asyncio import Redis, RedisCluster
 from redis.asyncio.connection import Connection, UnixDomainSocketConnection
@@ -18,6 +20,15 @@ class BackoffMock(AbstractBackoff):
     def compute(self, failures):
         self.calls += 1
         return 0
+
+
+class UncopyableBackoff(AbstractBackoff):
+    def __init__(self):
+        self._lock = Lock()
+
+    def compute(self, failures):
+        with self._lock:
+            return 0
 
 
 @pytest.mark.fixed_client
@@ -122,6 +133,15 @@ class TestConnectionConstructorWithRetry:
 
         assert isinstance(client.retry, Retry)
         assert client.retry.get_retries() == new_retry.get_retries()
+
+    def test_cluster_preserves_uncopyable_sync_backoff(self):
+        backoff = UncopyableBackoff()
+        retry = SyncRetry(backoff, 2)
+
+        client = RedisCluster(host="127.0.0.1", port=6379, retry=retry)
+
+        assert isinstance(client.retry, Retry)
+        assert client.retry._backoff is backoff
 
 
 @pytest.mark.fixed_client

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -1,11 +1,17 @@
+import warnings
 from threading import Lock
 
 import pytest
 from redis.asyncio import Redis, RedisCluster
-from redis.asyncio.connection import Connection, UnixDomainSocketConnection
+from redis.asyncio.connection import (
+    Connection,
+    ConnectionPool,
+    UnixDomainSocketConnection,
+)
 from redis.asyncio.retry import Retry
 from redis.backoff import AbstractBackoff, ExponentialBackoff, NoBackoff
 from redis.exceptions import ConnectionError, TimeoutError
+from redis.retry import AbstractRetry
 from redis.retry import Retry as SyncRetry
 
 
@@ -29,6 +35,28 @@ class UncopyableBackoff(AbstractBackoff):
     def compute(self, failures):
         with self._lock:
             return 0
+
+
+class CustomAsyncRetry(AbstractRetry):
+    def __init__(self):
+        super().__init__(NoBackoff(), 1, (ConnectionError,))
+
+    def __eq__(self, other):
+        return self is other
+
+    async def call_with_retry(self, do, fail, **kwargs):
+        return await do()
+
+
+class DuckTypedAsyncRetry:
+    async def call_with_retry(self, do, fail, **kwargs):
+        return await do()
+
+    def get_retries(self):
+        return 1
+
+    def update_supported_errors(self, specified_errors):
+        pass
 
 
 @pytest.mark.fixed_client
@@ -86,50 +114,91 @@ class TestConnectionConstructorWithRetry:
 
     @pytest.mark.parametrize("Class", [Connection, UnixDomainSocketConnection])
     @pytest.mark.asyncio
-    async def test_sync_retry_is_converted(self, Class):
+    async def test_sync_retry_is_used_by_connect(self, Class, monkeypatch):
         retry = SyncRetry(NoBackoff(), 2)
-        connection = Class(retry=retry)
+        with pytest.warns(UserWarning, match="synchronous redis.retry.Retry"):
+            connection = Class(retry=retry)
         attempts = 0
         failures = 0
 
-        async def do():
+        async def connect_check_health(
+            _self, check_health=True, retry_socket_connect=True
+        ):
             nonlocal attempts
             attempts += 1
-            raise ConnectionError
+            if attempts < 3:
+                raise ConnectionError
 
-        async def fail(_error):
+        async def disconnect(_self, *args, **kwargs):
             nonlocal failures
             failures += 1
 
+        monkeypatch.setattr(Class, "connect_check_health", connect_check_health)
+        monkeypatch.setattr(Class, "disconnect", disconnect)
+
         assert isinstance(connection.retry, Retry)
-        with pytest.raises(ConnectionError):
-            await connection.retry.call_with_retry(do, fail)
+        await connection.connect()
 
         assert attempts == 3
-        assert failures == 3
+        assert failures == 2
+
+    @pytest.mark.asyncio
+    async def test_pool_from_url_converts_sync_retry(self, monkeypatch):
+        retry = SyncRetry(NoBackoff(), 2)
+        with pytest.warns(UserWarning, match="synchronous redis.retry.Retry"):
+            pool = ConnectionPool.from_url(
+                "redis://localhost:6379",
+                retry=retry,
+                retry_on_error=[ConnectionError],
+            )
+
+        async def ensure_connection(_self, _connection):
+            pass
+
+        monkeypatch.setattr(ConnectionPool, "ensure_connection", ensure_connection)
+        connection = await pool.get_connection()
+
+        assert isinstance(connection.retry, Retry)
+        assert connection.retry.get_retries() == 2
+        assert ConnectionError in connection.retry._supported_errors
+
+        await pool.release(connection)
+        await pool.aclose()
+
+    @pytest.mark.parametrize("retry", [CustomAsyncRetry(), DuckTypedAsyncRetry()])
+    def test_async_shaped_retry_is_preserved(self, retry):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            pool = ConnectionPool(retry=retry)
+
+        assert pool.connection_kwargs["retry"] is retry
 
     def test_pool_converts_sync_retry(self):
         retry = SyncRetry(NoBackoff(), 2)
-        client = Redis(retry=retry)
+        with pytest.warns(UserWarning, match="synchronous redis.retry.Retry"):
+            client = Redis(retry=retry)
 
         assert isinstance(client.get_retry(), Retry)
         assert client.get_retry().get_retries() == retry.get_retries()
 
         new_retry = SyncRetry(ExponentialBackoff(), 3)
-        client.set_retry(new_retry)
+        with pytest.warns(UserWarning, match="synchronous redis.retry.Retry"):
+            client.set_retry(new_retry)
 
         assert isinstance(client.get_retry(), Retry)
         assert client.get_retry().get_retries() == new_retry.get_retries()
 
     def test_cluster_converts_sync_retry(self):
         retry = SyncRetry(NoBackoff(), 2)
-        client = RedisCluster(host="127.0.0.1", port=6379, retry=retry)
+        with pytest.warns(UserWarning, match="synchronous redis.retry.Retry"):
+            client = RedisCluster(host="127.0.0.1", port=6379, retry=retry)
 
         assert isinstance(client.retry, Retry)
         assert client.retry.get_retries() == retry.get_retries()
 
         new_retry = SyncRetry(ExponentialBackoff(), 3)
-        client.set_retry(new_retry)
+        with pytest.warns(UserWarning, match="synchronous redis.retry.Retry"):
+            client.set_retry(new_retry)
 
         assert isinstance(client.retry, Retry)
         assert client.retry.get_retries() == new_retry.get_retries()
@@ -138,7 +207,8 @@ class TestConnectionConstructorWithRetry:
         backoff = UncopyableBackoff()
         retry = SyncRetry(backoff, 2)
 
-        client = RedisCluster(host="127.0.0.1", port=6379, retry=retry)
+        with pytest.warns(UserWarning, match="synchronous redis.retry.Retry"):
+            client = RedisCluster(host="127.0.0.1", port=6379, retry=retry)
 
         assert isinstance(client.retry, Retry)
         assert client.retry._backoff is backoff

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -1,9 +1,10 @@
 import pytest
-from redis.asyncio import Redis
+from redis.asyncio import Redis, RedisCluster
 from redis.asyncio.connection import Connection, UnixDomainSocketConnection
 from redis.asyncio.retry import Retry
 from redis.backoff import AbstractBackoff, ExponentialBackoff, NoBackoff
 from redis.exceptions import ConnectionError, TimeoutError
+from redis.retry import Retry as SyncRetry
 
 
 class BackoffMock(AbstractBackoff):
@@ -71,6 +72,56 @@ class TestConnectionConstructorWithRetry:
         assert isinstance(c.retry, Retry)
         assert c.retry._retries == retries
         assert set(c.retry._supported_errors) == set(retry_on_error)
+
+    @pytest.mark.parametrize("Class", [Connection, UnixDomainSocketConnection])
+    @pytest.mark.asyncio
+    async def test_sync_retry_is_converted(self, Class):
+        retry = SyncRetry(NoBackoff(), 2)
+        connection = Class(retry=retry)
+        attempts = 0
+        failures = 0
+
+        async def do():
+            nonlocal attempts
+            attempts += 1
+            raise ConnectionError
+
+        async def fail(_error):
+            nonlocal failures
+            failures += 1
+
+        assert isinstance(connection.retry, Retry)
+        with pytest.raises(ConnectionError):
+            await connection.retry.call_with_retry(do, fail)
+
+        assert attempts == 3
+        assert failures == 3
+
+    def test_pool_converts_sync_retry(self):
+        retry = SyncRetry(NoBackoff(), 2)
+        client = Redis(retry=retry)
+
+        assert isinstance(client.get_retry(), Retry)
+        assert client.get_retry().get_retries() == retry.get_retries()
+
+        new_retry = SyncRetry(ExponentialBackoff(), 3)
+        client.set_retry(new_retry)
+
+        assert isinstance(client.get_retry(), Retry)
+        assert client.get_retry().get_retries() == new_retry.get_retries()
+
+    def test_cluster_converts_sync_retry(self):
+        retry = SyncRetry(NoBackoff(), 2)
+        client = RedisCluster(host="127.0.0.1", port=6379, retry=retry)
+
+        assert isinstance(client.retry, Retry)
+        assert client.retry.get_retries() == retry.get_retries()
+
+        new_retry = SyncRetry(ExponentialBackoff(), 3)
+        client.set_retry(new_retry)
+
+        assert isinstance(client.retry, Retry)
+        assert client.retry.get_retries() == new_retry.get_retries()
 
 
 @pytest.mark.fixed_client

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -59,6 +59,17 @@ class DuckTypedAsyncRetry:
         pass
 
 
+class DuckTypedAwaitableRetry:
+    def call_with_retry(self, do, fail, **kwargs):
+        return do()
+
+    def get_retries(self):
+        return 1
+
+    def update_supported_errors(self, specified_errors):
+        pass
+
+
 @pytest.mark.fixed_client
 class TestConnectionConstructorWithRetry:
     "Test that the Connection constructors properly handles Retry objects"
@@ -165,13 +176,34 @@ class TestConnectionConstructorWithRetry:
         await pool.release(connection)
         await pool.aclose()
 
-    @pytest.mark.parametrize("retry", [CustomAsyncRetry(), DuckTypedAsyncRetry()])
+    @pytest.mark.parametrize(
+        "retry",
+        [CustomAsyncRetry(), DuckTypedAsyncRetry(), DuckTypedAwaitableRetry()],
+    )
     def test_async_shaped_retry_is_preserved(self, retry):
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             pool = ConnectionPool(retry=retry)
 
         assert pool.connection_kwargs["retry"] is retry
+
+    @pytest.mark.asyncio
+    async def test_pool_set_retry_applies_to_new_connection(self, monkeypatch):
+        pool = ConnectionPool()
+        retry = Retry(NoBackoff(), 2)
+        pool.set_retry(retry)
+
+        async def ensure_connection(_self, _connection):
+            pass
+
+        monkeypatch.setattr(ConnectionPool, "ensure_connection", ensure_connection)
+        connection = await pool.get_connection()
+
+        assert connection.retry.get_retries() == retry.get_retries()
+        assert isinstance(connection.retry._backoff, NoBackoff)
+
+        await pool.release(connection)
+        await pool.aclose()
 
     def test_pool_converts_sync_retry(self):
         retry = SyncRetry(NoBackoff(), 2)


### PR DESCRIPTION
### Description of change

Passing `redis.retry.Retry` to an asyncio client currently appears valid but bypasses the retry loop and failure callback because its synchronous wrapper returns the coroutine before observing failures. This converts synchronous retry policies at the asyncio connection, pool, cluster, and MultiDB boundaries while preserving their backoff, retry count, and supported errors.

The regression coverage verifies both the stored policy type and the actual three-attempt/three-callback behavior.

Fixes #4262.

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (CI is starting on this PR)
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (not applicable; no public API is added or changed)
- [x] Is there an example added to the examples folder (not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how retry policies are applied on asyncio connections and cluster/MultiDB clients, which can alter reconnect behavior. Conversion is compatibility-oriented and covered by tests, but custom sync retry implementations are intentionally dropped.
> 
> **Overview**
> Fixes a bug where passing `redis.retry.Retry` into asyncio clients looked valid but skipped the async retry loop (the sync wrapper returned a coroutine without observing failures).
> 
> Async connection, pool, cluster, and MultiDB now convert sync policies via `_to_async_retry`, keeping backoff, retry count, and supported errors, and warning that custom `call_with_retry` is not preserved. Already-async or duck-typed retry objects are left unchanged. Docs describe the conversion and recommend configuring `redis.asyncio.retry.Retry` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8448a6af568ca84687036a525d76aed1dd627758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->