### PR TITLE
docs(cluster): say which async ClusterPipeline methods must be awaited

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2468,6 +2468,28 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
     Note: For commands `DELETE`, `EXISTS`, `TOUCH`, `UNLINK`, `mset_nonatomic`, which
     are split across multiple nodes, you'll get multiple results for them in the array.
 
+    Which methods must be awaited:
+
+    Outside a transactional block, staging a command returns the pipeline itself, so
+    commands chain and are not awaited, as in the example above. These methods are
+    coroutines and must be awaited individually::
+
+        watch, unwatch, unlink, discard, reset, execute, initialize,
+        himport_prepare, himport_discard, himport_discard_all
+
+    They return ``None`` rather than the pipeline, so they do not chain even once
+    awaited. `unlink` is the surprising one, because `delete` sits beside it in the note
+    above and behaves the other way::
+
+        pipe = rc.pipeline()
+        pipe.delete("A")          # stages, chainable
+        await pipe.unlink("B")    # stages, must be awaited, returns None
+        await pipe.execute()
+
+    Inside a transactional block opened with :meth:`multi`, commands are sent as they
+    are issued and return a response instead of the pipeline, so they do not chain
+    there either.
+
     Retryable errors:
         - :class:`~.ClusterDownError`
         - :class:`~.ConnectionError`
@@ -2621,7 +2643,7 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
         self._execution_strategy.multi()
 
     async def discard(self):
-        """ """
+        """Discards the transactional block. Must be awaited."""
         await self._execution_strategy.discard()
 
     async def watch(self, *names):
@@ -2633,6 +2655,15 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
         await self._execution_strategy.unwatch()
 
     async def unlink(self, *names):
+        """
+        Stages an `UNLINK` for keys ``names``. Must be awaited, and returns ``None``
+        rather than the pipeline, so unlike `delete` it does not chain::
+
+            await pipe.unlink("A")
+
+        Outside a transactional block only one key is accepted; more raises
+        :class:`~.RedisClusterException`.
+        """
         await self._execution_strategy.unlink(*names)
 
     def mset_nonatomic(

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2470,25 +2470,42 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
 
     Which methods must be awaited:
 
-    Outside a transactional block, staging a command returns the pipeline itself, so
-    commands chain and are not awaited, as in the example above. These methods are
-    coroutines and must be awaited individually::
+    Staging a command returns the pipeline itself, so commands chain and are not
+    awaited, as in the example above. The coroutines defined on this class must be
+    awaited individually::
 
         watch, unwatch, unlink, discard, reset, execute, initialize,
         himport_prepare, himport_discard, himport_discard_all
 
-    They return ``None`` rather than the pipeline, so they do not chain even once
-    awaited. `unlink` is the surprising one, because `delete` sits beside it in the note
-    above and behaves the other way::
+    Of those, only ``reset``, ``discard``, ``watch``, ``unwatch`` and ``unlink`` return
+    ``None``, so only they fail to chain once awaited. The rest return a value:
+    ``execute`` a ``list``, ``initialize`` the pipeline, ``himport_prepare`` a ``bool``
+    and the two ``himport_discard`` methods an ``int``. Inherited command coroutines
+    such as ``command_info``, ``cluster_delslots``, ``client_tracking_on`` and the
+    ``hotkeys_*`` family must be awaited too and are not listed here.
+
+    `unlink` is the surprising one, because `delete` sits beside it in the note above
+    and behaves the other way::
 
         pipe = rc.pipeline()
         pipe.delete("A")          # stages, chainable
         await pipe.unlink("B")    # stages, must be awaited, returns None
         await pipe.execute()
 
-    Inside a transactional block opened with :meth:`multi`, commands are sent as they
-    are issued and return a response instead of the pipeline, so they do not chain
-    there either.
+    Between :meth:`watch` and :meth:`multi` commands are sent as they are issued and
+    return a response rather than the pipeline, so they must be awaited. After
+    :meth:`multi` they are queued again and chain as usual::
+
+        async with rc.pipeline(transaction=True) as pipe:
+            await pipe.watch("a")
+            a = await pipe.get("a")     # sent now, so awaited
+            pipe.multi()
+            pipe.set("a", int(a) + 1)   # queued, chains
+            await pipe.execute()
+
+    Outside a transactional pipeline ``watch``, ``unwatch`` and ``discard`` raise
+    :class:`~.RedisClusterException`, and the ``himport_*`` methods act on the shared
+    fieldset registry rather than staging a command.
 
     Retryable errors:
         - :class:`~.ClusterDownError`

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2480,9 +2480,12 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
     Of those, only ``reset``, ``discard``, ``watch``, ``unwatch`` and ``unlink`` return
     ``None``, so only they fail to chain once awaited. The rest return a value:
     ``execute`` a ``list``, ``initialize`` the pipeline, ``himport_prepare`` a ``bool``
-    and the two ``himport_discard`` methods an ``int``. Inherited command coroutines
-    such as ``command_info``, ``cluster_delslots``, ``client_tracking_on`` and the
-    ``hotkeys_*`` family must be awaited too and are not listed here.
+    and the two ``himport_discard`` methods an ``int``.
+
+    That list covers only the methods defined on this class. Inherited command
+    coroutines such as ``command_info``, ``cluster_delslots``, ``client_tracking_on``
+    and the ``hotkeys_*`` family are not pipeline steps: awaiting one awaits the
+    pipeline itself, which re-initializes it and discards everything staged so far.
 
     `unlink` is the surprising one, because `delete` sits beside it in the note above
     and behaves the other way::

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3728,7 +3728,7 @@ class ClusterPipeline(RedisCluster):
         self._execution_strategy.load_scripts()
 
     def discard(self):
-        """ """
+        """Discards the transactional block."""
         self._execution_strategy.discard()
 
     def watch(self, *names):
@@ -3746,6 +3746,15 @@ class ClusterPipeline(RedisCluster):
         self._execution_strategy.delete(*names)
 
     def unlink(self, *names):
+        """
+        Stages an `UNLINK` for keys ``names``, and returns ``None`` rather than the
+        pipeline, so unlike `delete` it does not chain::
+
+            pipe.unlink("A")
+
+        Outside a transactional block only one key is accepted; more raises
+        :class:`~.RedisClusterException`.
+        """
         self._execution_strategy.unlink(*names)
 
 


### PR DESCRIPTION
Follow-up you invited on #4259: making it clear which `ClusterPipeline` methods have to be awaited.

The confusion is visible in the class docstring itself. The usage example chains `.delete("A", "B", "K").execute()` without awaiting the `delete`, and the note underneath lists `UNLINK` right beside `DELETE` as though the two behave alike. They do not. `unlink` is a coroutine that returns `None`, so it neither chains nor stages anything unless you await it.

So the docstring now lists the ten coroutine methods, says plainly that they return `None` instead of the pipeline, and shows the contrast:

```python
pipe = rc.pipeline()
pipe.delete("A")          # stages, chainable
await pipe.unlink("B")    # stages, must be awaited, returns None
await pipe.execute()
```

While checking the claim I found a third case worth a line: inside a `multi()` block, `TransactionStrategy` overrides `execute_command` and returns a response instead of the pipeline, so commands do not chain there either. My first draft said staged commands always return the pipeline, which was wrong outside the default strategy.

Also filled in two gaps next door: `discard()` had an empty docstring, and `unlink()` had none. The `unlink` one records that outside a transaction it takes a single key and raises `RedisClusterException` for more, which is currently only discoverable by reading `PipelineStrategy`.

Docs only, no behaviour change. `ruff check` and `vulture --min-confidence 80` are clean. `ruff format --check` reports this file, but it does so on an unmodified checkout too, so I left it alone instead of reformatting code I did not touch.

The list of ten was generated from the class, not typed by hand, so it includes the `himport_*` methods I would otherwise have missed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> **Async `ClusterPipeline`** gets a new docstring section that lists the ten coroutine methods that must be awaited individually, which of those return `None` (breaking chaining), and warns that inherited command coroutines are not pipeline steps—awaiting them re-initializes the pipeline.
> 
> It also documents the **`unlink` vs `delete`** contrast (delete chains; async `unlink` must be awaited), **WATCH → MULTI** behavior (commands between them run immediately and must be awaited; after `multi()` staging chains again), and notes on non-transactional `watch`/`unwatch`/`discard` and `himport_*` registry behavior.
> 
> **`discard()`** and **`unlink()`** docstrings are filled in on both **async** (`redis/asyncio/cluster.py`) and **sync** (`redis/cluster.py`) cluster pipelines, including the single-key-only `unlink` rule outside transactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c81c478f4be5b8a18903194f7511ea57e99841e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->