### PR TITLE
feat: support cluster topology discovery via CLUSTER SHARDS command

### DIFF
--- a/docs/clustering.rst
+++ b/docs/clustering.rst
@@ -195,6 +195,65 @@ that currently owns its slot and re-routes it when the topology changes; see
 the sharded pubsub section of :doc:`advanced_features` for that behavior and
 what it means for the errors ``get_sharded_message()`` raises.
 
+Topology Discovery
+------------------
+
+On initialization, and on every topology refresh, the client asks one of the
+cluster's nodes which nodes own which slots. By default it uses ``CLUSTER
+SLOTS``, which returns one entry per contiguous slot range.
+
+``CLUSTER SHARDS`` is available as an alternative. It returns one entry per
+*shard* rather than per slot range, so its reply stays compact on clusters whose
+slot ranges have become fragmented — typically after resharding. On a freshly
+built cluster with contiguous ranges the two commands are close to equivalent,
+so this is a tuning option for a specific class of deployment rather than a
+universal improvement. ``CLUSTER SHARDS`` requires Redis 7.0 or later.
+
+Pass a provider to opt in. Both providers produce the same slot mapping, so
+switching is transparent to the rest of the client:
+
+.. code:: python
+
+   >>> from redis.cluster import RedisCluster as Redis
+   >>> from redis.cluster_topology import ClusterShardsTopologyProvider
+   >>> rc = Redis(host='localhost', port=6379,
+   ...            topology_provider=ClusterShardsTopologyProvider())
+
+The async client takes the async provider of the same name:
+
+.. code:: python
+
+   >>> from redis.asyncio.cluster import RedisCluster as Redis
+   >>> from redis.cluster_topology import AsyncClusterShardsTopologyProvider
+   >>> rc = Redis(host='localhost', port=6379,
+   ...            topology_provider=AsyncClusterShardsTopologyProvider())
+
+Unlike ``CLUSTER SLOTS``, ``CLUSTER SHARDS`` reports a health status per node.
+Replicas reported as ``failed`` or ``loading`` are left out of the slot mapping
+so that reads are not routed to them. A primary is always kept regardless of its
+health, because dropping it would leave its slots uncovered and, with
+``require_full_coverage=True``, turn a transient state into a connection error.
+
+If your cluster's nodes advertise a TLS port, ask the provider for it:
+
+.. code:: python
+
+   >>> ClusterShardsTopologyProvider(prefer_tls_port=True)
+
+To discover topology some other way — for example from a service registry —
+subclass ``ClusterTopologyProvider``, name the command to issue, and return one
+``(start_slot, end_slot, primary, replicas)`` tuple per slot range:
+
+.. code:: python
+
+   >>> from redis.cluster_topology import ClusterTopologyProvider
+   >>>
+   >>> class MyTopologyProvider(ClusterTopologyProvider):
+   ...     command = ("CLUSTER SLOTS",)
+   ...
+   ...     def parse(self, response):
+   ...         return [(0, 16383, ("10.0.0.1", 6379), [("10.0.0.2", 6379)])]
+
 Known PubSub Limitations
 ------------------------
 

--- a/docs/connections.rst
+++ b/docs/connections.rst
@@ -51,6 +51,21 @@ ClusterNode
 .. autoclass:: redis.cluster.ClusterNode
     :members:
 
+Topology Providers
+==================
+
+Selects the command used to discover which nodes own which slots. See
+`Topology Discovery <clustering.html#topology-discovery>`__.
+
+.. autoclass:: redis.cluster_topology.ClusterTopologyProvider
+    :members:
+
+.. autoclass:: redis.cluster_topology.ClusterSlotsTopologyProvider
+    :members:
+
+.. autoclass:: redis.cluster_topology.ClusterShardsTopologyProvider
+    :members:
+
 
 Async Client
 ************
@@ -83,6 +98,17 @@ ClusterPipeline (Async)
 .. autoclass:: redis.asyncio.cluster.ClusterPipeline
     :members: execute_command, execute
     :member-order: bysource
+
+Topology Providers (Async)
+==========================
+.. autoclass:: redis.cluster_topology.AsyncClusterTopologyProvider
+    :members:
+
+.. autoclass:: redis.cluster_topology.AsyncClusterSlotsTopologyProvider
+    :members:
+
+.. autoclass:: redis.cluster_topology.AsyncClusterShardsTopologyProvider
+    :members:
 
 
 Connection

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -84,6 +84,10 @@ from redis.cluster import (
     parse_cluster_shards_with_str_keys,
     parse_cluster_slots,
 )
+from redis.cluster_topology import (
+    AsyncClusterSlotsTopologyProvider,
+    AsyncClusterTopologyProvider,
+)
 from redis.commands import AsyncRedisClusterCommands
 from redis.commands.helpers import list_or_args, parse_pubsub_subscriptions
 from redis.commands.metadata import (
@@ -530,6 +534,9 @@ class RedisCluster(
         address_remap: Callable[[Tuple[str, int]], Tuple[str, int]] | None = None,
         event_dispatcher: EventDispatcher | None = None,
         policy_resolver: AsyncPolicyResolver | None = None,
+        topology_provider: AsyncClusterTopologyProvider = (
+            AsyncClusterSlotsTopologyProvider()
+        ),
         maint_notifications_config: MaintNotificationsConfig | None = None,
         metadata_resolver: AsyncMetadataResolver | None = None,
     ) -> None:
@@ -679,6 +686,7 @@ class RedisCluster(
             dynamic_startup_nodes=dynamic_startup_nodes,
             address_remap=address_remap,
             event_dispatcher=self._event_dispatcher,
+            topology_provider=topology_provider,
         )
         AsyncMaintNotificationsAbstractRedisCluster.__init__(
             self,
@@ -2245,6 +2253,7 @@ class NodesManager:
         "slots_cache",
         "startup_nodes",
         "address_remap",
+        "_topology_provider",
     )
 
     def __init__(
@@ -2255,11 +2264,15 @@ class NodesManager:
         dynamic_startup_nodes: bool = True,
         address_remap: Optional[Callable[[Tuple[str, int]], Tuple[str, int]]] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
+        topology_provider: AsyncClusterTopologyProvider = (
+            AsyncClusterSlotsTopologyProvider()
+        ),
     ) -> None:
         self.startup_nodes = {node.name: node for node in startup_nodes}
         self.require_full_coverage = require_full_coverage
         self.connection_kwargs = connection_kwargs
         self.address_remap = address_remap
+        self._topology_provider = topology_provider
 
         self.default_node: "ClusterNode" = None
         self.nodes_cache: Dict[str, "ClusterNode"] = {}
@@ -2519,11 +2532,12 @@ class NodesManager:
                         )
                         if logger.isEnabledFor(logging.DEBUG):
                             logger.debug(
-                                "Topology refresh: querying CLUSTER SLOTS on "
+                                "Topology refresh: querying "
+                                f"{' '.join(self._topology_provider.command)} on "
                                 f"{startup_node.name}"
                             )
-                        cluster_slots = await startup_node.execute_command(
-                            "CLUSTER SLOTS"
+                        topology_response = await startup_node.execute_command(
+                            *self._topology_provider.command
                         )
                     except ResponseError:
                         raise RedisClusterException(
@@ -2541,28 +2555,16 @@ class NodesManager:
                     exception = e
                     continue
 
-                # CLUSTER SLOTS command results in the following output:
-                # [[slot_section[from_slot,to_slot,master,replica1,...,replicaN]]]
-                # where each node contains the following list: [IP, port, node_id]
-                # Therefore, cluster_slots[0][2][0] will be the IP address of the
-                # primary node of the first slot section.
-                # If there's only one server in the cluster, its ``host`` is ''
-                # Fix it to the host in startup_nodes
-                if (
-                    len(cluster_slots) == 1
-                    and not cluster_slots[0][2][0]
-                    and len(self.startup_nodes) == 1
-                ):
-                    cluster_slots[0][2][0] = startup_node.host
-
-                for slot in cluster_slots:
-                    for i in range(2, len(slot)):
-                        slot[i] = [str_if_bytes(val) for val in slot[i]]
-                    primary_node = slot[2]
-                    host = primary_node[0]
+                for (
+                    start_slot,
+                    end_slot,
+                    primary,
+                    replicas,
+                ) in self._topology_provider.parse(topology_response):
+                    host, port = primary
+                    # A single-node cluster reports its own host as ''.
                     if host == "":
                         host = startup_node.host
-                    port = int(primary_node[1])
                     host, port = self.remap_host_port(host, port)
 
                     nodes_for_slot = []
@@ -2576,24 +2578,26 @@ class NodesManager:
                     tmp_nodes_cache[target_node.name] = target_node
                     nodes_for_slot.append(target_node)
 
-                    replica_nodes = slot[3:]
-                    for replica_node in replica_nodes:
-                        host = replica_node[0]
-                        port = replica_node[1]
-                        host, port = self.remap_host_port(host, port)
+                    for replica_host, replica_port in replicas:
+                        replica_host, replica_port = self.remap_host_port(
+                            replica_host, replica_port
+                        )
 
                         target_replica_node = tmp_nodes_cache.get(
-                            get_node_name(host, port)
+                            get_node_name(replica_host, replica_port)
                         )
                         if not target_replica_node:
                             target_replica_node = ClusterNode(
-                                host, port, REPLICA, **self.connection_kwargs
+                                replica_host,
+                                replica_port,
+                                REPLICA,
+                                **self.connection_kwargs,
                             )
                         # add this node to the nodes cache
                         tmp_nodes_cache[target_replica_node.name] = target_replica_node
                         nodes_for_slot.append(target_replica_node)
 
-                    for i in range(int(slot[0]), int(slot[1]) + 1):
+                    for i in range(start_slot, end_slot + 1):
                         if i not in tmp_slots:
                             tmp_slots[i] = nodes_for_slot
                         else:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2539,10 +2539,19 @@ class NodesManager:
                         topology_response = await startup_node.execute_command(
                             *self._topology_provider.command
                         )
-                    except ResponseError:
+                    except ResponseError as e:
+                        # A server too old for the configured topology command
+                        # rejects the subcommand itself; reporting that as cluster
+                        # mode being off would send the reader somewhere useless.
+                        if "unknown subcommand" in str(e).lower():
+                            raise RedisClusterException(
+                                f"Topology discovery with "
+                                f"{' '.join(self._topology_provider.command)} is "
+                                f"not supported on this node: {e}"
+                            ) from e
                         raise RedisClusterException(
                             "Cluster mode is not enabled on this node"
-                        )
+                        ) from e
                     startup_nodes_reachable = True
                 except Exception as e:
                     # Try the next startup node.

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -534,11 +534,11 @@ class RedisCluster(
         address_remap: Callable[[Tuple[str, int]], Tuple[str, int]] | None = None,
         event_dispatcher: EventDispatcher | None = None,
         policy_resolver: AsyncPolicyResolver | None = None,
+        maint_notifications_config: MaintNotificationsConfig | None = None,
+        metadata_resolver: AsyncMetadataResolver | None = None,
         topology_provider: AsyncClusterTopologyProvider = (
             AsyncClusterSlotsTopologyProvider()
         ),
-        maint_notifications_config: MaintNotificationsConfig | None = None,
-        metadata_resolver: AsyncMetadataResolver | None = None,
     ) -> None:
         if db:
             raise RedisClusterException(
@@ -2562,7 +2562,8 @@ class NodesManager:
                     replicas,
                 ) in self._topology_provider.parse(topology_response):
                     host, port = primary
-                    # A single-node cluster reports its own host as ''.
+                    # An empty host means the node does not know its own address
+                    # and must be reached at the host that answered this command.
                     if host == "":
                         host = startup_node.host
                     host, port = self.remap_host_port(host, port)
@@ -2579,6 +2580,8 @@ class NodesManager:
                     nodes_for_slot.append(target_node)
 
                     for replica_host, replica_port in replicas:
+                        if replica_host == "":
+                            replica_host = startup_node.host
                         replica_host, replica_port = self.remap_host_port(
                             replica_host, replica_port
                         )

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3016,10 +3016,19 @@ class NodesManager:
                                 r.connection_pool.update_active_connections_for_reconnect()
                                 # Needed to clear READONLY state when it is no longer applicable
                                 r.connection_pool.disconnect_free_connections()
-                    except ResponseError:
+                    except ResponseError as e:
+                        # A server too old for the configured topology command
+                        # rejects the subcommand itself; reporting that as cluster
+                        # mode being off would send the reader somewhere useless.
+                        if "unknown subcommand" in str(e).lower():
+                            raise RedisClusterException(
+                                f"Topology discovery with "
+                                f"{' '.join(self._topology_provider.command)} is "
+                                f"not supported on this node: {e}"
+                            ) from e
                         raise RedisClusterException(
                             "Cluster mode is not enabled on this node"
-                        )
+                        ) from e
                     startup_nodes_reachable = True
                 except Exception as e:
                     # Try the next startup node.

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -739,9 +739,9 @@ class RedisCluster(
         cache_config: Optional[CacheConfig] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
         policy_resolver: Optional[PolicyResolver] = None,
-        topology_provider: ClusterTopologyProvider = ClusterSlotsTopologyProvider(),
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
         metadata_resolver: Optional[MetadataResolver] = None,
+        topology_provider: ClusterTopologyProvider = ClusterSlotsTopologyProvider(),
         **kwargs,
     ):
         """
@@ -3039,7 +3039,8 @@ class NodesManager:
                     replicas,
                 ) in self._topology_provider.parse(topology_response):
                     host, port = primary
-                    # A single-node cluster reports its own host as ''.
+                    # An empty host means the node does not know its own address
+                    # and must be reached at the host that answered this command.
                     if host == "":
                         host = startup_node.host
                     host, port = self.remap_host_port(host, port)
@@ -3052,6 +3053,8 @@ class NodesManager:
                     nodes_for_slot.append(target_node)
 
                     for replica_host, replica_port in replicas:
+                        if replica_host == "":
+                            replica_host = startup_node.host
                         replica_host, replica_port = self.remap_host_port(
                             replica_host, replica_port
                         )

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -39,6 +39,10 @@ from redis._parsers.helpers import parse_scan
 from redis.backoff import ExponentialWithJitterBackoff, NoBackoff
 from redis.cache import CacheConfig, CacheFactory, CacheFactoryInterface, CacheInterface
 from redis.client import EMPTY_RESPONSE, CaseInsensitiveDict, PubSub, Redis
+from redis.cluster_topology import (
+    ClusterSlotsTopologyProvider,
+    ClusterTopologyProvider,
+)
 from redis.commands import RedisClusterCommands
 from redis.commands.helpers import list_or_args, parse_pubsub_subscriptions
 from redis.commands.metadata import (
@@ -735,6 +739,7 @@ class RedisCluster(
         cache_config: Optional[CacheConfig] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
         policy_resolver: Optional[PolicyResolver] = None,
+        topology_provider: ClusterTopologyProvider = ClusterSlotsTopologyProvider(),
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
         metadata_resolver: Optional[MetadataResolver] = None,
         **kwargs,
@@ -806,6 +811,12 @@ class RedisCluster(
             where the node is reachable.  This can be used to map the addresses at
             which the nodes _think_ they are, to addresses at which a client may
             reach them, such as when they sit behind a proxy.
+        :param topology_provider:
+            Selects the command used to discover the cluster's slot mapping.
+            Defaults to `CLUSTER SLOTS`. Pass
+            :class:`~redis.cluster_topology.ClusterShardsTopologyProvider` to use
+            `CLUSTER SHARDS` instead, which requires Redis 7.0+ and returns one
+            entry per shard rather than per slot range.
 
         :param policy_resolver:
             Decides the request/response policies each command is routed by - see
@@ -991,6 +1002,7 @@ class RedisCluster(
             event_dispatcher=self._event_dispatcher,
             maint_notifications_config=maint_notifications_config,
             himport_registry=self._himport_registry,
+            topology_provider=topology_provider,
             **kwargs,
         )
 
@@ -2472,6 +2484,7 @@ class NodesManager:
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
         himport_registry: HImportRegistry | None = None,
         metadata_resolver: Optional[MetadataResolver] = None,
+        topology_provider: ClusterTopologyProvider = ClusterSlotsTopologyProvider(),
         **kwargs,
     ):
         # Shared, cluster-wide HIMPORT registry object, injected onto every node's pool
@@ -2494,6 +2507,7 @@ class NodesManager:
         # through the one object the cluster client was configured with.
         self._metadata_resolver = metadata_resolver
 
+        self._topology_provider = topology_provider
         self._cache: Optional[CacheInterface] = None
         if cache:
             self._cache = cache
@@ -2986,11 +3000,14 @@ class NodesManager:
                     try:
                         if is_debug_log_enabled():
                             logger.debug(
-                                "Topology refresh: querying CLUSTER SLOTS on "
+                                "Topology refresh: querying "
+                                f"{' '.join(self._topology_provider.command)} on "
                                 f"{startup_node.name}"
                             )
                         # Make sure cluster mode is enabled on this node
-                        cluster_slots = str_if_bytes(r.execute_command("CLUSTER SLOTS"))
+                        topology_response = r.execute_command(
+                            *self._topology_provider.command
+                        )
                         if disconnect_startup_nodes_pools:
                             with r.connection_pool._lock:
                                 # take care to clear connections before we move on
@@ -3015,26 +3032,16 @@ class NodesManager:
                     exception = e
                     continue
 
-                # CLUSTER SLOTS command results in the following output:
-                # [[slot_section[from_slot,to_slot,master,replica1,...,replicaN]]]
-                # where each node contains the following list: [IP, port, node_id]
-                # Therefore, cluster_slots[0][2][0] will be the IP address of the
-                # primary node of the first slot section.
-                # If there's only one server in the cluster, its ``host`` is ''
-                # Fix it to the host in startup_nodes
-                if (
-                    len(cluster_slots) == 1
-                    and len(cluster_slots[0][2][0]) == 0
-                    and len(self.startup_nodes) == 1
-                ):
-                    cluster_slots[0][2][0] = startup_node.host
-
-                for slot in cluster_slots:
-                    primary_node = slot[2]
-                    host = str_if_bytes(primary_node[0])
+                for (
+                    start_slot,
+                    end_slot,
+                    primary,
+                    replicas,
+                ) in self._topology_provider.parse(topology_response):
+                    host, port = primary
+                    # A single-node cluster reports its own host as ''.
                     if host == "":
                         host = startup_node.host
-                    port = int(primary_node[1])
                     host, port = self.remap_host_port(host, port)
 
                     nodes_for_slot = []
@@ -3044,17 +3051,16 @@ class NodesManager:
                     )
                     nodes_for_slot.append(target_node)
 
-                    replica_nodes = slot[3:]
-                    for replica_node in replica_nodes:
-                        host = str_if_bytes(replica_node[0])
-                        port = int(replica_node[1])
-                        host, port = self.remap_host_port(host, port)
+                    for replica_host, replica_port in replicas:
+                        replica_host, replica_port = self.remap_host_port(
+                            replica_host, replica_port
+                        )
                         target_replica_node = self._get_or_create_cluster_node(
-                            host, port, REPLICA, tmp_nodes_cache
+                            replica_host, replica_port, REPLICA, tmp_nodes_cache
                         )
                         nodes_for_slot.append(target_replica_node)
 
-                    for i in range(int(slot[0]), int(slot[1]) + 1):
+                    for i in range(start_slot, end_slot + 1):
                         if i not in tmp_slots:
                             tmp_slots[i] = nodes_for_slot
                         else:

--- a/redis/cluster_topology.py
+++ b/redis/cluster_topology.py
@@ -14,11 +14,17 @@ SlotOwner = tuple[str, int]
 SlotOwners = tuple[int, int, SlotOwner, list[SlotOwner]]
 
 _MASTER_ROLE = "master"
+_UNKNOWN_HOSTNAME = "?"
 _ONLINE_HEALTH = "online"
 
 
 def _as_str(value: Any) -> str:
     return str_if_bytes(value) if isinstance(value, bytes) else value
+
+
+def _as_host(value: Any) -> str:
+    """Normalize a missing address to the empty host callers fall back on."""
+    return "" if value is None else _as_str(value)
 
 
 def _as_mapping(entry: Any) -> dict[str, Any]:
@@ -42,14 +48,16 @@ def _node_address(node: dict[str, Any], prefer_tls_port: bool) -> SlotOwner:
     # (typically because it sits behind a load balancer); the caller must reach
     # it at the host the topology command was sent to, so leave the host empty
     # rather than substituting ``ip``, which is the unreachable internal address.
-    endpoint = node.get("endpoint")
-    host = "" if endpoint is None else _as_str(endpoint)
+    host = _as_host(node.get("endpoint"))
+    # "?" means a hostname was preferred but never announced. It denotes an
+    # unknown node rather than the one being queried, so the queried host must
+    # not be reused for it; ``ip`` is the only address left to try.
+    if host == _UNKNOWN_HOSTNAME:
+        host = _as_host(node.get("ip"))
 
     port_keys = ("tls-port", "port") if prefer_tls_port else ("port", "tls-port")
-    port = next(
-        (node[key] for key in port_keys if node.get(key) is not None),
-        None,
-    )
+    # A disabled listener is reported as port 0, which is never connectable.
+    port = next((node[key] for key in port_keys if node.get(key)), None)
     return host, int(port)
 
 
@@ -58,8 +66,8 @@ def parse_cluster_slots_topology(response: Any) -> list[SlotOwners]:
     topology = []
     for slot in response:
         start, end = int(slot[0]), int(slot[1])
-        primary = (_as_str(slot[2][0]), int(slot[2][1]))
-        replicas = [(_as_str(node[0]), int(node[1])) for node in slot[3:]]
+        primary = (_as_host(slot[2][0]), int(slot[2][1]))
+        replicas = [(_as_host(node[0]), int(node[1])) for node in slot[3:]]
         topology.append((start, end, primary, replicas))
     return topology
 

--- a/redis/cluster_topology.py
+++ b/redis/cluster_topology.py
@@ -109,7 +109,7 @@ class ClusterTopologyProvider(ABC):
             response: The reply to the provider's ``command``.
 
         Returns:
-            list[SlotOwners]: ``(start, end, primary, replicas)`` per slot range.
+            One ``(start, end, primary, replicas)`` tuple per slot range.
         """
         pass
 
@@ -128,7 +128,7 @@ class AsyncClusterTopologyProvider(ABC):
             response: The reply to the provider's ``command``.
 
         Returns:
-            list[SlotOwners]: ``(start, end, primary, replicas)`` per slot range.
+            One ``(start, end, primary, replicas)`` tuple per slot range.
         """
         pass
 

--- a/redis/cluster_topology.py
+++ b/redis/cluster_topology.py
@@ -38,8 +38,12 @@ def _slot_ranges(slots: Any) -> list[tuple[int, int]]:
 
 
 def _node_address(node: dict[str, Any], prefer_tls_port: bool) -> SlotOwner:
-    endpoint = _as_str(node.get("endpoint", ""))
-    host = endpoint or _as_str(node.get("ip", ""))
+    # A null or empty endpoint means the node's address is unknown to itself
+    # (typically because it sits behind a load balancer); the caller must reach
+    # it at the host the topology command was sent to, so leave the host empty
+    # rather than substituting ``ip``, which is the unreachable internal address.
+    endpoint = node.get("endpoint")
+    host = "" if endpoint is None else _as_str(endpoint)
 
     port_keys = ("tls-port", "port") if prefer_tls_port else ("port", "tls-port")
     port = next(

--- a/redis/cluster_topology.py
+++ b/redis/cluster_topology.py
@@ -1,0 +1,173 @@
+"""Pluggable cluster topology discovery.
+
+``NodesManager`` uses a topology provider to learn which nodes own which slots.
+A provider names the command to issue and knows how to read its reply; issuing
+the command and building the node caches stay with ``NodesManager``.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from redis.utils import str_if_bytes
+
+SlotOwner = tuple[str, int]
+SlotOwners = tuple[int, int, SlotOwner, list[SlotOwner]]
+
+_MASTER_ROLE = "master"
+_ONLINE_HEALTH = "online"
+
+
+def _as_str(value: Any) -> str:
+    return str_if_bytes(value) if isinstance(value, bytes) else value
+
+
+def _as_mapping(entry: Any) -> dict[str, Any]:
+    """Normalize a RESP3 map or a RESP2 flat ``[key, value, ...]`` array."""
+    if isinstance(entry, dict):
+        return {_as_str(key): value for key, value in entry.items()}
+    return {_as_str(entry[i]): entry[i + 1] for i in range(0, len(entry) - 1, 2)}
+
+
+def _slot_ranges(slots: Any) -> list[tuple[int, int]]:
+    """Read a shard's slot ranges, which arrive either flat or already paired."""
+    if not slots:
+        return []
+    if isinstance(slots[0], (list, tuple)):
+        return [(int(start), int(end)) for start, end in slots]
+    return [(int(slots[i]), int(slots[i + 1])) for i in range(0, len(slots) - 1, 2)]
+
+
+def _node_address(node: dict[str, Any], prefer_tls_port: bool) -> SlotOwner:
+    endpoint = _as_str(node.get("endpoint", ""))
+    host = endpoint or _as_str(node.get("ip", ""))
+
+    port_keys = ("tls-port", "port") if prefer_tls_port else ("port", "tls-port")
+    port = next(
+        (node[key] for key in port_keys if node.get(key) is not None),
+        None,
+    )
+    return host, int(port)
+
+
+def parse_cluster_slots_topology(response: Any) -> list[SlotOwners]:
+    """Read a ``CLUSTER SLOTS`` reply into per-range slot ownership."""
+    topology = []
+    for slot in response:
+        start, end = int(slot[0]), int(slot[1])
+        primary = (_as_str(slot[2][0]), int(slot[2][1]))
+        replicas = [(_as_str(node[0]), int(node[1])) for node in slot[3:]]
+        topology.append((start, end, primary, replicas))
+    return topology
+
+
+def parse_cluster_shards_topology(
+    response: Any, prefer_tls_port: bool = False
+) -> list[SlotOwners]:
+    """Read a ``CLUSTER SHARDS`` reply into per-range slot ownership.
+
+    A shard covers any number of slot ranges and lists its nodes in no
+    guaranteed order, so the primary is selected by role rather than position.
+    """
+    topology = []
+    for shard_entry in response:
+        shard = _as_mapping(shard_entry)
+        ranges = _slot_ranges(shard.get("slots"))
+        if not ranges:
+            continue
+
+        primary = None
+        replicas = []
+        for node_entry in shard.get("nodes", []):
+            node = _as_mapping(node_entry)
+            role = _as_str(node.get("role", ""))
+            if role == _MASTER_ROLE:
+                if primary is None:
+                    primary = _node_address(node, prefer_tls_port)
+            # An unhealthy primary still owns its slots, so only replicas are
+            # dropped on health; dropping the primary would leave them uncovered.
+            elif _as_str(node.get("health", _ONLINE_HEALTH)) == _ONLINE_HEALTH:
+                replicas.append(_node_address(node, prefer_tls_port))
+
+        if primary is None:
+            continue
+
+        topology.extend((start, end, primary, replicas) for start, end in ranges)
+    return topology
+
+
+class ClusterTopologyProvider(ABC):
+    """Names a topology command and reads its reply."""
+
+    command: tuple[str, ...]
+
+    @abstractmethod
+    def parse(self, response: Any) -> list[SlotOwners]:
+        """
+        Reads a topology command reply into per-range slot ownership.
+
+        Args:
+            response: The reply to the provider's ``command``.
+
+        Returns:
+            list[SlotOwners]: ``(start, end, primary, replicas)`` per slot range.
+        """
+        pass
+
+
+class AsyncClusterTopologyProvider(ABC):
+    """Names a topology command and reads its reply."""
+
+    command: tuple[str, ...]
+
+    @abstractmethod
+    def parse(self, response: Any) -> list[SlotOwners]:
+        """
+        Reads a topology command reply into per-range slot ownership.
+
+        Args:
+            response: The reply to the provider's ``command``.
+
+        Returns:
+            list[SlotOwners]: ``(start, end, primary, replicas)`` per slot range.
+        """
+        pass
+
+
+class ClusterSlotsTopologyProvider(ClusterTopologyProvider):
+    """Discovers topology with ``CLUSTER SLOTS``."""
+
+    command = ("CLUSTER SLOTS",)
+
+    def parse(self, response: Any) -> list[SlotOwners]:
+        return parse_cluster_slots_topology(response)
+
+
+class ClusterShardsTopologyProvider(ClusterTopologyProvider):
+    """Discovers topology with ``CLUSTER SHARDS``, which requires Redis 7.0+.
+
+    One reply entry per shard rather than per slot range, so replies stay small
+    on clusters whose slot ranges have become fragmented.
+
+    Args:
+        prefer_tls_port: Take each node's ``tls-port`` in preference to ``port``.
+    """
+
+    command = ("CLUSTER SHARDS",)
+
+    def __init__(self, prefer_tls_port: bool = False) -> None:
+        self.prefer_tls_port = prefer_tls_port
+
+    def parse(self, response: Any) -> list[SlotOwners]:
+        return parse_cluster_shards_topology(response, self.prefer_tls_port)
+
+
+class AsyncClusterSlotsTopologyProvider(
+    ClusterSlotsTopologyProvider, AsyncClusterTopologyProvider
+):
+    """Discovers topology with ``CLUSTER SLOTS``."""
+
+
+class AsyncClusterShardsTopologyProvider(
+    ClusterShardsTopologyProvider, AsyncClusterTopologyProvider
+):
+    """Discovers topology with ``CLUSTER SHARDS``, which requires Redis 7.0+."""

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -4198,6 +4198,42 @@ class TestNodesManagerTopologyProvider:
         assert list(rc.nodes_manager.nodes_cache) == ["127.0.0.1:7000"]
         await rc.aclose()
 
+    @pytest.mark.parametrize("endpoint", ["", None], ids=["empty", "null"])
+    async def test_unknown_endpoint_routes_to_queried_host(self, endpoint):
+        """Nodes behind a load balancer must not be reached at their internal ip."""
+        rc = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            cluster_shards=[
+                {
+                    "slots": [0, REDIS_CLUSTER_HASH_SLOTS - 1],
+                    "nodes": [
+                        {
+                            "endpoint": endpoint,
+                            "ip": "10.0.0.1",
+                            "port": 7000,
+                            "role": "master",
+                            "health": "online",
+                        },
+                        {
+                            "endpoint": endpoint,
+                            "ip": "10.0.0.2",
+                            "port": 7001,
+                            "role": "replica",
+                            "health": "online",
+                        },
+                    ],
+                }
+            ],
+            topology_provider=AsyncClusterShardsTopologyProvider(),
+        )
+
+        assert sorted(rc.nodes_manager.nodes_cache) == [
+            "127.0.0.1:7000",
+            "127.0.0.1:7001",
+        ]
+        await rc.aclose()
+
 
 @pytest.mark.fixed_client
 class TestClusterNodeConnectionHandling:

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -192,6 +192,7 @@ async def get_mocked_redis_client(
     """
     cluster_slots = kwargs.pop("cluster_slots", default_cluster_slots)
     cluster_shards = kwargs.pop("cluster_shards", default_cluster_shards)
+    topology_error = kwargs.pop("topology_error", None)
     coverage_res = kwargs.pop("coverage_result", "yes")
     cluster_enabled = kwargs.pop("cluster_enabled", True)
     with mock.patch.object(ClusterNode, "execute_command") as execute_command_mock:
@@ -199,13 +200,13 @@ async def get_mocked_redis_client(
         async def execute_command(*_args, **_kwargs):
             if _args[0] == "CLUSTER SLOTS":
                 if cluster_slots_raise_error:
-                    raise ResponseError()
+                    raise topology_error or ResponseError()
                 else:
                     mock_cluster_slots = cluster_slots
                     return mock_cluster_slots
             elif _args[0] == "CLUSTER SHARDS":
                 if cluster_slots_raise_error:
-                    raise ResponseError()
+                    raise topology_error or ResponseError()
                 return cluster_shards
             elif _args[0] == "COMMAND":
                 return {"get": [], "set": []}
@@ -4197,6 +4198,36 @@ class TestNodesManagerTopologyProvider:
 
         assert list(rc.nodes_manager.nodes_cache) == ["127.0.0.1:7000"]
         await rc.aclose()
+
+    async def test_slots_null_endpoint_routes_to_queried_host(self):
+        """A null CLUSTER SLOTS host must not be cached as ``None:port``."""
+        rc = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            cluster_slots=[[0, REDIS_CLUSTER_HASH_SLOTS - 1, [None, 7000, "node_0"]]],
+        )
+
+        assert list(rc.nodes_manager.nodes_cache) == ["127.0.0.1:7000"]
+        await rc.aclose()
+
+    async def test_unsupported_topology_command_is_not_reported_as_cluster_disabled(
+        self,
+    ):
+        """An unknown subcommand must not be diagnosed as cluster mode being off."""
+        with pytest.raises(RedisClusterException) as excinfo:
+            await get_mocked_redis_client(
+                host=default_host,
+                port=default_port,
+                cluster_slots_raise_error=True,
+                topology_provider=AsyncClusterShardsTopologyProvider(),
+                topology_error=ResponseError(
+                    "Unknown subcommand or wrong number of arguments for 'SHARDS'."
+                ),
+            )
+
+        message = str(excinfo.value)
+        assert "Cluster mode is not enabled" not in message
+        assert "CLUSTER SHARDS" in message
 
     @pytest.mark.parametrize("endpoint", ["", None], ids=["empty", "null"])
     async def test_unknown_endpoint_routes_to_queried_host(self, endpoint):

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -33,6 +33,10 @@ from redis.cluster import (
     LoadBalancingStrategy,
     get_node_name,
 )
+from redis.cluster_topology import (
+    AsyncClusterShardsTopologyProvider,
+    AsyncClusterSlotsTopologyProvider,
+)
 from redis.commands.cluster import AsyncClusterMultiKeyCommands
 from redis.commands.core import HotkeysMetricsTypes
 from redis.commands.metadata import (
@@ -82,6 +86,11 @@ from redis.observability.config import OTelConfig, MetricGroup
 from redis.observability.metrics import RedisMetricsCollector
 
 from ..ssl_utils import get_tls_certificates
+from ..test_cluster import (
+    default_cluster_shards,
+    default_cluster_shards_bytes_keys,
+    default_cluster_shards_resp2,
+)
 from .compat import aclosing
 
 default_host = "127.0.0.1"
@@ -182,6 +191,7 @@ async def get_mocked_redis_client(
     on different installations and machines.
     """
     cluster_slots = kwargs.pop("cluster_slots", default_cluster_slots)
+    cluster_shards = kwargs.pop("cluster_shards", default_cluster_shards)
     coverage_res = kwargs.pop("coverage_result", "yes")
     cluster_enabled = kwargs.pop("cluster_enabled", True)
     with mock.patch.object(ClusterNode, "execute_command") as execute_command_mock:
@@ -193,6 +203,10 @@ async def get_mocked_redis_client(
                 else:
                     mock_cluster_slots = cluster_slots
                     return mock_cluster_slots
+            elif _args[0] == "CLUSTER SHARDS":
+                if cluster_slots_raise_error:
+                    raise ResponseError()
+                return cluster_shards
             elif _args[0] == "COMMAND":
                 return {"get": [], "set": []}
             elif _args[0] == "INFO":
@@ -4057,6 +4071,132 @@ class TestNodesManager:
 
         listener.listen.assert_not_called()
         await r.aclose()
+
+
+@pytest.mark.fixed_client
+class TestNodesManagerTopologyProvider:
+    """
+    Unit tests for topology provider selection in the async NodesManager.
+    """
+
+    @staticmethod
+    def _slot_map(client):
+        return {
+            slot: sorted(node.name for node in nodes)
+            for slot, nodes in client.nodes_manager.slots_cache.items()
+        }
+
+    async def test_default_provider_uses_cluster_slots(self):
+        rc = await get_mocked_redis_client(host=default_host, port=default_port)
+
+        assert isinstance(
+            rc.nodes_manager._topology_provider, AsyncClusterSlotsTopologyProvider
+        )
+        await rc.aclose()
+
+    async def test_shards_provider_builds_same_topology_as_slots(self):
+        slots_client = await get_mocked_redis_client(
+            host=default_host, port=default_port
+        )
+        shards_client = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            topology_provider=AsyncClusterShardsTopologyProvider(),
+        )
+
+        assert self._slot_map(shards_client) == self._slot_map(slots_client)
+        assert sorted(shards_client.nodes_manager.nodes_cache) == sorted(
+            slots_client.nodes_manager.nodes_cache
+        )
+        await slots_client.aclose()
+        await shards_client.aclose()
+
+    @pytest.mark.parametrize(
+        "cluster_shards",
+        [
+            default_cluster_shards,
+            default_cluster_shards_bytes_keys,
+            default_cluster_shards_resp2,
+        ],
+        ids=["resp3-str-keys", "resp3-bytes-keys", "resp2"],
+    )
+    async def test_shards_provider_handles_every_response_shape(self, cluster_shards):
+        rc = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            cluster_shards=cluster_shards,
+            topology_provider=AsyncClusterShardsTopologyProvider(),
+        )
+
+        assert len(rc.nodes_manager.slots_cache) == REDIS_CLUSTER_HASH_SLOTS
+        assert sorted(rc.nodes_manager.nodes_cache) == [
+            "127.0.0.1:7000",
+            "127.0.0.1:7001",
+            "127.0.0.1:7002",
+            "127.0.0.1:7003",
+        ]
+        await rc.aclose()
+
+    @pytest.mark.parametrize("protocol", [2, 3])
+    @pytest.mark.parametrize("legacy_responses", [True, False])
+    async def test_shards_provider_across_response_callbacks(
+        self, protocol, legacy_responses
+    ):
+        """Each protocol/legacy pairing selects a different CLUSTER SHARDS callback."""
+        slots_client = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            protocol=protocol,
+            legacy_responses=legacy_responses,
+        )
+        shards_client = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            protocol=protocol,
+            legacy_responses=legacy_responses,
+            topology_provider=AsyncClusterShardsTopologyProvider(),
+        )
+
+        assert self._slot_map(shards_client) == self._slot_map(slots_client)
+        await slots_client.aclose()
+        await shards_client.aclose()
+
+    async def test_provider_does_not_leak_into_connection_kwargs(self):
+        rc = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            topology_provider=AsyncClusterShardsTopologyProvider(),
+        )
+
+        assert "topology_provider" not in rc.nodes_manager.connection_kwargs
+        await rc.aclose()
+
+    async def test_provider_attribute_is_declared_in_slots(self):
+        provider = AsyncClusterShardsTopologyProvider()
+        nodes_manager = NodesManager(
+            startup_nodes=[ClusterNode(default_host, default_port)],
+            require_full_coverage=False,
+            connection_kwargs={},
+            topology_provider=provider,
+        )
+
+        assert nodes_manager._topology_provider is provider
+
+    async def test_single_node_cluster_uses_startup_host(self):
+        rc = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            cluster_shards=[
+                {
+                    "slots": [0, REDIS_CLUSTER_HASH_SLOTS - 1],
+                    "nodes": [{"endpoint": "", "port": 7000, "role": "master"}],
+                }
+            ],
+            topology_provider=AsyncClusterShardsTopologyProvider(),
+        )
+
+        assert list(rc.nodes_manager.nodes_cache) == ["127.0.0.1:7000"]
+        await rc.aclose()
 
 
 @pytest.mark.fixed_client

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -276,18 +276,19 @@ def get_mocked_redis_client(
     cluster_shards = kwargs.pop("cluster_shards", default_cluster_shards)
     coverage_res = kwargs.pop("coverage_result", "yes")
     cluster_enabled = kwargs.pop("cluster_enabled", True)
+    topology_error = kwargs.pop("topology_error", None)
     with patch.object(Redis, "execute_command") as execute_command_mock:
 
         def execute_command(*_args, **_kwargs):
             if _args[0] == "CLUSTER SLOTS":
                 if cluster_slots_raise_error:
-                    raise ResponseError()
+                    raise topology_error or ResponseError()
                 else:
                     mock_cluster_slots = cluster_slots
                     return mock_cluster_slots
             elif _args[0] == "CLUSTER SHARDS":
                 if cluster_slots_raise_error:
-                    raise ResponseError()
+                    raise topology_error or ResponseError()
                 return cluster_shards
             elif _args[0] == "COMMAND":
                 return {"get": [], "set": []}
@@ -4770,6 +4771,54 @@ class TestClusterTopologyProvider:
             (0, 1, (expected_host, 7000), [])
         ]
 
+    @pytest.mark.parametrize(
+        "node,expected_host",
+        [
+            ({"endpoint": "?", "ip": "10.0.0.1"}, "10.0.0.1"),
+            ({"endpoint": "?"}, ""),
+        ],
+        ids=["falls-back-to-ip", "no-ip-available"],
+    )
+    def test_unannounced_hostname_is_not_used_as_host(self, node, expected_host):
+        """ "?" denotes an unknown node, so it must never become a host."""
+        response = [
+            {"slots": [0, 1], "nodes": [{**node, "port": 7000, "role": "master"}]}
+        ]
+
+        assert ClusterShardsTopologyProvider().parse(response) == [
+            (0, 1, (expected_host, 7000), [])
+        ]
+
+    @pytest.mark.parametrize(
+        "ports,prefer_tls,expected_port",
+        [
+            ({"port": 7000, "tls-port": 0}, False, 7000),
+            ({"port": 7000, "tls-port": 0}, True, 7000),
+            ({"port": 0, "tls-port": 7100}, False, 7100),
+            ({"port": 0, "tls-port": 7100}, True, 7100),
+        ],
+        ids=["tls-disabled", "tls-disabled-preferred", "plain-disabled", "tls-only"],
+    )
+    def test_disabled_listener_port_is_skipped(self, ports, prefer_tls, expected_port):
+        """Redis reports a disabled listener as port 0, which is unconnectable."""
+        response = [
+            {
+                "slots": [0, 1],
+                "nodes": [{"endpoint": "127.0.0.1", "role": "master", **ports}],
+            }
+        ]
+
+        provider = ClusterShardsTopologyProvider(prefer_tls_port=prefer_tls)
+        assert provider.parse(response) == [(0, 1, ("127.0.0.1", expected_port), [])]
+
+    def test_slots_null_host_is_normalized_to_empty(self):
+        """A null CLUSTER SLOTS host must reach the queried-host fallback."""
+        response = [[0, 16383, [None, 7000, "node_0"], [None, 7001, "node_1"]]]
+
+        assert ClusterSlotsTopologyProvider().parse(response) == [
+            (0, 16383, ("", 7000), [("", 7001)])
+        ]
+
     def test_prefer_tls_port(self):
         response = [
             {
@@ -4937,6 +4986,44 @@ class TestNodesManagerTopologyProvider:
             "127.0.0.1:7000",
             "127.0.0.1:7001",
         ]
+
+    def test_slots_null_endpoint_routes_to_queried_host(self):
+        """A null CLUSTER SLOTS host must not be cached as ``None:port``."""
+        rc = get_mocked_redis_client(
+            url="redis://127.0.0.1:7000",
+            cluster_slots=[[0, REDIS_CLUSTER_HASH_SLOTS - 1, [None, 7000, "node_0"]]],
+        )
+
+        assert list(rc.nodes_manager.nodes_cache) == ["127.0.0.1:7000"]
+
+    def test_unsupported_topology_command_is_not_reported_as_cluster_disabled(self):
+        """An unknown subcommand must not be diagnosed as cluster mode being off."""
+        with pytest.raises(RedisClusterException) as excinfo:
+            get_mocked_redis_client(
+                url="redis://127.0.0.1:7000",
+                cluster_slots_raise_error=True,
+                topology_provider=ClusterShardsTopologyProvider(),
+                topology_error=ResponseError(
+                    "Unknown subcommand or wrong number of arguments for 'SHARDS'."
+                ),
+            )
+
+        message = str(excinfo.value)
+        assert "Cluster mode is not enabled" not in message
+        assert "CLUSTER SHARDS" in message
+        assert "not supported on this node" in message
+
+    def test_cluster_support_disabled_is_still_reported_clearly(self):
+        with pytest.raises(RedisClusterException) as excinfo:
+            get_mocked_redis_client(
+                url="redis://127.0.0.1:7000",
+                cluster_slots_raise_error=True,
+                topology_error=ResponseError(
+                    "This instance has cluster support disabled"
+                ),
+            )
+
+        assert "Cluster mode is not enabled" in str(excinfo.value)
 
     @pytest.mark.parametrize(
         "cluster_class", [RedisCluster, AsyncRedisCluster], ids=["sync", "async"]

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,5 +1,6 @@
 import binascii
 import datetime
+import inspect
 import select
 import socket
 import socketserver
@@ -32,6 +33,7 @@ from redis.cluster import (
     RedisCluster,
     get_node_name,
 )
+from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
 from redis.cache import CacheConfig
 from redis.cluster_topology import (
     ClusterShardsTopologyProvider,
@@ -4657,7 +4659,7 @@ class TestClusterTopologyProvider:
         response = [
             {
                 "slots": [0, 10, 100, 110],
-                "nodes": [{"ip": "127.0.0.1", "port": 7000, "role": "master"}],
+                "nodes": [{"endpoint": "127.0.0.1", "port": 7000, "role": "master"}],
             }
         ]
 
@@ -4671,8 +4673,8 @@ class TestClusterTopologyProvider:
             {
                 "slots": [0, 1],
                 "nodes": [
-                    {"ip": "127.0.0.1", "port": 7003, "role": "replica"},
-                    {"ip": "127.0.0.1", "port": 7000, "role": "master"},
+                    {"endpoint": "127.0.0.1", "port": 7003, "role": "replica"},
+                    {"endpoint": "127.0.0.1", "port": 7000, "role": "master"},
                 ],
             }
         ]
@@ -4687,9 +4689,9 @@ class TestClusterTopologyProvider:
             {
                 "slots": [0, 1],
                 "nodes": [
-                    {"ip": "127.0.0.1", "port": 7000, "role": "master"},
+                    {"endpoint": "127.0.0.1", "port": 7000, "role": "master"},
                     {
-                        "ip": "127.0.0.1",
+                        "endpoint": "127.0.0.1",
                         "port": 7003,
                         "role": "replica",
                         "health": health,
@@ -4709,7 +4711,7 @@ class TestClusterTopologyProvider:
                 "slots": [0, 1],
                 "nodes": [
                     {
-                        "ip": "127.0.0.1",
+                        "endpoint": "127.0.0.1",
                         "port": 7000,
                         "role": "master",
                         "health": health,
@@ -4726,7 +4728,7 @@ class TestClusterTopologyProvider:
         response = [
             {
                 "slots": [0, 1],
-                "nodes": [{"ip": "127.0.0.1", "port": 7003, "role": "replica"}],
+                "nodes": [{"endpoint": "127.0.0.1", "port": 7003, "role": "replica"}],
             }
         ]
 
@@ -4736,7 +4738,7 @@ class TestClusterTopologyProvider:
         response = [
             {
                 "slots": [],
-                "nodes": [{"ip": "127.0.0.1", "port": 7000, "role": "master"}],
+                "nodes": [{"endpoint": "127.0.0.1", "port": 7000, "role": "master"}],
             }
         ]
 
@@ -4745,13 +4747,21 @@ class TestClusterTopologyProvider:
     @pytest.mark.parametrize(
         "node,expected_host",
         [
-            ({"endpoint": "", "ip": "127.0.0.1"}, "127.0.0.1"),
-            ({"ip": "127.0.0.1"}, "127.0.0.1"),
-            ({"endpoint": "node.example.com", "ip": "127.0.0.1"}, "node.example.com"),
+            ({"endpoint": "", "ip": "10.0.0.1"}, ""),
+            ({"endpoint": None, "ip": "10.0.0.1"}, ""),
+            ({"ip": "10.0.0.1"}, ""),
+            ({"endpoint": "node.example.com", "ip": "10.0.0.1"}, "node.example.com"),
         ],
-        ids=["empty-endpoint", "absent-endpoint", "endpoint-preferred"],
+        ids=["empty-endpoint", "null-endpoint", "absent-endpoint", "endpoint-present"],
     )
-    def test_host_falls_back_to_ip(self, node, expected_host):
+    def test_unknown_endpoint_is_left_empty(self, node, expected_host):
+        """An unknown endpoint must not resolve to ``ip``.
+
+        Redis returns a null or empty endpoint when the node does not know the
+        address clients reach it at, and requires the caller to reuse the host it
+        queried. ``ip`` is the node's internal address, which is unreachable when
+        the cluster sits behind a load balancer.
+        """
         response = [
             {"slots": [0, 1], "nodes": [{**node, "port": 7000, "role": "master"}]}
         ]
@@ -4766,7 +4776,7 @@ class TestClusterTopologyProvider:
                 "slots": [0, 1],
                 "nodes": [
                     {
-                        "ip": "127.0.0.1",
+                        "endpoint": "127.0.0.1",
                         "port": 7000,
                         "tls-port": 7100,
                         "role": "master",
@@ -4787,7 +4797,7 @@ class TestClusterTopologyProvider:
             {
                 "slots": [0, 1],
                 "nodes": [
-                    {"ip": "127.0.0.1", "tls-port": 7100, "role": "master"},
+                    {"endpoint": "127.0.0.1", "tls-port": 7100, "role": "master"},
                 ],
             }
         ]
@@ -4892,6 +4902,56 @@ class TestNodesManagerTopologyProvider:
         )
 
         assert list(rc.nodes_manager.nodes_cache) == ["127.0.0.1:7000"]
+
+    @pytest.mark.parametrize("endpoint", ["", None], ids=["empty", "null"])
+    def test_unknown_endpoint_routes_to_queried_host(self, endpoint):
+        """Nodes behind a load balancer must not be reached at their internal ip."""
+        rc = get_mocked_redis_client(
+            url="redis://127.0.0.1:7000",
+            cluster_shards=[
+                {
+                    "slots": [0, REDIS_CLUSTER_HASH_SLOTS - 1],
+                    "nodes": [
+                        {
+                            "endpoint": endpoint,
+                            "ip": "10.0.0.1",
+                            "port": 7000,
+                            "role": "master",
+                            "health": "online",
+                        },
+                        {
+                            "endpoint": endpoint,
+                            "ip": "10.0.0.2",
+                            "port": 7001,
+                            "role": "replica",
+                            "health": "online",
+                        },
+                    ],
+                }
+            ],
+            topology_provider=ClusterShardsTopologyProvider(),
+        )
+
+        # The internal 10.0.0.x addresses must not appear for either role.
+        assert sorted(rc.nodes_manager.nodes_cache) == [
+            "127.0.0.1:7000",
+            "127.0.0.1:7001",
+        ]
+
+    @pytest.mark.parametrize(
+        "cluster_class", [RedisCluster, AsyncRedisCluster], ids=["sync", "async"]
+    )
+    def test_topology_provider_is_last_positional_parameter(self, cluster_class):
+        """Appending keeps every pre-existing positional argument at its index."""
+        names = [
+            name
+            for name, parameter in inspect.signature(
+                cluster_class.__init__
+            ).parameters.items()
+            if name != "self" and parameter.kind is parameter.POSITIONAL_OR_KEYWORD
+        ]
+
+        assert names[-1] == "topology_provider"
 
 
 @pytest.mark.fixed_client

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -33,6 +33,10 @@ from redis.cluster import (
     get_node_name,
 )
 from redis.cache import CacheConfig
+from redis.cluster_topology import (
+    ClusterShardsTopologyProvider,
+    ClusterSlotsTopologyProvider,
+)
 from redis.commands.cluster import ClusterMultiKeyCommands
 from redis.commands.core import HotkeysMetricsTypes
 from redis.commands.metadata import (
@@ -90,6 +94,75 @@ default_port = 7000
 default_cluster_slots = [
     [0, 8191, ["127.0.0.1", 7000, "node_0"], ["127.0.0.1", 7003, "node_3"]],
     [8192, 16383, ["127.0.0.1", 7001, "node_1"], ["127.0.0.1", 7002, "node_2"]],
+]
+
+# The same topology as ``default_cluster_slots``, in each of the shapes a
+# CLUSTER SHARDS reply can reach the client in.
+default_cluster_shards = [
+    {
+        "slots": [0, 8191],
+        "nodes": [
+            {
+                "id": "node_0",
+                "endpoint": "127.0.0.1",
+                "ip": "127.0.0.1",
+                "port": 7000,
+                "role": "master",
+                "health": "online",
+            },
+            {
+                "id": "node_3",
+                "endpoint": "127.0.0.1",
+                "ip": "127.0.0.1",
+                "port": 7003,
+                "role": "replica",
+                "health": "online",
+            },
+        ],
+    },
+    {
+        "slots": [8192, 16383],
+        "nodes": [
+            {
+                "id": "node_1",
+                "endpoint": "127.0.0.1",
+                "ip": "127.0.0.1",
+                "port": 7001,
+                "role": "master",
+                "health": "online",
+            },
+            {
+                "id": "node_2",
+                "endpoint": "127.0.0.1",
+                "ip": "127.0.0.1",
+                "port": 7002,
+                "role": "replica",
+                "health": "online",
+            },
+        ],
+    },
+]
+default_cluster_shards_bytes_keys = [
+    {
+        b"slots": shard["slots"],
+        b"nodes": [
+            {key.encode(): value for key, value in node.items()}
+            for node in shard["nodes"]
+        ],
+    }
+    for shard in default_cluster_shards
+]
+default_cluster_shards_resp2 = [
+    [
+        b"slots",
+        shard["slots"],
+        b"nodes",
+        [
+            [item for key, value in node.items() for item in (key.encode(), value)]
+            for node in shard["nodes"]
+        ],
+    ]
+    for shard in default_cluster_shards
 ]
 
 
@@ -198,6 +271,7 @@ def get_mocked_redis_client(
     on different installations and machines.
     """
     cluster_slots = kwargs.pop("cluster_slots", default_cluster_slots)
+    cluster_shards = kwargs.pop("cluster_shards", default_cluster_shards)
     coverage_res = kwargs.pop("coverage_result", "yes")
     cluster_enabled = kwargs.pop("cluster_enabled", True)
     with patch.object(Redis, "execute_command") as execute_command_mock:
@@ -209,6 +283,10 @@ def get_mocked_redis_client(
                 else:
                     mock_cluster_slots = cluster_slots
                     return mock_cluster_slots
+            elif _args[0] == "CLUSTER SHARDS":
+                if cluster_slots_raise_error:
+                    raise ResponseError()
+                return cluster_shards
             elif _args[0] == "COMMAND":
                 return {"get": [], "set": []}
             elif _args[0] == "INFO":
@@ -3578,6 +3656,28 @@ class TestNodesManager:
     """
 
     @pytest.mark.onlycluster
+    @skip_if_server_version_lt("7.0.0")
+    @skip_if_redis_enterprise()
+    def test_shards_provider_matches_slots_against_real_cluster(self, r, request):
+        shards_client = _get_client(
+            RedisCluster,
+            request,
+            flushdb=False,
+            topology_provider=ClusterShardsTopologyProvider(),
+        )
+
+        def slot_map(client):
+            return {
+                slot: sorted(node.name for node in nodes)
+                for slot, nodes in client.nodes_manager.slots_cache.items()
+            }
+
+        assert slot_map(shards_client) == slot_map(r)
+        assert sorted(shards_client.nodes_manager.nodes_cache) == sorted(
+            r.nodes_manager.nodes_cache
+        )
+
+    @pytest.mark.onlycluster
     def test_load_balancer(self, r):
         n_manager = r.nodes_manager
         lb = n_manager.read_load_balancer
@@ -4508,6 +4608,290 @@ class TestNodesManager:
             nodes_cache_names = list(nodes_manager.nodes_cache.keys())
             assert startup_node_names == [node1.name]
             assert nodes_cache_names == [node1.name]
+
+
+@pytest.mark.fixed_client
+class TestClusterTopologyProvider:
+    """
+    Unit tests for the topology providers' response parsing.
+    """
+
+    expected_topology = [
+        (0, 8191, ("127.0.0.1", 7000), [("127.0.0.1", 7003)]),
+        (8192, 16383, ("127.0.0.1", 7001), [("127.0.0.1", 7002)]),
+    ]
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            default_cluster_shards,
+            default_cluster_shards_bytes_keys,
+            default_cluster_shards_resp2,
+        ],
+        ids=["resp3-str-keys", "resp3-bytes-keys", "resp2"],
+    )
+    def test_shards_parsing_is_shape_agnostic(self, response):
+        assert ClusterShardsTopologyProvider().parse(response) == self.expected_topology
+
+    def test_shards_parsing_accepts_paired_slot_ranges(self):
+        response = [
+            {**shard, "slots": [tuple(shard["slots"])]}
+            for shard in default_cluster_shards
+        ]
+
+        assert ClusterShardsTopologyProvider().parse(response) == self.expected_topology
+
+    def test_shards_and_slots_agree(self):
+        assert ClusterShardsTopologyProvider().parse(
+            default_cluster_shards
+        ) == ClusterSlotsTopologyProvider().parse(default_cluster_slots)
+
+    def test_slots_parsing_decodes_bytes(self):
+        response = [[0, 16383, [b"127.0.0.1", b"7000", b"node_0"]]]
+
+        assert ClusterSlotsTopologyProvider().parse(response) == [
+            (0, 16383, ("127.0.0.1", 7000), [])
+        ]
+
+    def test_shard_with_multiple_slot_ranges(self):
+        response = [
+            {
+                "slots": [0, 10, 100, 110],
+                "nodes": [{"ip": "127.0.0.1", "port": 7000, "role": "master"}],
+            }
+        ]
+
+        assert ClusterShardsTopologyProvider().parse(response) == [
+            (0, 10, ("127.0.0.1", 7000), []),
+            (100, 110, ("127.0.0.1", 7000), []),
+        ]
+
+    def test_primary_is_selected_by_role_not_position(self):
+        response = [
+            {
+                "slots": [0, 1],
+                "nodes": [
+                    {"ip": "127.0.0.1", "port": 7003, "role": "replica"},
+                    {"ip": "127.0.0.1", "port": 7000, "role": "master"},
+                ],
+            }
+        ]
+
+        assert ClusterShardsTopologyProvider().parse(response) == [
+            (0, 1, ("127.0.0.1", 7000), [("127.0.0.1", 7003)])
+        ]
+
+    @pytest.mark.parametrize("health", ["failed", "loading"])
+    def test_unhealthy_replicas_are_excluded(self, health):
+        response = [
+            {
+                "slots": [0, 1],
+                "nodes": [
+                    {"ip": "127.0.0.1", "port": 7000, "role": "master"},
+                    {
+                        "ip": "127.0.0.1",
+                        "port": 7003,
+                        "role": "replica",
+                        "health": health,
+                    },
+                ],
+            }
+        ]
+
+        assert ClusterShardsTopologyProvider().parse(response) == [
+            (0, 1, ("127.0.0.1", 7000), [])
+        ]
+
+    @pytest.mark.parametrize("health", ["failed", "loading"])
+    def test_unhealthy_primary_is_retained(self, health):
+        response = [
+            {
+                "slots": [0, 1],
+                "nodes": [
+                    {
+                        "ip": "127.0.0.1",
+                        "port": 7000,
+                        "role": "master",
+                        "health": health,
+                    }
+                ],
+            }
+        ]
+
+        assert ClusterShardsTopologyProvider().parse(response) == [
+            (0, 1, ("127.0.0.1", 7000), [])
+        ]
+
+    def test_shard_without_master_is_skipped(self):
+        response = [
+            {
+                "slots": [0, 1],
+                "nodes": [{"ip": "127.0.0.1", "port": 7003, "role": "replica"}],
+            }
+        ]
+
+        assert ClusterShardsTopologyProvider().parse(response) == []
+
+    def test_shard_without_slots_is_skipped(self):
+        response = [
+            {
+                "slots": [],
+                "nodes": [{"ip": "127.0.0.1", "port": 7000, "role": "master"}],
+            }
+        ]
+
+        assert ClusterShardsTopologyProvider().parse(response) == []
+
+    @pytest.mark.parametrize(
+        "node,expected_host",
+        [
+            ({"endpoint": "", "ip": "127.0.0.1"}, "127.0.0.1"),
+            ({"ip": "127.0.0.1"}, "127.0.0.1"),
+            ({"endpoint": "node.example.com", "ip": "127.0.0.1"}, "node.example.com"),
+        ],
+        ids=["empty-endpoint", "absent-endpoint", "endpoint-preferred"],
+    )
+    def test_host_falls_back_to_ip(self, node, expected_host):
+        response = [
+            {"slots": [0, 1], "nodes": [{**node, "port": 7000, "role": "master"}]}
+        ]
+
+        assert ClusterShardsTopologyProvider().parse(response) == [
+            (0, 1, (expected_host, 7000), [])
+        ]
+
+    def test_prefer_tls_port(self):
+        response = [
+            {
+                "slots": [0, 1],
+                "nodes": [
+                    {
+                        "ip": "127.0.0.1",
+                        "port": 7000,
+                        "tls-port": 7100,
+                        "role": "master",
+                    }
+                ],
+            }
+        ]
+
+        assert ClusterShardsTopologyProvider(prefer_tls_port=True).parse(response) == [
+            (0, 1, ("127.0.0.1", 7100), [])
+        ]
+        assert ClusterShardsTopologyProvider().parse(response) == [
+            (0, 1, ("127.0.0.1", 7000), [])
+        ]
+
+    def test_port_falls_back_when_preferred_is_absent(self):
+        response = [
+            {
+                "slots": [0, 1],
+                "nodes": [
+                    {"ip": "127.0.0.1", "tls-port": 7100, "role": "master"},
+                ],
+            }
+        ]
+
+        assert ClusterShardsTopologyProvider().parse(response) == [
+            (0, 1, ("127.0.0.1", 7100), [])
+        ]
+
+
+@pytest.mark.fixed_client
+class TestNodesManagerTopologyProvider:
+    """
+    Unit tests for topology provider selection in NodesManager.
+    """
+
+    @staticmethod
+    def _issued_commands(**kwargs):
+        """Build a mocked client, returning it with the commands it issued."""
+        issued = []
+        original = NodesManager.initialize
+
+        def recording_initialize(self, *args, **init_kwargs):
+            issued.extend(self._topology_provider.command)
+            return original(self, *args, **init_kwargs)
+
+        with patch.object(NodesManager, "initialize", recording_initialize):
+            client = get_mocked_redis_client(url="redis://127.0.0.1:7000", **kwargs)
+        return client, issued
+
+    def test_default_provider_uses_cluster_slots(self):
+        rc, issued = self._issued_commands()
+
+        assert isinstance(
+            rc.nodes_manager._topology_provider, ClusterSlotsTopologyProvider
+        )
+        assert "CLUSTER SLOTS" in issued
+        assert "CLUSTER SHARDS" not in issued
+
+    def test_shards_provider_issues_cluster_shards(self):
+        rc, issued = self._issued_commands(
+            topology_provider=ClusterShardsTopologyProvider()
+        )
+
+        assert "CLUSTER SHARDS" in issued
+        assert "CLUSTER SLOTS" not in issued
+        assert len(rc.nodes_manager.slots_cache) == REDIS_CLUSTER_HASH_SLOTS
+
+    def test_shards_provider_builds_same_topology_as_slots(self):
+        slots_client = get_mocked_redis_client(url="redis://127.0.0.1:7000")
+        shards_client = get_mocked_redis_client(
+            url="redis://127.0.0.1:7000",
+            topology_provider=ClusterShardsTopologyProvider(),
+        )
+
+        def slot_map(client):
+            return {
+                slot: [node.name for node in nodes]
+                for slot, nodes in client.nodes_manager.slots_cache.items()
+            }
+
+        assert slot_map(shards_client) == slot_map(slots_client)
+        assert sorted(shards_client.nodes_manager.nodes_cache) == sorted(
+            slots_client.nodes_manager.nodes_cache
+        )
+
+    def test_provider_does_not_leak_into_connection_kwargs(self):
+        rc = get_mocked_redis_client(
+            url="redis://127.0.0.1:7000",
+            topology_provider=ClusterShardsTopologyProvider(),
+        )
+
+        assert "topology_provider" not in rc.nodes_manager.connection_kwargs
+
+    @pytest.mark.parametrize(
+        "provider", [None, ClusterShardsTopologyProvider()], ids=["slots", "shards"]
+    )
+    def test_address_remap_applies_to_both_providers(self, provider):
+        kwargs = {"topology_provider": provider} if provider else {}
+        rc = get_mocked_redis_client(
+            url="redis://127.0.0.1:7000",
+            address_remap=lambda address: (address[0], address[1] + 1000),
+            **kwargs,
+        )
+
+        assert {node.port for node in rc.nodes_manager.nodes_cache.values()} == {
+            8000,
+            8001,
+            8002,
+            8003,
+        }
+
+    def test_single_node_cluster_uses_startup_host(self):
+        rc = get_mocked_redis_client(
+            url="redis://127.0.0.1:7000",
+            cluster_shards=[
+                {
+                    "slots": [0, REDIS_CLUSTER_HASH_SLOTS - 1],
+                    "nodes": [{"endpoint": "", "port": 7000, "role": "master"}],
+                }
+            ],
+            topology_provider=ClusterShardsTopologyProvider(),
+        )
+
+        assert list(rc.nodes_manager.nodes_cache) == ["127.0.0.1:7000"]
 
 
 @pytest.mark.fixed_client


### PR DESCRIPTION
### Description of change

Add support for cluster discovery via `CLUSTER SHARDS` rather than `CLUSTER SLOTS`, deprecated in Redis 7.0+.

This introduces `ClusterTopologyProvider`/`AsyncClusterTopologyProvider`, mirroring the existing `PolicyResolver` pattern: a provider names the topology command and parses its reply, while `NodesManager` keeps connection handling and cache construction. Adding a source is now a new subclass rather than a branch in `initialize()`.

`CLUSTER SHARDS` requires Redis 7.0+ and returns one entry per shard rather than per slot range, so replies stay small on clusters with fragmented slot maps. It is strictly opt-in via the new `topology_provider` kwarg; the default remains `CLUSTER SLOTS`.

The shards parser is tolerant of every shape the reply arrives in, because the async stack installs a `CLUSTER SHARDS` response callback on its node connections while the sync stack receives the raw wire reply.

Replicas reported as failed or loading are excluded; an unhealthy primary is retained, since dropping it would leave its slots uncovered.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how cluster slot maps are built on init and refresh; wrong parsing or replica filtering could misroute traffic, though defaults preserve prior behavior and coverage is extensive.
> 
> **Overview**
> Introduces **pluggable cluster topology discovery** via a new `topology_provider` argument on sync and async `RedisCluster`. Default behavior is unchanged (`CLUSTER SLOTS` through `ClusterSlotsTopologyProvider`); callers can opt into **`CLUSTER SHARDS`** (Redis 7.0+) with `ClusterShardsTopologyProvider` for more compact replies on fragmented slot maps.
> 
> `NodesManager` no longer parses `CLUSTER SLOTS` inline—it runs the provider’s command and builds slot/node caches from normalized `(start_slot, end_slot, primary, replicas)` tuples. The shards parser handles RESP2/RESP3 shapes, picks primaries by role, skips unhealthy replicas, supports `prefer_tls_port`, and leaves empty/null endpoints for the existing “use the queried startup host” fallback (without routing through internal `ip` behind load balancers).
> 
> Topology refresh errors now distinguish **unsupported topology commands** (“unknown subcommand”) from **cluster mode disabled**. Docs cover configuration, async providers, and subclassing `ClusterTopologyProvider` for custom discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b717731aec5ffd81ce3d2d221ec17668b8fe0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->