### PR TITLE
Assert the reclamation property in the _connect cycle tests

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,4 +1,5 @@
 import copy
+import gc
 import os
 import platform
 import select
@@ -9,6 +10,7 @@ import sys
 import threading
 import time
 import types
+import weakref
 from errno import ECONNREFUSED, EWOULDBLOCK
 from typing import Any
 from unittest import mock
@@ -582,6 +584,10 @@ class TestConnection:
         The exception's traceback references the frame, so a retained local
         would form a cycle only reclaimable by the GC.
         The finally clause in _connect breaks it by clearing the local.
+
+        The exception escapes to the caller here, so it cannot be asserted
+        dead; the frame is what has to be checked. See the sibling test for
+        the reclamation property, which does not depend on the local's name.
         """
         conn = Connection(host="localhost", port=6379)
         addr_info = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 6379))
@@ -602,41 +608,58 @@ class TestConnection:
                 connect_frame = tb.tb_frame
             tb = tb.tb_next
         assert connect_frame is not None
-        assert connect_frame.f_locals.get("err") is None
+        # `is None` alone also holds when no such local exists, so assert the
+        # name is present before asserting its value.
+        assert "err" in connect_frame.f_locals
+        assert connect_frame.f_locals["err"] is None
 
     def test_connect_breaks_reference_cycle_when_a_later_address_succeeds(self):
         """
         When an address fails but a later one connects, _connect must not
         return while still holding the caught exception.
-        The exception's traceback references the frame, so a retained local
-        would form a cycle only reclaimable by the GC.
         """
+
+        class WeakReferenceableOSError(OSError):
+            """OSError itself cannot be weak-referenced."""
+
         conn = Connection(host="localhost", port=6379)
         addr_infos = [
             (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 6379)),
             (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.2", 6379)),
         ]
 
-        # _connect calls getaddrinfo, so hook that as a way to peek the caller
-        connect_frames = []
+        # Raise from a factory so the test itself never holds a strong
+        # reference; the weakref is the only handle on the failure.
+        raised_ref = []
 
-        def capturing_getaddrinfo(*args, **kwargs):
-            connect_frames.append(sys._getframe(1))
-            return addr_infos
+        def fail_to_connect(*args, **kwargs):
+            err = WeakReferenceableOSError("refused")
+            raised_ref.append(weakref.ref(err))
+            try:
+                raise err
+            finally:
+                # Clear this frame's local too, or the traceback keeps the
+                # exception alive here and the assertion measures the test
+                # rather than _connect.
+                err = None
 
         failing_sock, working_sock = MagicMock(), MagicMock()
-        failing_sock.connect.side_effect = OSError("refused")
+        failing_sock.connect.side_effect = fail_to_connect
 
-        with (
-            patch.object(socket, "getaddrinfo", capturing_getaddrinfo),
-            patch.object(socket, "socket", side_effect=[failing_sock, working_sock]),
-        ):
-            assert conn._connect() is working_sock
+        gc.disable()
+        try:
+            with (
+                patch.object(socket, "getaddrinfo", return_value=addr_infos),
+                patch.object(
+                    socket, "socket", side_effect=[failing_sock, working_sock]
+                ),
+            ):
+                assert conn._connect() is working_sock
 
-        # Error should be cleared in the connect frame
-        assert len(connect_frames) == 1
-        (connect_frame,) = connect_frames
-        assert connect_frame.f_locals.get("err") is None
+            (ref,) = raised_ref
+            assert ref() is None
+        finally:
+            gc.enable()
 
     @pytest.mark.parametrize(
         "connection_kwargs",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -612,6 +612,10 @@ class TestConnection:
         assert "err" in connect_frame.f_locals
         assert connect_frame.f_locals["err"] is None
 
+    @pytest.mark.skipif(
+        platform.python_implementation() == "PyPy",
+        reason="Immediate reclamation is a refcounting property",
+    )
     def test_connect_breaks_reference_cycle_when_a_later_address_succeeds(self):
         """
         When an address fails but a later one connects, _connect must not
@@ -645,6 +649,7 @@ class TestConnection:
         failing_sock, working_sock = MagicMock(), MagicMock()
         failing_sock.connect.side_effect = fail_to_connect
 
+        gc_was_enabled = gc.isenabled()
         gc.disable()
         try:
             with (
@@ -658,7 +663,8 @@ class TestConnection:
             (ref,) = raised_ref
             assert ref() is None
         finally:
-            gc.enable()
+            if gc_was_enabled:
+                gc.enable()
 
     @pytest.mark.parametrize(
         "connection_kwargs",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,7 +6,6 @@ import select
 import selectors
 import socket
 import ssl
-import sys
 import threading
 import time
 import types


### PR DESCRIPTION
### Description of change

Follows up on the note in #4195, per @petyaslavova's ask there.

Both tests ended in `assert connect_frame.f_locals.get("err") is None`. `dict.get` returns `None` when the local was cleared and also when there is no local by that name, so renaming `err` while dropping both clears would have put the cycle straight back and left the tests green.

The fail-then-succeed case can assert the property instead of the name: with the GC disabled, refcounting alone has to reclaim the caught exception once `_connect` returns. It raises from a factory so the test holds no strong reference of its own, and it no longer mentions `err` anywhere.

The all-addresses-fail case cannot do that. The exception escapes to the caller, so it is legitimately still alive and there is nothing to assert dead. That one keeps frame introspection, with `assert "err" in connect_frame.f_locals` added before the value check so a rename fails loudly rather than passing vacuously.

Checked both ways: with the two `err = None` clears reverted, both tests fail; with them in place, both pass. `tests/test_connection.py` is otherwise unchanged from master on my machine (3 failed / 86 passed / 5 errors before and after, all needing a live server).

Both gaps were reported by [Context Goblin](https://github.com/apps/contextgoblin), an automated reviewer I'm building, run against a fork with #4195 recreated on it.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

Tests only, so no docs or examples. CI box left unchecked since I have not enabled actions on the fork.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to connection reference-cycle coverage; no library behavior is modified.
> 
> **Overview**
> **Tightens regression tests** for `Connection._connect` clearing the `err` local so failed connection attempts do not leave exception↔frame reference cycles.
> 
> For the all-addresses-fail path, the test now requires `"err"` to exist in the `_connect` frame before asserting it is `None`, so a renamed or removed local cannot pass via `f_locals.get("err")`.
> 
> For fail-then-succeed, frame introspection is replaced with **GC disabled** and a **weak reference** to a custom `OSError` subclass: after `_connect` returns the working socket, the caught exception must be gone without relying on the local’s name. The test is **skipped on PyPy** (refcount semantics). Docstrings clarify why the two cases use different strategies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd66b2dbcafe07f61c69437653caf0ac9405377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->