### PR TITLE
docs: point multi-database docs at geographic_failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ This is useful when:
 1. You have more than one Redis deployment. This might include two independent Redis servers or two or more Redis databases replicated across multiple [active-active Redis Enterprise](https://redis.io/docs/latest/operate/rs/databases/active-active/) clusters.
 2. You want your application to connect to one deployment at a time and to fail over to the next available deployment if the first deployment becomes unavailable.
 
-For the complete failover configuration options and examples, see the [Multi-database client docs](https://redis.readthedocs.io/en/latest/multi_database.html).
+For the complete failover configuration options and examples, see the [Multi-database client docs](https://redis.readthedocs.io/en/latest/geographic_failover.html).
 
 ### Bulk hash ingestion (HIMPORT)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ Module Documentation
 
    connections
    clustering
-   multi_database
+   geographic_failover
    exceptions
    backoff
    lock


### PR DESCRIPTION
## Problem

README linked to `https://redis.readthedocs.io/en/latest/multi_database.html`,
and `docs/index.rst` included a `multi_database` toctree entry.
There is no `docs/multi_database.rst` in the tree. The page that exists is
`docs/geographic_failover.rst`.

Verified:

    GET https://redis.readthedocs.io/en/latest/multi_database.html -> 404
    GET https://redis.readthedocs.io/en/latest/geographic_failover.html -> 200

## Solution

Point the README at the published geographic failover page and include
`geographic_failover` in the Sphinx toctree.

## Verification

GET `https://redis.readthedocs.io/en/latest/geographic_failover.html` returns 200.
`docs/geographic_failover.rst` is present in the repository.

This is a documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL and toctree fixes with no runtime or API impact.
> 
> **Overview**
> Fixes broken documentation links for the multi-database (Active-Active) client by aligning names with the page that actually ships in the docs.
> 
> The **README** “Multi-database client” link now targets `geographic_failover.html` instead of the 404 `multi_database.html` URL. The Sphinx **docs index** toctree swaps the missing `multi_database` entry for `geographic_failover`, matching `docs/geographic_failover.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f36f2a6daac210d36666bbea18409aecd5155d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->