### PR TITLE
docs: fix OpenTelemetry Flask guide URL

### DIFF
--- a/docs/opentelemetry.rst
+++ b/docs/opentelemetry.rst
@@ -346,6 +346,6 @@ Next, you can learn how to configure `uptrace-python <https://uptrace.dev/get/op
 You may also be interested in the following guides:
 
 - `OpenTelemetry Django <https://uptrace.dev/get/instrument/opentelemetry-django.html>`_
-- `OpenTelemetry Flask <https://uptrace.dev/get/instrument/instrument/opentelemetry-flask.html>`_
+- `OpenTelemetry Flask <https://uptrace.dev/get/instrument/opentelemetry-flask.html>`_
 - `OpenTelemetry FastAPI <https://uptrace.dev/get/instrument/opentelemetry-fastapi.html>`_
 - `OpenTelemetry SQLAlchemy <https://uptrace.dev/get/instrument/opentelemetry-sqlalchemy.html>`_


### PR DESCRIPTION
## Problem

The OpenTelemetry Flask guide link used a duplicated `/instrument/instrument/`
path and returned 404.

Verified:

    GET https://uptrace.dev/get/instrument/instrument/opentelemetry-flask.html -> 404
    GET https://uptrace.dev/get/instrument/opentelemetry-flask.html -> 200
        (redirects to https://uptrace.dev/guides/opentelemetry-flask)

Sibling Django/FastAPI/SQLAlchemy links already use a single `/instrument/` segment.

## Solution

Use the same path shape as the other Uptrace instrument guides.

## Verification

GET of the replacement URL returns 200.

This is a documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL fix with no runtime or behavioral impact.
> 
> **Overview**
> Corrects the **OpenTelemetry Flask** link in `docs/opentelemetry.rst` so it matches the other instrument guides (Django, FastAPI, SQLAlchemy).
> 
> The URL was `.../get/instrument/instrument/opentelemetry-flask.html` (404); it is now `.../get/instrument/opentelemetry-flask.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9f06cec825c89d5c6dbaa2698c510cd9d5f512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->