### PR TITLE
fix: use ZRANGE REV instead of deprecated ZREVRANGE

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -8923,11 +8923,6 @@ class SortedSetCommands(CommandsProtocol):
 
         For more information, see https://redis.io/commands/zrange
         """
-        # Need to support ``desc`` also when using old redis version
-        # because it was supported in 3.5.3 (of redis-py)
-        if not byscore and not bylex and (offset is None and num is None) and desc:
-            return self.zrevrange(name, start, end, withscores, score_cast_func)
-
         return self._zrange(
             "ZRANGE",
             None,


### PR DESCRIPTION
## Summary

Fixes #4268

Remove the legacy fallback in `zrange(desc=True)` that delegated to `zrevrange()` which sends the deprecated `ZREVRANGE` command.

## Problem

Since redis-py >= 6.0.0 only supports Redis 7.2+, and Redis 7.2+ supports `ZRANGE ... REV`, the `_zrange` helper already handles `desc` correctly by appending `REV` to the `ZRANGE` command. But the `zrange` method had a shortcut that bypassed `_zrange` and called `zrevrange()` directly, sending the deprecated `ZREVRANGE` command.

## Fix

Removed the 5-line legacy fallback. `zrange(desc=True)` now sends `ZRANGE ... REV` instead of `ZREVRANGE`, aligning with the Redis deprecation roadmap.

The existing `zrevrange()` method is preserved for direct callers who want the explicit `ZREVRANGE` command.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>