### PR TITLE
Preserve status codes for unmapped response errors

### DIFF
--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -119,7 +119,7 @@ class BaseParser(ABC):
             if isinstance(exception_class, dict):
                 exception_class = exception_class.get(response, ResponseError)
             return exception_class(response, status_code=error_code)
-        return ResponseError(response)
+        return ResponseError(response, status_code=error_code)
 
     @abstractmethod
     def on_disconnect(self):

--- a/tests/test_parsers/test_errors.py
+++ b/tests/test_parsers/test_errors.py
@@ -2,8 +2,9 @@ import socket
 from unittest.mock import patch
 
 import pytest
+from redis._parsers.base import BaseParser
 from redis.client import Redis
-from redis.exceptions import ExternalAuthProviderError
+from redis.exceptions import ExternalAuthProviderError, ResponseError
 
 
 class MockSocket:
@@ -116,6 +117,17 @@ class MockSocket:
 
     def shutdown(self, how):
         pass
+
+
+def test_unmapped_response_error_preserves_status_code_and_message():
+    response = "BUSYGROUP Consumer Group name already exists"
+
+    error = BaseParser.parse_error(response)
+
+    assert type(error) is ResponseError
+    assert str(error) == response
+    assert error.args == (response,)
+    assert error.status_code == "BUSYGROUP"
 
 
 @pytest.mark.fixed_client


### PR DESCRIPTION
## Summary

- preserve the RESP error code on generic `ResponseError` instances
- add a compatibility test covering an unmapped `BUSYGROUP` response

## Why

`BaseParser.parse_error()` extracts the server error code, but currently only passes it to mapped exception classes. Unmapped errors retain the full response message but leave `status_code` as `None`, requiring callers to parse `str(error)` even though `RedisError` exposes a structured `status_code` attribute.

This change preserves the existing exception type, message, and arguments while populating the already-public field.

## Validation

- `invoke linters`
- focused parser compatibility test
- fixed-client suite: 1,261 passed, 2 skipped
- standalone suite: 3,393 passed, 660 skipped; two macOS `AF_UNIX path too long` failures passed when rerun with a shorter `TMPDIR`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small parser behavior fix with no auth, security, or data-path changes; covered by a focused compatibility test.
> 
> **Overview**
> Unmapped RESP error replies (e.g. **BUSYGROUP**) now get the leading token on **`ResponseError.status_code`**, matching mapped exceptions from `BaseParser.parse_error()`.
> 
> Exception type, message, and `args` stay the same; callers can use the structured field instead of parsing `str(error)`.
> 
> A parser test asserts an unmapped **BUSYGROUP** response keeps the full message and sets `status_code` to `"BUSYGROUP"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 776b3233179956c84bccb7a10fd5fd24c7595c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->