### PR TITLE
fix(multidb): stop star-unpacking args in execute_pubsub_method

### DIFF
--- a/redis/asyncio/multidb/command_executor.py
+++ b/redis/asyncio/multidb/command_executor.py
@@ -280,7 +280,7 @@ class DefaultCommandExecutor(BaseCommandExecutor, AsyncCommandExecutor):
             await self._register_command_execution(args)
             return response
 
-        return await self._execute_with_failure_detection(callback, *args)
+        return await self._execute_with_failure_detection(callback, args)
 
     async def execute_pubsub_run(
         self, sleep_time: float, exception_handler=None, pubsub=None

--- a/redis/multidb/command_executor.py
+++ b/redis/multidb/command_executor.py
@@ -300,7 +300,7 @@ class DefaultCommandExecutor(SyncCommandExecutor, BaseCommandExecutor):
             self._register_command_execution(args)
             return response
 
-        return self._execute_with_failure_detection(callback, *args)
+        return self._execute_with_failure_detection(callback, args)
 
     def execute_pubsub_run(self, sleep_time, **kwargs) -> "PubSubWorkerThread":
         def callback():

--- a/tests/test_asyncio/test_multidb/test_command_executor.py
+++ b/tests/test_asyncio/test_multidb/test_command_executor.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from redis.asyncio.multidb.failure_detector import FailureDetectorAsyncWrapper
-from redis.event import EventDispatcher
+from redis.event import EventDispatcher, OnCommandsFailEvent
 from redis.exceptions import ConnectionError
 from redis.asyncio.multidb.command_executor import DefaultCommandExecutor
 from redis.asyncio.retry import Retry
@@ -180,3 +180,83 @@ class TestDefaultCommandExecutor:
         assert await executor.execute_command("SET", "key", "value") == "OK2"
         assert await executor.execute_command("SET", "key", "value") == "OK1"
         assert mock_selector.call_count == 3
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_db,mock_db1,mock_db2",
+        [
+            (
+                {"weight": 0.2, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.7, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.5, "circuit": {"state": CBState.CLOSED}},
+            ),
+        ],
+        indirect=True,
+    )
+    async def test_execute_pubsub_method_forwards_multiple_args(
+        self, mock_db, mock_db1, mock_db2, mock_fd, mock_fs, mock_ed
+    ):
+        databases = create_weighted_list(mock_db, mock_db1, mock_db2)
+
+        executor = DefaultCommandExecutor(
+            failure_detectors=[mock_fd],
+            databases=databases,
+            failover_strategy=mock_fs,
+            event_dispatcher=mock_ed,
+            command_retry=Retry(NoBackoff(), 0),
+        )
+
+        await executor.set_active_database(mock_db1, GeoFailoverReason.MANUAL)
+        executor.active_pubsub = AsyncMock()
+
+        # Subscribing to more than one channel used to raise TypeError,
+        # because execute_pubsub_method star-unpacked the args tuple into
+        # _execute_with_failure_detection, which only accepts one extra arg.
+        await executor.execute_pubsub_method("subscribe", "channel-1", "channel-2")
+
+        executor.active_pubsub.subscribe.assert_called_once_with(
+            "channel-1", "channel-2"
+        )
+        mock_fd.register_command_execution.assert_called_once_with(
+            ("channel-1", "channel-2")
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_db,mock_db1,mock_db2",
+        [
+            (
+                {"weight": 0.2, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.7, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.5, "circuit": {"state": CBState.CLOSED}},
+            ),
+        ],
+        indirect=True,
+    )
+    async def test_execute_pubsub_method_failure_reports_intact_command_tuple(
+        self, mock_db, mock_db1, mock_db2, mock_fd, mock_fs, mock_ed
+    ):
+        databases = create_weighted_list(mock_db, mock_db1, mock_db2)
+
+        executor = DefaultCommandExecutor(
+            failure_detectors=[mock_fd],
+            databases=databases,
+            failover_strategy=mock_fs,
+            event_dispatcher=mock_ed,
+            command_retry=Retry(NoBackoff(), 0),
+        )
+
+        await executor.set_active_database(mock_db1, GeoFailoverReason.MANUAL)
+        mock_pubsub = AsyncMock()
+        mock_pubsub.subscribe.side_effect = ConnectionError("boom")
+        executor.active_pubsub = mock_pubsub
+
+        # With a single channel the old code passed a bare string as `cmds`,
+        # so the failure event star-unpacked it into individual characters
+        # instead of the channel name.
+        with pytest.raises(ConnectionError):
+            await executor.execute_pubsub_method("subscribe", "channel-1")
+
+        event = mock_ed.dispatch_async.call_args[0][0]
+        assert isinstance(event, OnCommandsFailEvent)
+        assert event.commands == ("channel-1",)

--- a/tests/test_multidb/test_command_executor.py
+++ b/tests/test_multidb/test_command_executor.py
@@ -1,9 +1,10 @@
 from time import sleep
+from unittest.mock import Mock
 
 import pytest
 
 from redis.backoff import NoBackoff
-from redis.event import EventDispatcher
+from redis.event import EventDispatcher, OnCommandsFailEvent
 from redis.exceptions import ConnectionError
 from redis.multidb.circuit import State as CBState
 from redis.multidb.command_executor import DefaultCommandExecutor
@@ -172,3 +173,81 @@ class TestDefaultCommandExecutor:
         assert executor.execute_command("SET", "key", "value") == "OK2"
         assert executor.execute_command("SET", "key", "value") == "OK1"
         assert mock_fs.database.call_count == 3
+
+    @pytest.mark.parametrize(
+        "mock_db,mock_db1,mock_db2",
+        [
+            (
+                {"weight": 0.2, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.7, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.5, "circuit": {"state": CBState.CLOSED}},
+            ),
+        ],
+        indirect=True,
+    )
+    def test_execute_pubsub_method_forwards_multiple_args(
+        self, mock_db, mock_db1, mock_db2, mock_fd, mock_fs, mock_ed
+    ):
+        databases = create_weighted_list(mock_db, mock_db1, mock_db2)
+
+        executor = DefaultCommandExecutor(
+            failure_detectors=[mock_fd],
+            databases=databases,
+            failover_strategy=mock_fs,
+            event_dispatcher=mock_ed,
+            command_retry=Retry(NoBackoff(), 0),
+        )
+
+        executor.active_database = (mock_db1, GeoFailoverReason.MANUAL)
+        executor.active_pubsub = Mock()
+
+        # Subscribing to more than one channel used to raise TypeError,
+        # because execute_pubsub_method star-unpacked the args tuple into
+        # _execute_with_failure_detection, which only accepts one extra arg.
+        executor.execute_pubsub_method("subscribe", "channel-1", "channel-2")
+
+        executor.active_pubsub.subscribe.assert_called_once_with(
+            "channel-1", "channel-2"
+        )
+        mock_fd.register_command_execution.assert_called_once_with(
+            ("channel-1", "channel-2")
+        )
+
+    @pytest.mark.parametrize(
+        "mock_db,mock_db1,mock_db2",
+        [
+            (
+                {"weight": 0.2, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.7, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.5, "circuit": {"state": CBState.CLOSED}},
+            ),
+        ],
+        indirect=True,
+    )
+    def test_execute_pubsub_method_failure_reports_intact_command_tuple(
+        self, mock_db, mock_db1, mock_db2, mock_fd, mock_fs, mock_ed
+    ):
+        databases = create_weighted_list(mock_db, mock_db1, mock_db2)
+
+        executor = DefaultCommandExecutor(
+            failure_detectors=[mock_fd],
+            databases=databases,
+            failover_strategy=mock_fs,
+            event_dispatcher=mock_ed,
+            command_retry=Retry(NoBackoff(), 0),
+        )
+
+        executor.active_database = (mock_db1, GeoFailoverReason.MANUAL)
+        mock_pubsub = Mock()
+        mock_pubsub.subscribe.side_effect = ConnectionError("boom")
+        executor.active_pubsub = mock_pubsub
+
+        # With a single channel the old code passed a bare string as `cmds`,
+        # so the failure event star-unpacked it into individual characters
+        # instead of the channel name.
+        with pytest.raises(ConnectionError):
+            executor.execute_pubsub_method("subscribe", "channel-1")
+
+        event = mock_ed.dispatch.call_args[0][0]
+        assert isinstance(event, OnCommandsFailEvent)
+        assert event.commands == ("channel-1",)


### PR DESCRIPTION
## Summary

Fixes #4274.

`DefaultCommandExecutor.execute_pubsub_method` forwarded its `args` tuple star-unpacked into `_execute_with_failure_detection(callback, cmds: tuple = ())`, which only accepts one extra positional argument:

```python
return self._execute_with_failure_detection(callback, *args)
```

Subscribing to more than one channel through `MultiDBClient.pubsub()` raised `TypeError`. Subscribing to exactly one channel didn't crash, but the channel string was star-unpacked into individual characters before reaching the failure detector on the failure path, so `"channel-1"` got reported as `('c', 'h', 'a', 'n', ...)` instead of `("channel-1",)`.

The fix is passing the tuple unstarred, matching how `execute_command` and `execute_pipeline` already do it right next to this method:

```python
return self._execute_with_failure_detection(callback, args)
```

Same bug, same fix, in both `redis/multidb/command_executor.py` (sync) and `redis/asyncio/multidb/command_executor.py` (async).

## Test coverage

Added to both `tests/test_multidb/test_command_executor.py` and `tests/test_asyncio/test_multidb/test_command_executor.py`:

- `test_execute_pubsub_method_forwards_multiple_args` — subscribing to two channels no longer raises, and the failure detector is registered with the correct args tuple.
- `test_execute_pubsub_method_failure_reports_intact_command_tuple` — on a subscribe failure, the dispatched `OnCommandsFailEvent.commands` is `("channel-1",)`, not exploded into characters.

Confirmed both new tests fail against the pre-fix code (one with the `TypeError`, one with the corrupted tuple) and pass with the fix. Full `tests/test_multidb/` and `tests/test_asyncio/test_multidb/` suites (158 tests, excluding the infra-dependent integration tests) pass, and `ruff check` / `ruff format --check` are clean on all changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line argument-passing fix in command execution with tests; no auth, data, or failover-strategy changes.
> 
> **Overview**
> Stops `execute_pubsub_method` from star-unpacking `args` into `_execute_with_failure_detection` in both sync and async MultiDB executors.
> 
> That unpacking caused a `TypeError` when subscribing to more than one channel, and on the failure path a single channel name was exploded into characters in `OnCommandsFailEvent`. The tuple is now passed intact, matching `execute_command` / `execute_pipeline`. Tests cover multi-channel subscribe and intact failure-event commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd30a822cae8067299664ee9eb2ed40e88880959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->