### PR TITLE
Fix asyncio Connection mutating caller retry_on_error list

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -665,6 +665,9 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         self.retry_on_timeout = retry_on_timeout
         if retry_on_error is SENTINEL:
             retry_on_error = []
+        else:
+            # Copy so we never mutate the caller-supplied list (parity with sync).
+            retry_on_error = list(retry_on_error)
         if retry_on_timeout:
             retry_on_error.append(TimeoutError)
             retry_on_error.append(socket.timeout)

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -591,7 +591,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         socket_timeout: float | None = DEFAULT_SOCKET_TIMEOUT,
         socket_connect_timeout: float | None = DEFAULT_SOCKET_CONNECT_TIMEOUT,
         retry_on_timeout: bool = False,
-        retry_on_error: list | object = SENTINEL,
+        retry_on_error: Iterable[Type[Exception]] | object = SENTINEL,
         encoding: str = "utf-8",
         encoding_errors: str = "strict",
         decode_responses: bool = False,

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -59,6 +59,21 @@ class TestConnectionConstructorWithRetry:
         assert isinstance(c.retry, Retry)
         assert c.retry._retries == retries
 
+    @pytest.mark.parametrize("Class", [Connection, UnixDomainSocketConnection])
+    def test_retry_on_error_does_not_mutate_caller_list(self, Class):
+        retry_on_error = [ValueError]
+        snapshot = list(retry_on_error)
+
+        # Two constructions must not grow or otherwise mutate the caller's list.
+        c1 = Class(retry_on_error=retry_on_error, retry_on_timeout=True)
+        c2 = Class(retry_on_error=retry_on_error, retry_on_timeout=True)
+
+        assert retry_on_error == snapshot
+        assert retry_on_error is not c1.retry_on_error
+        assert ValueError in c1.retry_on_error
+        assert TimeoutError in c1.retry_on_error
+        assert c1.retry_on_error == c2.retry_on_error
+
     @pytest.mark.parametrize("retries", range(10))
     @pytest.mark.parametrize("Class", [Connection, UnixDomainSocketConnection])
     def test_retry_with_retry_on_error(self, Class, retries: int):


### PR DESCRIPTION
### Description of change

`AbstractAsyncConnection.__init__` appended timeout exceptions onto the caller-supplied `retry_on_error` list. A shared list (or one reused by a connection pool) therefore grew on every construction, and the sync client already avoided this by copying first.

Copy the list before appending, matching `AbstractConnection` in `redis/connection.py`. Construction no longer mutates the caller's list, including after two connections are created with `retry_on_timeout=True`.

Fixes #4278

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized constructor fix matching existing sync behavior, with a focused regression test; no change to retry runtime logic beyond avoiding shared-list mutation.
> 
> **Overview**
> Fixes a bug where **async** `AbstractConnection` appended timeout exception types directly onto the caller’s `retry_on_error` list when `retry_on_timeout=True`, so a shared list (e.g. from pool kwargs) could grow on every connection build. The sync client already copied first; async now does the same with `list(retry_on_error)` before appending `TimeoutError`, `socket.timeout`, and `asyncio.TimeoutError`.
> 
> The `retry_on_error` parameter type is tightened from bare `list` to `Iterable[Type[Exception]] | object` for clearer typing. A regression test ensures two constructions with `retry_on_timeout=True` leave the original list unchanged and give each connection its own copy with the expected timeout types added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29a3a4342a78d78b393e6b86ded8ba65c7a2d50c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->