### PR TITLE
fix(connection): parse retry_on_error URL query as exception classes

### DIFF
--- a/docs/retry.rst
+++ b/docs/retry.rst
@@ -29,6 +29,10 @@ As you can see from the example above, Redis client supports 2 parameters to con
       which can be overridden by passing a tuple with :ref:`exceptions-label` to the ``supported_errors`` parameter.
 * ``retry_on_error``: list of additional :ref:`exceptions-label` to retry on
 
+``retry_on_error`` can also be set in a connection URL as a comma-separated
+list of names from :mod:`redis.exceptions` (for example
+``redis://localhost?retry_on_error=ConnectionError,TimeoutError``).
+
 
 If no ``retry`` is provided, a default one is created with  :class:`~.ExponentialWithJitterBackoff` as backoff strategy
 and 3 retries.

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1757,7 +1757,7 @@ def parse_retry_on_error(value):
     for name in value.replace("[", "").replace("]", "").split(","):
         name = name.strip()
         if not name:
-            continue
+            raise ValueError("Empty retry_on_error entry")
         exc = getattr(redis_exceptions, name, None)
         if not (isinstance(exc, type) and issubclass(exc, Exception)):
             raise ValueError(f"Unknown redis exception {name!r}")

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -60,6 +60,7 @@ if sys.version_info >= (3, 11, 3):
 else:
     from async_timeout import timeout as async_timeout
 
+from redis import exceptions as redis_exceptions
 from redis.asyncio.maint_notifications import (
     AsyncMaintNotificationsConnectionHandler,
     AsyncMaintNotificationsPoolHandler,
@@ -1734,6 +1735,21 @@ def parse_ssl_verify_flags(value):
     return verify_flags
 
 
+def parse_retry_on_error(value):
+    # exception class names are passed as a comma-separated list,
+    # e.g. ConnectionError,TimeoutError
+    retry_on_error = []
+    for name in value.replace("[", "").replace("]", "").split(","):
+        name = name.strip()
+        if not name:
+            continue
+        exc = getattr(redis_exceptions, name, None)
+        if not (isinstance(exc, type) and issubclass(exc, BaseException)):
+            raise ValueError(f"Unknown redis exception {name!r}")
+        retry_on_error.append(exc)
+    return retry_on_error
+
+
 URL_QUERY_ARGUMENT_PARSERS: Mapping[str, Callable[..., object]] = MappingProxyType(
     {
         "db": int,
@@ -1742,6 +1758,7 @@ URL_QUERY_ARGUMENT_PARSERS: Mapping[str, Callable[..., object]] = MappingProxyTy
         "socket_read_size": int,
         "socket_keepalive": to_bool,
         "retry_on_timeout": to_bool,
+        "retry_on_error": parse_retry_on_error,
         "max_connections": int,
         "health_check_interval": int,
         "ssl_check_hostname": to_bool,
@@ -1788,8 +1805,10 @@ def parse_url(url: str) -> ConnectKwargs:
             if parser:
                 try:
                     kwargs[name] = parser(value)
-                except (TypeError, ValueError):
-                    raise ValueError(f"Invalid value for '{name}' in connection URL.")
+                except (TypeError, ValueError) as err:
+                    raise ValueError(
+                        f"Invalid value for '{name}' in connection URL: {err}"
+                    ) from err
             else:
                 kwargs[name] = value
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -666,9 +666,6 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         self.retry_on_timeout = retry_on_timeout
         if retry_on_error is SENTINEL:
             retry_on_error = []
-        else:
-            # Copy so we never mutate the caller-supplied list (parity with sync).
-            retry_on_error = list(retry_on_error)
         if retry_on_timeout:
             retry_on_error.append(TimeoutError)
             retry_on_error.append(socket.timeout)
@@ -1747,7 +1744,7 @@ def parse_retry_on_error(value):
         if not name:
             continue
         exc = getattr(redis_exceptions, name, None)
-        if not (isinstance(exc, type) and issubclass(exc, BaseException)):
+        if not (isinstance(exc, type) and issubclass(exc, Exception)):
             raise ValueError(f"Unknown redis exception {name!r}")
         retry_on_error.append(exc)
     return retry_on_error
@@ -1808,14 +1805,8 @@ def parse_url(url: str) -> ConnectKwargs:
             if parser:
                 try:
                     kwargs[name] = parser(value)
-                except (TypeError, ValueError) as err:
-                    if parser is parse_retry_on_error:
-                        raise ValueError(
-                            f"Invalid value for '{name}' in connection URL: {err}"
-                        ) from err
-                    raise ValueError(
-                        f"Invalid value for '{name}' in connection URL."
-                    ) from err
+                except (TypeError, ValueError):
+                    raise ValueError(f"Invalid value for '{name}' in connection URL.")
             else:
                 kwargs[name] = value
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -666,6 +666,9 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         self.retry_on_timeout = retry_on_timeout
         if retry_on_error is SENTINEL:
             retry_on_error = []
+        else:
+            # Copy so we never mutate the caller-supplied list (parity with sync).
+            retry_on_error = list(retry_on_error)
         if retry_on_timeout:
             retry_on_error.append(TimeoutError)
             retry_on_error.append(socket.timeout)
@@ -1806,8 +1809,12 @@ def parse_url(url: str) -> ConnectKwargs:
                 try:
                     kwargs[name] = parser(value)
                 except (TypeError, ValueError) as err:
+                    if parser is parse_retry_on_error:
+                        raise ValueError(
+                            f"Invalid value for '{name}' in connection URL: {err}"
+                        ) from err
                     raise ValueError(
-                        f"Invalid value for '{name}' in connection URL: {err}"
+                        f"Invalid value for '{name}' in connection URL."
                     ) from err
             else:
                 kwargs[name] = value

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2344,7 +2344,7 @@ def parse_retry_on_error(value):
         if not name:
             continue
         exc = getattr(redis_exceptions, name, None)
-        if not (isinstance(exc, type) and issubclass(exc, BaseException)):
+        if not (isinstance(exc, type) and issubclass(exc, Exception)):
             raise ValueError(f"Unknown redis exception {name!r}")
         retry_on_error.append(exc)
     return retry_on_error
@@ -2393,14 +2393,8 @@ def parse_url(url):
             if parser:
                 try:
                     kwargs[name] = parser(value)
-                except (TypeError, ValueError) as err:
-                    if parser is parse_retry_on_error:
-                        raise ValueError(
-                            f"Invalid value for '{name}' in connection URL: {err}"
-                        ) from err
-                    raise ValueError(
-                        f"Invalid value for '{name}' in connection URL."
-                    ) from err
+                except (TypeError, ValueError):
+                    raise ValueError(f"Invalid value for '{name}' in connection URL.")
             else:
                 kwargs[name] = value
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2394,8 +2394,12 @@ def parse_url(url):
                 try:
                     kwargs[name] = parser(value)
                 except (TypeError, ValueError) as err:
+                    if parser is parse_retry_on_error:
+                        raise ValueError(
+                            f"Invalid value for '{name}' in connection URL: {err}"
+                        ) from err
                     raise ValueError(
-                        f"Invalid value for '{name}' in connection URL: {err}"
+                        f"Invalid value for '{name}' in connection URL."
                     ) from err
             else:
                 kwargs[name] = value

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2342,7 +2342,7 @@ def parse_retry_on_error(value):
     for name in value.replace("[", "").replace("]", "").split(","):
         name = name.strip()
         if not name:
-            continue
+            raise ValueError("Empty retry_on_error entry")
         exc = getattr(redis_exceptions, name, None)
         if not (isinstance(exc, type) and issubclass(exc, Exception)):
             raise ValueError(f"Unknown redis exception {name!r}")

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -34,6 +34,7 @@ from redis.cache import (
 )
 from redis.commands.metadata import MetadataResolver
 
+from . import exceptions as redis_exceptions
 from ._defaults import (
     DEFAULT_SOCKET_CONNECT_TIMEOUT,
     DEFAULT_SOCKET_READ_SIZE,
@@ -2334,6 +2335,21 @@ def parse_ssl_verify_flags(value):
     return verify_flags
 
 
+def parse_retry_on_error(value):
+    # exception class names are passed as a comma-separated list,
+    # e.g. ConnectionError,TimeoutError
+    retry_on_error = []
+    for name in value.replace("[", "").replace("]", "").split(","):
+        name = name.strip()
+        if not name:
+            continue
+        exc = getattr(redis_exceptions, name, None)
+        if not (isinstance(exc, type) and issubclass(exc, BaseException)):
+            raise ValueError(f"Unknown redis exception {name!r}")
+        retry_on_error.append(exc)
+    return retry_on_error
+
+
 URL_QUERY_ARGUMENT_PARSERS = {
     "db": int,
     "socket_timeout": float,
@@ -2341,7 +2357,7 @@ URL_QUERY_ARGUMENT_PARSERS = {
     "socket_read_size": int,
     "socket_keepalive": to_bool,
     "retry_on_timeout": to_bool,
-    "retry_on_error": list,
+    "retry_on_error": parse_retry_on_error,
     "max_connections": int,
     "health_check_interval": int,
     "ssl_check_hostname": to_bool,
@@ -2377,8 +2393,10 @@ def parse_url(url):
             if parser:
                 try:
                     kwargs[name] = parser(value)
-                except (TypeError, ValueError):
-                    raise ValueError(f"Invalid value for '{name}' in connection URL.")
+                except (TypeError, ValueError) as err:
+                    raise ValueError(
+                        f"Invalid value for '{name}' in connection URL: {err}"
+                    ) from err
             else:
                 kwargs[name] = value
 

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -1076,6 +1076,21 @@ def test_parse_url_retry_on_error_comma_separated():
     assert kw["retry_on_error"] == [ConnectionError, TimeoutError]
 
 
+def test_parse_url_retry_on_error_bracket_list():
+    kw = parse_url(
+        "redis://localhost:6379/?retry_on_error=[ConnectionError,TimeoutError]"
+    )
+    assert kw["retry_on_error"] == [ConnectionError, TimeoutError]
+
+
+def test_parse_url_retry_on_error_blank_entry():
+    with pytest.raises(ValueError) as exc_info:
+        parse_url("redis://localhost:6379/?retry_on_error=,")
+    assert str(exc_info.value) == (
+        "Invalid value for 'retry_on_error' in connection URL."
+    )
+
+
 def test_parse_url_invalid_db_keeps_stable_message():
     with pytest.raises(ValueError) as exc_info:
         parse_url("redis://localhost:6379/?db=not-an-int")

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -979,27 +979,9 @@ def test_parse_url_invalid_db_keeps_stable_message():
 def test_parse_url_retry_on_error_unknown_name():
     with pytest.raises(ValueError) as exc_info:
         parse_url("redis://localhost:6379/?retry_on_error=NotARealError")
-    message = str(exc_info.value)
-    assert message == (
-        "Invalid value for 'retry_on_error' in connection URL: "
-        "Unknown redis exception 'NotARealError'"
+    assert str(exc_info.value) == (
+        "Invalid value for 'retry_on_error' in connection URL."
     )
-
-
-def test_parse_url_retry_on_error_does_not_mutate_shared_list():
-    kw = parse_url(
-        "redis://localhost:6379/?retry_on_error=ConnectionError&retry_on_timeout=true"
-    )
-    snapshot = list(kw["retry_on_error"])
-
-    c1 = Connection(**kw)
-    c2 = Connection(**kw)
-
-    assert kw["retry_on_error"] == snapshot
-    assert kw["retry_on_error"] is not c1.retry_on_error
-    assert ConnectionError in c1.retry_on_error
-    assert TimeoutError in c1.retry_on_error
-    assert c1.retry_on_error == c2.retry_on_error
 
 
 @pytest.mark.asyncio
@@ -1008,7 +990,7 @@ async def test_parse_url_retry_on_error_usable_in_retry():
     conn = Connection(**kw)
     assert ConnectionError in conn.retry._supported_errors
     assert all(
-        isinstance(err, type) and issubclass(err, BaseException)
+        isinstance(err, type) and issubclass(err, Exception)
         for err in conn.retry._supported_errors
     )
 

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -956,3 +956,45 @@ async def test_disconnect_no_current_task_calls_close(request):
             mock_on_disconnect.assert_called_once()
 
     assert not conn.is_connected
+
+
+def test_parse_url_retry_on_error_resolves_exception_names():
+    kw = parse_url("redis://localhost:6379/?retry_on_error=ConnectionError")
+    assert kw["retry_on_error"] == [ConnectionError]
+
+
+def test_parse_url_retry_on_error_comma_separated():
+    kw = parse_url(
+        "redis://localhost:6379/?retry_on_error=ConnectionError,TimeoutError"
+    )
+    assert kw["retry_on_error"] == [ConnectionError, TimeoutError]
+
+
+def test_parse_url_retry_on_error_unknown_name():
+    with pytest.raises(ValueError, match="NotARealError"):
+        parse_url("redis://localhost:6379/?retry_on_error=NotARealError")
+
+
+@pytest.mark.asyncio
+async def test_parse_url_retry_on_error_usable_in_retry():
+    kw = parse_url("redis://localhost:6379/?retry_on_error=ConnectionError")
+    conn = Connection(**kw)
+    assert ConnectionError in conn.retry._supported_errors
+    assert all(
+        isinstance(err, type) and issubclass(err, BaseException)
+        for err in conn.retry._supported_errors
+    )
+
+    calls = 0
+
+    async def do():
+        nonlocal calls
+        calls += 1
+        raise ConnectionError("simulated network drop")
+
+    async def fail(error):
+        return None
+
+    with pytest.raises(ConnectionError):
+        await conn.retry.call_with_retry(do=do, fail=fail)
+    assert calls == 2

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -970,9 +970,36 @@ def test_parse_url_retry_on_error_comma_separated():
     assert kw["retry_on_error"] == [ConnectionError, TimeoutError]
 
 
+def test_parse_url_invalid_db_keeps_stable_message():
+    with pytest.raises(ValueError) as exc_info:
+        parse_url("redis://localhost:6379/?db=not-an-int")
+    assert str(exc_info.value) == "Invalid value for 'db' in connection URL."
+
+
 def test_parse_url_retry_on_error_unknown_name():
-    with pytest.raises(ValueError, match="NotARealError"):
+    with pytest.raises(ValueError) as exc_info:
         parse_url("redis://localhost:6379/?retry_on_error=NotARealError")
+    message = str(exc_info.value)
+    assert message == (
+        "Invalid value for 'retry_on_error' in connection URL: "
+        "Unknown redis exception 'NotARealError'"
+    )
+
+
+def test_parse_url_retry_on_error_does_not_mutate_shared_list():
+    kw = parse_url(
+        "redis://localhost:6379/?retry_on_error=ConnectionError&retry_on_timeout=true"
+    )
+    snapshot = list(kw["retry_on_error"])
+
+    c1 = Connection(**kw)
+    c2 = Connection(**kw)
+
+    assert kw["retry_on_error"] == snapshot
+    assert kw["retry_on_error"] is not c1.retry_on_error
+    assert ConnectionError in c1.retry_on_error
+    assert TimeoutError in c1.retry_on_error
+    assert c1.retry_on_error == c2.retry_on_error
 
 
 @pytest.mark.asyncio

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -724,7 +724,7 @@ class TestConnectionPoolURLParsing:
         ]
 
     def test_retry_on_error_querystring_invalid(self):
-        with pytest.raises(ValueError, match="NotARealError"):
+        with pytest.raises(ValueError, match="Invalid value for 'retry_on_error'"):
             redis.ConnectionPool.from_url(
                 "redis://localhost?retry_on_error=NotARealError"
             )

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -708,6 +708,35 @@ class TestConnectionPoolURLParsing:
                 "redis://localhost/2?socket_timeout=_&socket_connect_timeout=abc"
             )
 
+    def test_retry_on_error_querystring(self):
+        pool = redis.ConnectionPool.from_url(
+            "redis://localhost?retry_on_error=ConnectionError"
+        )
+        assert pool.connection_kwargs["retry_on_error"] == [redis.ConnectionError]
+
+    def test_retry_on_error_querystring_multiple(self):
+        pool = redis.ConnectionPool.from_url(
+            "redis://localhost?retry_on_error=ConnectionError,TimeoutError"
+        )
+        assert pool.connection_kwargs["retry_on_error"] == [
+            redis.ConnectionError,
+            redis.TimeoutError,
+        ]
+
+    def test_retry_on_error_querystring_invalid(self):
+        with pytest.raises(ValueError, match="NotARealError"):
+            redis.ConnectionPool.from_url(
+                "redis://localhost?retry_on_error=NotARealError"
+            )
+
+    def test_from_url_retry_on_error(self):
+        client = redis.Redis.from_url(
+            "redis://localhost?retry_on_error=ConnectionError"
+        )
+        assert client.connection_pool.connection_kwargs["retry_on_error"] == [
+            redis.ConnectionError
+        ]
+
     def test_extra_querystring_options(self):
         pool = redis.ConnectionPool.from_url("redis://localhost?a=1&b=2")
         assert pool.connection_class == redis.Connection

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -723,6 +723,19 @@ class TestConnectionPoolURLParsing:
             redis.TimeoutError,
         ]
 
+    def test_retry_on_error_querystring_brackets(self):
+        pool = redis.ConnectionPool.from_url(
+            "redis://localhost?retry_on_error=[ConnectionError,TimeoutError]"
+        )
+        assert pool.connection_kwargs["retry_on_error"] == [
+            redis.ConnectionError,
+            redis.TimeoutError,
+        ]
+
+    def test_retry_on_error_querystring_blank(self):
+        with pytest.raises(ValueError, match="Invalid value for 'retry_on_error'"):
+            redis.ConnectionPool.from_url("redis://localhost?retry_on_error=,")
+
     def test_retry_on_error_querystring_invalid(self):
         with pytest.raises(ValueError, match="Invalid value for 'retry_on_error'"):
             redis.ConnectionPool.from_url(

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -59,6 +59,21 @@ class TestConnectionConstructorWithRetry:
         assert isinstance(c.retry, Retry)
         assert c.retry._retries == retries
 
+    @pytest.mark.parametrize("Class", [Connection, UnixDomainSocketConnection])
+    def test_retry_on_error_does_not_mutate_caller_list(self, Class):
+        retry_on_error = [ValueError]
+        snapshot = list(retry_on_error)
+
+        # Two constructions must not grow or otherwise mutate the caller's list.
+        c1 = Class(retry_on_error=retry_on_error, retry_on_timeout=True)
+        c2 = Class(retry_on_error=retry_on_error, retry_on_timeout=True)
+
+        assert retry_on_error == snapshot
+        assert retry_on_error is not c1.retry_on_error
+        assert ValueError in c1.retry_on_error
+        assert TimeoutError in c1.retry_on_error
+        assert c1.retry_on_error == c2.retry_on_error
+
     @pytest.mark.parametrize("retries", range(10))
     @pytest.mark.parametrize("Class", [Connection, UnixDomainSocketConnection])
     def test_retry_with_retry_on_error(self, Class, retries: int):

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -59,21 +59,6 @@ class TestConnectionConstructorWithRetry:
         assert isinstance(c.retry, Retry)
         assert c.retry._retries == retries
 
-    @pytest.mark.parametrize("Class", [Connection, UnixDomainSocketConnection])
-    def test_retry_on_error_does_not_mutate_caller_list(self, Class):
-        retry_on_error = [ValueError]
-        snapshot = list(retry_on_error)
-
-        # Two constructions must not grow or otherwise mutate the caller's list.
-        c1 = Class(retry_on_error=retry_on_error, retry_on_timeout=True)
-        c2 = Class(retry_on_error=retry_on_error, retry_on_timeout=True)
-
-        assert retry_on_error == snapshot
-        assert retry_on_error is not c1.retry_on_error
-        assert ValueError in c1.retry_on_error
-        assert TimeoutError in c1.retry_on_error
-        assert c1.retry_on_error == c2.retry_on_error
-
     @pytest.mark.parametrize("retries", range(10))
     @pytest.mark.parametrize("Class", [Connection, UnixDomainSocketConnection])
     def test_retry_with_retry_on_error(self, Class, retries: int):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2018,6 +2018,21 @@ def test_parse_url_retry_on_error_comma_separated():
     assert kw["retry_on_error"] == [ConnectionError, TimeoutError]
 
 
+def test_parse_url_retry_on_error_bracket_list():
+    kw = parse_url(
+        "redis://localhost:6379/?retry_on_error=[ConnectionError,TimeoutError]"
+    )
+    assert kw["retry_on_error"] == [ConnectionError, TimeoutError]
+
+
+def test_parse_url_retry_on_error_blank_entry():
+    with pytest.raises(ValueError) as exc_info:
+        parse_url("redis://localhost:6379/?retry_on_error=,")
+    assert str(exc_info.value) == (
+        "Invalid value for 'retry_on_error' in connection URL."
+    )
+
+
 def test_parse_url_invalid_db_keeps_stable_message():
     with pytest.raises(ValueError) as exc_info:
         parse_url("redis://localhost:6379/?db=not-an-int")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1990,9 +1990,20 @@ def test_parse_url_retry_on_error_comma_separated():
     assert kw["retry_on_error"] == [ConnectionError, TimeoutError]
 
 
+def test_parse_url_invalid_db_keeps_stable_message():
+    with pytest.raises(ValueError) as exc_info:
+        parse_url("redis://localhost:6379/?db=not-an-int")
+    assert str(exc_info.value) == "Invalid value for 'db' in connection URL."
+
+
 def test_parse_url_retry_on_error_unknown_name():
-    with pytest.raises(ValueError, match="NotARealError"):
+    with pytest.raises(ValueError) as exc_info:
         parse_url("redis://localhost:6379/?retry_on_error=NotARealError")
+    message = str(exc_info.value)
+    assert message == (
+        "Invalid value for 'retry_on_error' in connection URL: "
+        "Unknown redis exception 'NotARealError'"
+    )
 
 
 def test_parse_url_retry_on_error_usable_in_retry():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1999,10 +1999,8 @@ def test_parse_url_invalid_db_keeps_stable_message():
 def test_parse_url_retry_on_error_unknown_name():
     with pytest.raises(ValueError) as exc_info:
         parse_url("redis://localhost:6379/?retry_on_error=NotARealError")
-    message = str(exc_info.value)
-    assert message == (
-        "Invalid value for 'retry_on_error' in connection URL: "
-        "Unknown redis exception 'NotARealError'"
+    assert str(exc_info.value) == (
+        "Invalid value for 'retry_on_error' in connection URL."
     )
 
 
@@ -2011,7 +2009,7 @@ def test_parse_url_retry_on_error_usable_in_retry():
     conn = Connection(**kw)
     assert ConnectionError in conn.retry._supported_errors
     assert all(
-        isinstance(err, type) and issubclass(err, BaseException)
+        isinstance(err, type) and issubclass(err, Exception)
         for err in conn.retry._supported_errors
     )
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1976,3 +1976,41 @@ class TestBlockingConnectionPoolGetConnectionCount:
         assert used_count == 0
 
         pool.disconnect()
+
+
+def test_parse_url_retry_on_error_resolves_exception_names():
+    kw = parse_url("redis://localhost:6379/?retry_on_error=ConnectionError")
+    assert kw["retry_on_error"] == [ConnectionError]
+
+
+def test_parse_url_retry_on_error_comma_separated():
+    kw = parse_url(
+        "redis://localhost:6379/?retry_on_error=ConnectionError,TimeoutError"
+    )
+    assert kw["retry_on_error"] == [ConnectionError, TimeoutError]
+
+
+def test_parse_url_retry_on_error_unknown_name():
+    with pytest.raises(ValueError, match="NotARealError"):
+        parse_url("redis://localhost:6379/?retry_on_error=NotARealError")
+
+
+def test_parse_url_retry_on_error_usable_in_retry():
+    kw = parse_url("redis://localhost:6379/?retry_on_error=ConnectionError")
+    conn = Connection(**kw)
+    assert ConnectionError in conn.retry._supported_errors
+    assert all(
+        isinstance(err, type) and issubclass(err, BaseException)
+        for err in conn.retry._supported_errors
+    )
+
+    calls = 0
+
+    def do():
+        nonlocal calls
+        calls += 1
+        raise ConnectionError("simulated network drop")
+
+    with pytest.raises(ConnectionError):
+        conn.retry.call_with_retry(do=do, fail=lambda e: None)
+    assert calls == 2

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -551,6 +551,19 @@ class TestConnectionPoolURLParsing:
             redis.TimeoutError,
         ]
 
+    def test_retry_on_error_querystring_brackets(self):
+        pool = redis.ConnectionPool.from_url(
+            "redis://localhost?retry_on_error=[ConnectionError,TimeoutError]"
+        )
+        assert pool.connection_kwargs["retry_on_error"] == [
+            redis.ConnectionError,
+            redis.TimeoutError,
+        ]
+
+    def test_retry_on_error_querystring_blank(self):
+        with pytest.raises(ValueError, match="Invalid value for 'retry_on_error'"):
+            redis.ConnectionPool.from_url("redis://localhost?retry_on_error=,")
+
     def test_retry_on_error_querystring_invalid(self):
         with pytest.raises(ValueError, match="Invalid value for 'retry_on_error'"):
             redis.ConnectionPool.from_url(

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -536,6 +536,35 @@ class TestConnectionPoolURLParsing:
                 "redis://localhost/2?socket_timeout=_&socket_connect_timeout=abc"
             )
 
+    def test_retry_on_error_querystring(self):
+        pool = redis.ConnectionPool.from_url(
+            "redis://localhost?retry_on_error=ConnectionError"
+        )
+        assert pool.connection_kwargs["retry_on_error"] == [redis.ConnectionError]
+
+    def test_retry_on_error_querystring_multiple(self):
+        pool = redis.ConnectionPool.from_url(
+            "redis://localhost?retry_on_error=ConnectionError,TimeoutError"
+        )
+        assert pool.connection_kwargs["retry_on_error"] == [
+            redis.ConnectionError,
+            redis.TimeoutError,
+        ]
+
+    def test_retry_on_error_querystring_invalid(self):
+        with pytest.raises(ValueError, match="NotARealError"):
+            redis.ConnectionPool.from_url(
+                "redis://localhost?retry_on_error=NotARealError"
+            )
+
+    def test_from_url_retry_on_error(self):
+        client = redis.Redis.from_url(
+            "redis://localhost?retry_on_error=ConnectionError"
+        )
+        assert client.connection_pool.connection_kwargs["retry_on_error"] == [
+            redis.ConnectionError
+        ]
+
     def test_extra_querystring_options(self):
         pool = redis.ConnectionPool.from_url("redis://localhost?a=1&b=2")
         assert pool.connection_class == redis.Connection

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -552,7 +552,7 @@ class TestConnectionPoolURLParsing:
         ]
 
     def test_retry_on_error_querystring_invalid(self):
-        with pytest.raises(ValueError, match="NotARealError"):
+        with pytest.raises(ValueError, match="Invalid value for 'retry_on_error'"):
             redis.ConnectionPool.from_url(
                 "redis://localhost?retry_on_error=NotARealError"
             )


### PR DESCRIPTION
### Description of change

Passing `retry_on_error` through a connection URL used `list` as the query parser, so `?retry_on_error=ConnectionError` became `['C', 'o', …]`. Those strings ended up in `Retry._supported_errors` and turned every later error into `TypeError: catching classes that do not inherit from BaseException`.

This replaces that parser with one that splits on commas and resolves each name against `redis.exceptions`. Unknown names raise `ValueError` at `parse_url` time instead of corrupting retry handling. The same parser is registered on the asyncio URL map so a raw string cannot leak into `update_supported_errors()`.

Fixes #4277

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized URL parsing fix with validation at connect time; behavior change only for URL-based `retry_on_error`, which was previously broken.
> 
> **Overview**
> **Fixes broken `retry_on_error` in connection URLs** where the query parser used Python’s `list`, so `?retry_on_error=ConnectionError` became a list of characters and broke retry handling with `TypeError` when matching exceptions.
> 
> Sync and async URL parsing now use a shared **`parse_retry_on_error`** helper that splits comma-separated (optional bracket-wrapped) names, resolves each against **`redis.exceptions`**, and raises **`ValueError`** at parse time for empty or unknown names. **`docs/retry.rst`** documents the URL form (e.g. `redis://localhost?retry_on_error=ConnectionError,TimeoutError`). Tests cover `parse_url`, pools, `Redis.from_url`, and end-to-end retry behavior for sync and asyncio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 898f0c7c1cb3e329c7151e49ee0f71d47d9a71e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->