### PR TITLE
fix: raise ConnectionError when async RESP3 parser reads after disconnect

### DIFF
--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -177,6 +177,8 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
     async def read_response(
         self, disable_decoding: bool = False, push_request: bool = False
     ):
+        if not self._connected:
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         if self._chunks:
             # augment parsing buffer with previously read data
             self._buffer += b"".join(self._chunks)

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -62,6 +62,12 @@ class DummyAsyncStream:
         self.read_called = True
         raise AssertionError("can_read should not read from the stream")
 
+    async def readline(self):
+        self.read_called = True
+        data = bytes(self._buffer)
+        self._buffer.clear()
+        return data
+
 
 def make_async_hiredis_parser(
     stream, response=NOT_ENOUGH_DATA, decoded_response=None, has_data=False
@@ -213,6 +219,20 @@ async def test_async_resp_can_read_prefers_buffered_data_over_eof(parser_class):
     parser._buffer = b"+OK\r\n"
 
     assert await parser.can_read() is True
+    assert stream.read_called is False
+
+
+@pytest.mark.parametrize("parser_class", [_AsyncRESP2Parser, _AsyncRESP3Parser])
+async def test_async_resp_read_response_raises_after_disconnect(parser_class):
+    # A late reply read after disconnect could be assigned to the next
+    # cluster pipeline command.
+    stream = DummyAsyncStream(buffer=b"+OK\r\n")
+    parser = parser_class(socket_read_size=65536)
+    parser.on_connect(types.SimpleNamespace(_reader=stream, encoder=mock.Mock()))
+    parser.on_disconnect()
+
+    with pytest.raises(ConnectionError):
+        await parser.read_response()
     assert stream.read_called is False
 
 


### PR DESCRIPTION
### Description of change

**Bug.** `_AsyncRESP3Parser.read_response` does not check parser connectedness before reading, unlike `_AsyncRESP2Parser` (`resp2.py`) and `_AsyncHiredisParser` (`hiredis.py`). Since `on_disconnect()` only sets `_connected = False` and keeps `_stream`, a parser that was disconnected can still read a late-arriving reply from the old `StreamReader`.

**Impact.** In `ClusterNode.execute_pipeline`, replies are read sequentially on one connection and each read is wrapped in `except Exception`, so the loop keeps reading after a failure. With RESP3 (the default protocol), the sequence is:

1. Pipeline sends `[HGETALL, TTL]`; the `HGETALL` read hits `socket_timeout` → `Connection.read_response` calls `disconnect(nowait=True)`.
2. The `TTL` read on the same connection still succeeds, consuming the **late `HGETALL` reply** from the old stream → the `TTL` slot receives a dict.
3. `PipelineStrategy._execute` retries only commands whose result is an exception → the caller receives `[hash, hash]`.

We hit this in production (Cloud Run CPU throttling freezes the event loop past `socket_timeout`; `hgetall`+`ttl` session reads crashed on `ttl < 0` with `TypeError: '<' not supported between instances of 'dict' and 'int'`, ~2 000 events over 3 days). Reproduced locally with a single-node cluster and a task that blocks the loop with `time.sleep(1.2)` while 48 workers run the two-command pipeline with `socket_timeout=1.0`:

| protocol | pipelines executed | replies attributed to the wrong command |
|---|---:|---:|
| 3 (default) | 53 369 | 49 |
| 2 | 55 503 | 0 |

Instrumented trace of one occurrence:

```
execute_pipeline cmds=['HGETALL','TTL']  send on conn=1600
disconnect conn=1600 nowait=True            <- HGETALL read timeout
read_response conn=1600 !! TimeoutError     <- slot 0
read_response conn=1600 -> dict {...}       <- slot 1 receives the late HGETALL reply
execute_pipeline done results=['TimeoutError','dict']
_execute retry todo=[0]                     <- only HGETALL re-sent
final result: [dict, dict]
```

**Fix.** Add the same guard the RESP2 and hiredis parsers already have: raise `ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)` at the top of `_AsyncRESP3Parser.read_response` when the parser is disconnected. The disconnected read then fails fast and the normal retry path re-sends the whole pipeline. With this patch, the reproduction above shows 0 misattributed replies under RESP3.

The regression test covers both async Python parsers and verifies a disconnected parser raises without touching the stream; it fails on master for `_AsyncRESP3Parser` (`DID NOT RAISE ConnectionError`) and passes with the fix.

A possible follow-up (not in this PR): `ClusterNode.execute_pipeline` could stop reading from a connection after a transport error instead of relying on the parser guard.

### Pull Request check-list

- [x] Do tests and lints pass with this change? (`tests/test_asyncio/test_connection.py`: 25 passed, 1 skipped; ruff clean)
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? — behavior fix only, no API change
- [ ] Is there an example added to the examples folder (if applicable)? — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small parity fix with existing parser behavior; regression test covers disconnect-after-read; no API changes.
> 
> **Overview**
> **Aligns async RESP3 with RESP2/hiredis** by checking `_connected` at the start of `_AsyncRESP3Parser.read_response` and raising `ConnectionError` instead of reading from a disconnected stream.
> 
> This closes a **cluster pipeline bug** where a timeout on one pipelined command could disconnect the connection while the loop still read the next reply slot from the old stream, **mis-attributing a late reply** (e.g. `HGETALL` dict returned for `TTL`). Failed reads now fail fast so retries can resend the pipeline correctly.
> 
> Adds **`test_async_resp_read_response_raises_after_disconnect`** for both async Python parsers (disconnect → `read_response` raises without touching the stream) and extends **`DummyAsyncStream`** with `readline` for that test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2952b1c10539b6149e49554ed5dd9b17d10e9d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->