### PR TITLE
fix(asyncio): copy caller-supplied retry_on_error list

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -665,6 +665,11 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         self.retry_on_timeout = retry_on_timeout
         if retry_on_error is SENTINEL:
             retry_on_error = []
+        else:
+            # copy the caller-supplied list: the sync Connection does the same,
+            # and appending our default timeout errors below must not mutate
+            # user data (each pooled connection would keep adding duplicates)
+            retry_on_error = list(retry_on_error)
         if retry_on_timeout:
             retry_on_error.append(TimeoutError)
             retry_on_error.append(socket.timeout)

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -1,4 +1,4 @@
-import asyncio
+﻿import asyncio
 import socket
 import ssl
 import types
@@ -956,3 +956,18 @@ async def test_disconnect_no_current_task_calls_close(request):
             mock_on_disconnect.assert_called_once()
 
     assert not conn.is_connected
+
+def test_retry_on_error_list_not_mutated_by_connection_init():
+    # Constructing an asyncio Connection must not mutate the caller-supplied
+    # retry_on_error list: defaults are appended to a copy instead (#4278).
+    my_errors = [ValueError]
+    snapshot = list(my_errors)
+
+    conn = Connection(
+        host="localhost",
+        retry_on_error=my_errors,
+        retry_on_timeout=True,
+    )
+
+    assert TimeoutError in conn.retry_on_error
+    assert my_errors == snapshot


### PR DESCRIPTION
Fixes #4278

`redis.asyncio.Connection` appended its default timeout errors (`TimeoutError`, `socket.timeout`, `asyncio.TimeoutError`) directly to the **caller-supplied** `retry_on_error` list, mutating user data on every connection construction — and each pooled connection added three more duplicates.

The sync `redis.Connection` already copies the argument (`list(retry_on_error)`), so this also restores sync/async parity.

## Changes

- `redis/asyncio/connection.py`: copy the caller's list before appending defaults.

## Testing

- New regression test `test_retry_on_error_list_not_mutated_by_connection_init`: constructs a connection with `retry_on_error=[ValueError]` + `retry_on_timeout=True` and asserts the caller's list is unchanged.
- Verified red/green: fails on master, passes with the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small init-time copy of a retry-error list; no auth, protocol, or connection-lifecycle behavior change.
> 
> **Overview**
> Stops `redis.asyncio.Connection` from mutating the caller’s `retry_on_error` list when `retry_on_timeout=True`. Timeout exception types are now appended to a copy, matching the sync client and avoiding duplicate entries as pooled connections are created.
> 
> Adds a regression test that the original list is unchanged after construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773d0aa3403d21b797f744a7b080fd7b76c419d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->