### PR TITLE
fix(url): resolve retry_on_error exception classes from URL

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -33,6 +33,7 @@ from redis.cache import (
     CacheProxy,
 )
 from redis.commands.metadata import MetadataResolver
+from redis import exceptions
 
 from ._defaults import (
     DEFAULT_SOCKET_CONNECT_TIMEOUT,
@@ -2334,6 +2335,26 @@ def parse_ssl_verify_flags(value):
     return verify_flags
 
 
+
+
+def _parse_retry_on_error(value):
+    """Resolve a comma-separated list of exception class names taken from a
+    connection URL into actual exception classes.
+
+    A plain ``list`` parser here used to char-split the string into single
+    characters (#4277), producing a retry list that broke all error handling.
+    """
+    if not isinstance(value, str):
+        return value
+    resolved = []
+    for name in (v.strip() for v in value.split(",") if v.strip()):
+        exc_class = getattr(exceptions, name, None)
+        if isinstance(exc_class, type) and issubclass(exc_class, Exception):
+            resolved.append(exc_class)
+        else:
+            raise ValueError(f"Unknown exception class: {name!r}")
+    return resolved
+
 URL_QUERY_ARGUMENT_PARSERS = {
     "db": int,
     "socket_timeout": float,
@@ -2341,7 +2362,7 @@ URL_QUERY_ARGUMENT_PARSERS = {
     "socket_read_size": int,
     "socket_keepalive": to_bool,
     "retry_on_timeout": to_bool,
-    "retry_on_error": list,
+    "retry_on_error": _parse_retry_on_error,
     "max_connections": int,
     "health_check_interval": int,
     "ssl_check_hostname": to_bool,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1976,3 +1976,23 @@ class TestBlockingConnectionPoolGetConnectionCount:
         assert used_count == 0
 
         pool.disconnect()
+
+
+def test_parse_url_resolves_retry_on_error_exception_classes():
+    # issue #4277: the URL value is a comma-separated list of exception
+    # CLASS names, not a bare string to be char-split by list().
+    from redis.connection import parse_url
+    from redis.exceptions import ConnectionError, TimeoutError
+
+    kwargs = parse_url(
+        "redis://localhost:6379/0"
+        "?retry_on_error=ConnectionError,TimeoutError&retry_on_timeout=true"
+    )
+    assert kwargs["retry_on_error"] == [ConnectionError, TimeoutError]
+
+
+def test_parse_url_rejects_unknown_retry_on_error_name():
+    from redis.connection import parse_url
+
+    with pytest.raises(ValueError):
+        parse_url("redis://localhost:6379/0?retry_on_error=Nonsense")


### PR DESCRIPTION
Fixes #4277

`URL_QUERY_ARGUMENT_PARSERS["retry_on_error"]` used the plain `list` constructor as its parser, so the URL query value `"ConnectionError,TimeoutError"` was char-split into fifteen single-character strings. Those strings ended up inside `Retry`'s `supported_errors`, and any connection failure then raised

```
TypeError: catching classes that do not inherit from BaseException is not allowed
```

instead of retrying or re-raising the original error — i.e. passing `retry_on_error` through a URL silently disabled all retry/error handling.

## Changes

- `redis/connection.py`: replace the `list` parser with `_parse_retry_on_error()`, which splits the value on commas and resolves each name to an exception class via `redis.exceptions` (validating it's an `Exception` subclass; unknown names raise `ValueError`, which `parse_url` wraps into its usual "Invalid value" message). Non-string values pass through unchanged.

## Testing

- `test_parse_url_resolves_retry_on_error_exception_classes`: URL with `retry_on_error=ConnectionError,TimeoutError` now yields actual exception classes.
- `test_parse_url_rejects_unknown_retry_on_error_name`: unknown names raise `ValueError` at parse time.
- Both verified red/green against the unfixed parser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection URL parsing for retry error types, which controls which exceptions are retried. The change is small and well-tested, but incorrect parsing previously disabled error handling entirely.
> 
> **Overview**
> Fixes URL parsing of `retry_on_error` so a query like `ConnectionError,TimeoutError` becomes real exception classes instead of being char-split by `list()`.
> 
> That old parser put single-character strings into `Retry.supported_errors`, which then raised `TypeError: catching classes that do not inherit from BaseException` and silently broke retry/error handling.
> 
> `_parse_retry_on_error` now comma-splits names, looks them up on `redis.exceptions`, and rejects unknown names with `ValueError`. Tests cover both the happy path and invalid names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41fb9a71d5d2ce4e00092ed23c6d34b7e7f04e78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->