### PR TITLE
fix(lock): reacquire must not delete a persistent (timeout=0) lock

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -72,7 +72,11 @@ class Lock:
         if not token or token ~= ARGV[1] then
             return 0
         end
-        redis.call('pexpire', KEYS[1], ARGV[2])
+        -- A lock acquired with timeout=0 has no expiry by design; reacquiring
+        -- it must only re-verify ownership, never delete the key via pexpire(0)
+        if ARGV[2] ~= '0' then
+            redis.call('pexpire', KEYS[1], ARGV[2])
+        end
         return 1
     """
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -368,3 +368,23 @@ class TestLockClassSelection:
 
         lock = r.lock("foo", lock_class=MyLock)
         assert isinstance(lock, MyLock)
+
+    def test_reacquire_lock_zero_timeout_keeps_lock_persistent(self, r):
+        # issue #4279: reacquiring a persistent (timeout=0) lock used to
+        # delete the key via pexpire(0) while reporting success.
+        lock = self.get_lock(r, "foo", timeout=0)
+        assert lock.acquire(blocking=False)
+        assert r.pttl("foo") == -1
+        assert lock.reacquire()
+        assert r.exists("foo") == 1
+        assert r.pttl("foo") == -1
+        lock.release()
+        assert r.exists("foo") == 0
+
+    def test_extend_replace_ttl_on_zero_timeout_lock_raises_not_delete(self, r):
+        lock = self.get_lock(r, "foo", timeout=0)
+        assert lock.acquire(blocking=False)
+        with pytest.raises(LockError):
+            lock.extend(10, replace_ttl=True)
+        assert r.exists("foo") == 1
+        lock.release()


### PR DESCRIPTION
Fixes #4279

## Root cause

A `Lock(timeout=0)` acquires via `SET key token NX` **without PX** — the key is persistent by design ("hold until released"). But `LUA_REACQUIRE_SCRIPT` unconditionally ran `redis.call('pexpire', KEYS[1], ARGV[2])`, and `do_reacquire()` passed `timeout = int(0 * 1000) == 0`. `PEXPIRE key 0` deletes the key immediately, so `reacquire()` returned `True` while silently destroying the lock.

(The `extend()` path turned out to be already protected: its Lua script reads `PTTL` first and bails with `0` when it's negative, which surfaces as a loud `LockNotOwnedError` instead of deleting anything — covered by an added regression test regardless.)

## Changes

- `LUA_REACQUIRE_SCRIPT`: skip the `PEXPIRE` when the requested TTL is `"0"` — reacquiring a persistent lock now only re-verifies ownership and keeps the key without expiry.

## Testing

Two regression tests mirroring the issue repro:

- `test_reacquire_lock_zero_timeout_keeps_lock_persistent` — reacquire must keep the key alive and persistent (`PTTL == -1`), and `release()` must still fully remove it.
- `test_extend_replace_ttl_on_zero_timeout_lock_raises_not_delete` — pins the existing safe behavior of `extend(..., replace_ttl=True)` against regressions.

These live in `tests/test_lock.py` alongside the rest of the lock suite (they need the redis test service, same as the other cases there).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Corrects distributed lock TTL handling so reacquire no longer deletes persistent locks; a small Lua change with high impact if wrong.
> 
> **Overview**
> Fixes `reacquire()` deleting persistent `timeout=0` locks. `LUA_REACQUIRE_SCRIPT` used to always call `PEXPIRE` with the timeout, and `PEXPIRE 0` immediately removes the key while still returning success.
> 
> Reacquire now skips expiry when the TTL argument is `"0"`, so ownership is re-checked and the key stays without TTL.
> 
> Adds regression tests for that reacquire path and for `extend(..., replace_ttl=True)` on a zero-timeout lock (already raises, must not delete). **Note:** those tests were added on `TestLockClassSelection`, which has no `get_lock` helper (that lives on `TestLock`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c55e6f38123ba10c7d019d053824a03fb8e42cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->