### PR TITLE
fix(asyncio): raise ConnectionError when writing to a peer-closed connection

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1177,6 +1177,10 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             await self.check_health()
 
         try:
+            # Fail fast because writing to a closed transport can raise TypeError
+            # on CPython 3.12 (#4287).
+            if self._writer is None or self._writer.transport.is_closing():
+                raise ConnectionError("Connection closed by the server before write")
             if isinstance(command, str):
                 command = command.encode()
             if isinstance(command, bytes):

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1165,8 +1165,21 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             )
 
     async def _send_packed_command(self, command: Iterable[bytes]) -> None:
-        self._writer.writelines(command)
-        await self._writer.drain()
+        writer = self._writer
+        if writer is None or writer.transport.is_closing():
+            raise ConnectionError("Connection closed by the server before write")
+        try:
+            writer.writelines(command)
+            await writer.drain()
+        except (TypeError, AttributeError) as e:
+            # CPython gh-136234 adds the missing connection-lost check in 3.13.10+
+            # and 3.14.1+. Python 3.12, 3.13.0-3.13.9, and 3.14.0 can instead
+            # leak TypeError or AttributeError from the transport (#4287).
+            if writer.transport.is_closing():
+                raise ConnectionError(
+                    "Connection closed by the server while writing"
+                ) from e
+            raise
 
     async def send_packed_command(
         self, command: Union[bytes, str, Iterable[bytes]], check_health: bool = True
@@ -1177,10 +1190,6 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             await self.check_health()
 
         try:
-            # Fail fast because writing to a closed transport can raise TypeError
-            # on CPython 3.12 (#4287).
-            if self._writer is None or self._writer.transport.is_closing():
-                raise ConnectionError("Connection closed by the server before write")
             if isinstance(command, str):
                 command = command.encode()
             if isinstance(command, bytes):
@@ -1190,8 +1199,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
                     self._send_packed_command(command), self.socket_timeout
                 )
             else:
-                self._writer.writelines(command)
-                await self._writer.drain()
+                await self._send_packed_command(command)
         except asyncio.TimeoutError:
             await self.disconnect(nowait=True)
             raise TimeoutError("Timeout writing to socket") from None

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -251,6 +251,41 @@ def test_get_resolved_ip_uses_async_writer_peer_before_dns():
     getaddrinfo.assert_not_called()
 
 
+async def test_send_packed_command_rejects_closed_transport():
+    conn = Connection(health_check_interval=0)
+    writer = mock.Mock()
+    writer.transport.is_closing.return_value = True
+    writer.drain = mock.AsyncMock()
+    conn._reader = mock.Mock()
+    conn._writer = writer
+
+    with pytest.raises(ConnectionError, match="closed") as exc_info:
+        await conn.send_packed_command(b"PING", check_health=False)
+
+    assert type(exc_info.value) is ConnectionError
+    writer.writelines.assert_not_called()
+    writer.drain.assert_not_awaited()
+    writer.close.assert_called_once()
+    assert not conn.is_connected
+
+
+@pytest.mark.parametrize("socket_timeout", [None, 1])
+async def test_send_packed_command_writes_to_open_transport(socket_timeout):
+    conn = Connection(socket_timeout=socket_timeout, health_check_interval=0)
+    writer = mock.Mock()
+    writer.transport.is_closing.return_value = False
+    writer.drain = mock.AsyncMock()
+    conn._reader = mock.Mock()
+    conn._writer = writer
+
+    await conn.send_packed_command(b"PING", check_health=False)
+
+    writer.transport.is_closing.assert_called_once_with()
+    writer.writelines.assert_called_once_with([b"PING"])
+    writer.drain.assert_awaited_once_with()
+    await conn.disconnect(nowait=True)
+
+
 @pytest.mark.fixed_client
 @pytest.mark.parametrize(
     "client_kwargs",

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -286,6 +286,57 @@ async def test_send_packed_command_writes_to_open_transport(socket_timeout):
     await conn.disconnect(nowait=True)
 
 
+@pytest.mark.parametrize(
+    ("error_type", "message"),
+    [
+        (TypeError, "'NoneType' object is not callable"),
+        (AttributeError, "'NoneType' object has no attribute '_add_writer'"),
+    ],
+)
+async def test_send_packed_command_translates_closed_transport_error(
+    error_type, message
+):
+    conn = Connection(health_check_interval=0)
+    writer = mock.Mock()
+    writer.transport.is_closing.side_effect = [False, True]
+    error = error_type(message)
+    writer.writelines.side_effect = error
+    writer.drain = mock.AsyncMock()
+    conn._reader = mock.Mock()
+    conn._writer = writer
+
+    with pytest.raises(ConnectionError) as exc_info:
+        await conn.send_packed_command(b"PING", check_health=False)
+
+    assert type(exc_info.value) is ConnectionError
+    assert str(exc_info.value) == "Connection closed by the server while writing"
+    assert exc_info.value.__cause__ is error
+    assert writer.transport.is_closing.call_count == 2
+    writer.drain.assert_not_awaited()
+    writer.close.assert_called_once()
+    assert not conn.is_connected
+
+
+async def test_send_packed_command_preserves_type_error_on_open_transport():
+    conn = Connection(health_check_interval=0)
+    writer = mock.Mock()
+    writer.transport.is_closing.return_value = False
+    error = TypeError("sequence item 0: expected a bytes-like object")
+    writer.writelines.side_effect = error
+    writer.drain = mock.AsyncMock()
+    conn._reader = mock.Mock()
+    conn._writer = writer
+
+    with pytest.raises(TypeError) as exc_info:
+        await conn.send_packed_command(b"PING", check_health=False)
+
+    assert exc_info.value is error
+    assert writer.transport.is_closing.call_count == 2
+    writer.drain.assert_not_awaited()
+    writer.close.assert_called_once()
+    assert not conn.is_connected
+
+
 @pytest.mark.fixed_client
 @pytest.mark.parametrize(
     "client_kwargs",


### PR DESCRIPTION
### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

Fixes #4287, #3546.

When the server (or an intermediary) closes a pooled connection while it is idle, `AbstractConnection.is_connected` still reports the connection as healthy (it only checks that `_reader`/`_writer` are non-`None`), so the dead connection is reused. On CPython 3.12 the subsequent write then raises `TypeError: 'NoneType' object is not callable` instead of `ConnectionError`: 3.12's `_SelectorSocketTransport.writelines` is missing the `_conn_lost` guard that `write` has, and `_call_connection_lost` has already cleared the transport's `_write_ready` callback. The `TypeError` is not translated to `ConnectionError`, so it bypasses `Retry` and `RedisCluster.ERRORS_ALLOW_RETRY` and surfaces to application code. CPython fixed `writelines` in 3.13+, but 3.12 is security-only, so the fix will not be backported.

This change guards the write in `send_packed_command`: if the writer is missing or its transport is closing, raise `ConnectionError` (the exact class, since `ERRORS_ALLOW_RETRY` matching uses exact types) before touching the transport. The guard sits inside the existing `try` block, so the `except BaseException` clause disconnects the dead connection before re-raising, and the existing retry machinery takes over — on every Python version, covering both the `socket_timeout` path and the inline `writelines` path.

Regression tests (mock-based, no live server needed):

- a closed transport makes `send_packed_command` raise exactly `ConnectionError`, without writing, and the connection is disconnected;
- a healthy transport still writes through `writelines`/`drain` on both write paths (`socket_timeout` set and unset).

Verified against a real asyncio transport as well (peer sends a genuine RST via `SO_LINGER(1, 0)`): before this change the write raises the `TypeError` above on CPython 3.12; with it, `ConnectionError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot path for every async Redis command write and error classification; behavior change is intentional (TypeError → ConnectionError on dead sockets) but could affect callers that relied on the old exception type.
> 
> **Overview**
> Fixes **#4287** by hardening async command writes when a pooled connection was closed by the server but still looks connected.
> 
> **`_send_packed_command`** now refuses writes if the stream writer is missing or `transport.is_closing()` is true, raising **`ConnectionError`** (exact type, so cluster/retry allowlists still match). It centralizes `writelines`/`drain` for both the `socket_timeout` and non-timeout paths. On older CPython builds where a dead transport can surface **`TypeError`** or **`AttributeError`** from `writelines`, those are mapped to **`ConnectionError`** when the transport is closing; unrelated errors are re-raised. Existing **`send_packed_command`** error handling still disconnects on failure.
> 
> Adds mock-based tests for closed transport, successful writes, translated transport errors, and preserved **`TypeError`** on an open transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cd03beddd9f291a3db4cd0ff61f9d8a9124f86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->