### PR TITLE
fix(cache): deduplicate entries in delete_by_redis_keys

### DIFF
--- a/redis/cache.py
+++ b/redis/cache.py
@@ -234,7 +234,7 @@ class DefaultCache(CacheInterface):
                     keys_to_delete.append(cache_key)
                     response.append(True)
 
-        for key in keys_to_delete:
+        for key in dict.fromkeys(keys_to_delete):
             self._cache.pop(key)
 
         return response

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1530,6 +1530,46 @@ class TestUnitDefaultCache:
         assert results[0] is True
         assert results[1] is True, "Cache did not remove entry for non-UTF8 bytes key"
 
+    def test_delete_by_redis_keys_dedupes_entries_hit_multiple_times(
+        self, mock_connection
+    ):
+        """A cache entry matched by several redis keys must be removed only once."""
+        cache = DefaultCache(CacheConfig(max_size=5))
+
+        cache_key1 = CacheKey(
+            command="GET", redis_keys=("foo",), redis_args=("GET", "foo")
+        )
+        cache_key2 = CacheKey(
+            command="MGET",
+            redis_keys=("foo", "bar"),
+            redis_args=("MGET", "foo", "bar"),
+        )
+
+        assert cache.set(
+            CacheEntry(
+                cache_key=cache_key1,
+                cache_value=b"bar",
+                status=CacheEntryStatus.VALID,
+                connection_ref=mock_connection,
+            )
+        )
+        assert cache.set(
+            CacheEntry(
+                cache_key=cache_key2,
+                cache_value=b"bar2",
+                status=CacheEntryStatus.VALID,
+                connection_ref=mock_connection,
+            )
+        )
+
+        # Both "foo" and "bar" match cache_key2 (MGET foo bar), so it is added
+        # to the delete list twice. Popping it twice raises KeyError and leaves
+        # the other matched entries cached, so they must be deduplicated.
+        assert cache.delete_by_redis_keys([b"foo", b"bar"]) == [True, True, True]
+        assert len(cache.collection) == 0
+        assert cache.get(cache_key1) is None
+        assert cache.get(cache_key2) is None
+
     def test_flush(self, mock_connection):
         cache = DefaultCache(CacheConfig(max_size=5))
 


### PR DESCRIPTION
### Description of change

Fix a `KeyError` in `DefaultCache.delete_by_redis_keys` (`redis/cache.py`) that leaves stale entries in the client-side cache.

When an invalidation push contains multiple Redis keys matching the **same** `CacheKey` (e.g. `MGET foo bar`, pushed once with both `foo` and `bar`), that `CacheKey` gets appended to `keys_to_delete` multiple times. The subsequent `for key in keys_to_delete: self._cache.pop(key)` then pops the same `OrderedDict` key a second time, which raises `KeyError` (no default). The exception is swallowed by `handle_push_response` (`redis/_parsers/base.py:391`) and logged via `logger.error` without a traceback, so the remaining matched entries stay cached and stale.

Deduplicating `keys_to_delete` via `dict.fromkeys` (the entries are hashable `CacheKey` frozen dataclasses) makes the pop loop idempotent, so all matched entries are evicted and no `KeyError` is raised.

The return value semantics are unchanged: it still reports one `True` per match, as asserted by the existing `test_delete_by_redis_keys_removes_associated_entries` test.

### Reproduction

1. Enable client-side caching.
2. `GET foo` then `MGET foo bar` (both cached as `CacheKey`s).
3. Server pushes invalidation for both `foo` and `bar`.
4. `foo` matches the `GET foo` entry and both `GET foo` / `MGET foo bar` entries; `bar` matches `MGET foo bar` again → duplicate `CacheKey` in the delete list → `KeyError`.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change? (`ruff check`, `ruff format --check`, `vulture`; `tests/test_cache.py -k "Unit"` → 60 passed)
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested? (new regression test `test_delete_by_redis_keys_dedupes_entries_hit_multiple_times`)
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to cache eviction logic with a focused unit test and no API changes.
> 
> **Overview**
> Fixes client-side cache invalidation when a single push lists multiple Redis keys that all match the same cached entry (for example an `MGET foo bar` entry invalidated by both `foo` and `bar`).
> 
> `DefaultCache.delete_by_redis_keys` now deduplicates matched `CacheKey` values with `dict.fromkeys` before removing them from the internal `OrderedDict`, so each entry is popped once instead of raising `KeyError` on a second pop. That failure could abort the rest of the eviction and leave stale data; the per-match `True` return list is unchanged.
> 
> Adds regression test `test_delete_by_redis_keys_dedupes_entries_hit_multiple_times` for the multi-key invalidation case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116843b8fe69575ff23fa48b26259aa15fdd7f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->