### PR TITLE
fix(sentinel): disconnect on read errors by default

### DIFF
--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -70,7 +70,7 @@ class SentinelManagedConnection(Connection):
         disable_decoding=False,
         *,
         timeout: Union[float, object] = SENTINEL,
-        disconnect_on_error: Optional[bool] = False,
+        disconnect_on_error: Optional[bool] = True,
         push_request: Optional[bool] = False,
     ):
         try:

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -36,3 +36,29 @@ async def test_connect_retry_on_timeout_error(connect_args):
     assert conn._connect.call_count == 3
     assert connection_pool.get_master_address.call_count == 3
     await conn.disconnect()
+
+
+@pytest.mark.fixed_client
+async def test_read_response_disconnects_on_base_exception(connect_args):
+    """
+    Mirror of the sync test: a BaseException at the socket read leaves the reply
+    unread, so the connection must be closed rather than reused. See #1128.
+    """
+    connection_pool = mock.AsyncMock()
+    connection_pool.get_master_address = mock.AsyncMock(
+        return_value=(connect_args["host"], connect_args["port"])
+    )
+    connection_pool.is_master = True
+    connection_pool.check_connection = False
+    conn = SentinelManagedConnection(connection_pool=connection_pool)
+    await conn.connect()
+    try:
+        await conn.send_command("PING")
+        with mock.patch.object(
+            conn, "_read_response_from_parser", side_effect=KeyboardInterrupt
+        ):
+            with pytest.raises(KeyboardInterrupt):
+                await conn.read_response()
+        assert conn._reader is None
+    finally:
+        await conn.disconnect()

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -1,7 +1,9 @@
+import inspect
 import socket
 
 import pytest
 
+from redis.connection import Connection
 from redis.retry import Retry
 from redis.sentinel import SentinelManagedConnection
 from redis.backoff import NoBackoff
@@ -65,7 +67,7 @@ class TestSentinelManagedConnectionReadResponseTimeout:
             mock_read_response.assert_called_once_with(
                 disable_decoding=False,
                 timeout=0.5,
-                disconnect_on_error=False,
+                disconnect_on_error=True,
                 push_request=False,
             )
 
@@ -90,7 +92,7 @@ class TestSentinelManagedConnectionReadResponseTimeout:
             mock_read_response.assert_called_once_with(
                 disable_decoding=False,
                 timeout=SENTINEL,
-                disconnect_on_error=False,
+                disconnect_on_error=True,
                 push_request=False,
             )
 
@@ -115,7 +117,7 @@ class TestSentinelManagedConnectionReadResponseTimeout:
             mock_read_response.assert_called_once_with(
                 disable_decoding=False,
                 timeout=None,
-                disconnect_on_error=False,
+                disconnect_on_error=True,
                 push_request=False,
             )
 
@@ -140,7 +142,7 @@ class TestSentinelManagedConnectionReadResponseTimeout:
             mock_read_response.assert_called_once_with(
                 disable_decoding=False,
                 timeout=0,
-                disconnect_on_error=False,
+                disconnect_on_error=True,
                 push_request=False,
             )
 
@@ -173,3 +175,97 @@ class TestSentinelManagedConnectionReadResponseTimeout:
                 disconnect_on_error=True,
                 push_request=True,
             )
+
+
+@pytest.mark.fixed_client
+class TestSentinelManagedConnectionDisconnectOnError:
+    """
+    Tests for the disconnect-on-error behaviour of
+    SentinelManagedConnection.read_response().
+
+    These assert on the socket state and on the next reply rather than on the
+    arguments forwarded to the base class, so they observe what the flag
+    actually does.
+    """
+
+    def _connect(self, master_host):
+        connection_pool = mock.Mock()
+        connection_pool.get_master_address = mock.Mock(
+            return_value=(master_host[0], master_host[1])
+        )
+        connection_pool.is_master = True
+        connection_pool.check_connection = False
+        conn = SentinelManagedConnection(connection_pool=connection_pool)
+        conn.connect()
+        return conn
+
+    def test_default_disconnect_on_error_matches_base_connection(self):
+        """
+        The default is inherited behaviour, so it must equal the base class
+        default rather than a value of its own.
+        """
+        sentinel_default = (
+            inspect.signature(SentinelManagedConnection.read_response)
+            .parameters["disconnect_on_error"]
+            .default
+        )
+        base_default = (
+            inspect.signature(Connection.read_response)
+            .parameters["disconnect_on_error"]
+            .default
+        )
+        assert base_default is True
+        assert sentinel_default is True
+
+    def test_base_exception_during_read_disconnects(self, master_host):
+        """
+        A BaseException raised at the socket read leaves the reply unread, so
+        the connection must be closed instead of being reused. See #1128.
+        """
+        conn = self._connect(master_host)
+        try:
+            conn.send_command("PING")
+            with mock.patch.object(
+                conn._parser, "read_response", side_effect=KeyboardInterrupt
+            ):
+                with pytest.raises(KeyboardInterrupt):
+                    conn.read_response()
+            assert conn._sock is None
+        finally:
+            conn.disconnect()
+
+    def test_reply_after_interrupted_read_is_not_stale(self, master_host):
+        """
+        The next command on a reused connection must get its own reply, not the
+        reply left in the socket buffer by the interrupted one.
+        """
+        conn = self._connect(master_host)
+        try:
+            conn.send_command("ECHO", "interrupted")
+            with mock.patch.object(
+                conn._parser, "read_response", side_effect=KeyboardInterrupt
+            ):
+                with pytest.raises(KeyboardInterrupt):
+                    conn.read_response()
+
+            conn.send_command("PING")
+            assert conn.read_response() == b"PONG"
+        finally:
+            conn.disconnect()
+
+    def test_explicit_disconnect_on_error_false_is_honoured(self, master_host):
+        """
+        PubSub reads pass disconnect_on_error=False on purpose; an explicit
+        False must still keep the connection open.
+        """
+        conn = self._connect(master_host)
+        try:
+            conn.send_command("PING")
+            with mock.patch.object(
+                conn._parser, "read_response", side_effect=KeyboardInterrupt
+            ):
+                with pytest.raises(KeyboardInterrupt):
+                    conn.read_response(disconnect_on_error=False)
+            assert conn._sock is not None
+        finally:
+            conn.disconnect()

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -1,11 +1,11 @@
-import inspect
+import itertools
 import socket
 
 import pytest
 
-from redis.connection import Connection
+import redis
 from redis.retry import Retry
-from redis.sentinel import SentinelManagedConnection
+from redis.sentinel import SentinelConnectionPool, SentinelManagedConnection
 from redis.backoff import NoBackoff
 from redis.utils import SENTINEL
 from unittest import mock
@@ -199,24 +199,6 @@ class TestSentinelManagedConnectionDisconnectOnError:
         conn.connect()
         return conn
 
-    def test_default_disconnect_on_error_matches_base_connection(self):
-        """
-        The default is inherited behaviour, so it must equal the base class
-        default rather than a value of its own.
-        """
-        sentinel_default = (
-            inspect.signature(SentinelManagedConnection.read_response)
-            .parameters["disconnect_on_error"]
-            .default
-        )
-        base_default = (
-            inspect.signature(Connection.read_response)
-            .parameters["disconnect_on_error"]
-            .default
-        )
-        assert base_default is True
-        assert sentinel_default is True
-
     def test_base_exception_during_read_disconnects(self, master_host):
         """
         A BaseException raised at the socket read leaves the reply unread, so
@@ -252,6 +234,56 @@ class TestSentinelManagedConnectionDisconnectOnError:
             assert conn.read_response() == b"PONG"
         finally:
             conn.disconnect()
+
+    def test_interrupted_transaction_does_not_recycle_a_desynced_connection(
+        self, master_host
+    ):
+        """
+        _execute_transaction reads the MULTI reply, one reply per queued
+        command, then EXEC. A BaseException part way through that loop strands
+        the rest: Retry does not treat it as retryable, execute() catches only
+        Exception, and reset() disconnects only while watching, so the
+        connection is released straight back to the pool. Whatever comes out of
+        the pool next must not be holding those unread replies.
+        """
+        # The real pool class, so the release path under test is the production
+        # one. Only discover_master is reached, so no live Sentinel is needed.
+        sentinel_manager = mock.Mock()
+        sentinel_manager.discover_master = mock.Mock(
+            return_value=(master_host[0], master_host[1])
+        )
+        pool = SentinelConnectionPool("mymaster", sentinel_manager)
+
+        conn = pool.get_connection()
+        pipe = redis.Redis(connection_pool=pool).pipeline(transaction=True)
+        # Hand the pipeline the connection we hold, so it is the pool's own
+        # checked-out connection that gets released at the end of execute().
+        pipe.connection = conn
+        pipe.echo("first").echo("second").echo("third")
+
+        real_read = conn._parser.read_response
+        reads = itertools.count()
+
+        def interrupt_third_read(*args, **kwargs):
+            # MULTI, then "first" - the interrupt lands with "second", "third"
+            # and the EXEC reply still queued in the socket.
+            if next(reads) == 2:
+                raise KeyboardInterrupt
+            return real_read(*args, **kwargs)
+
+        with mock.patch.object(
+            conn._parser, "read_response", side_effect=interrupt_third_read
+        ):
+            with pytest.raises(KeyboardInterrupt):
+                pipe.execute()
+
+        reused = pool.get_connection()
+        assert reused is conn
+        try:
+            reused.send_command("ECHO", "after")
+            assert reused.read_response() == b"after"
+        finally:
+            reused.disconnect()
 
     def test_explicit_disconnect_on_error_false_is_honoured(self, master_host):
         """


### PR DESCRIPTION
### Description of change

`SentinelManagedConnection.read_response()` defaults `disconnect_on_error` to `False` (`redis/sentinel.py:73`), so a connection whose reply was never read goes back to the pool and the next command gets the previous one's response. Against a real sentinel, after an interrupt at the socket read:

```
master.ping()       -> False
master.get("probe") -> b'PONG'
```

Every other `read_response` defaults to `True`, including the async twin at `redis/asyncio/sentinel.py:76` and base `Connection.read_response`, whose `except BaseException` branch exists for this case (#1128, #2499). Both were written in one commit, `35b7e09a` for #2754, which took the value from the `PubSub.parse_response` call site, where `False` is passed explicitly.

`PubSub` passes the value explicitly, so it is unaffected. `ReadOnlyError` too, since the parser returns error replies rather than raising them and they surface after the guarded block.

Why no existing test caught it: they patch out `Connection.read_response`, the only code that reads the flag, so they check the forwarded value and never its effect. Four assertions pinned `False` and now pin `True`; the new tests assert socket state and the next reply.

Ran `tests/` standalone plus asyncio against a local sentinel setup, with a failure set identical to master's (the rest need redis-stack or TLS). `invoke linters` clean on the pinned ruff 0.9.6. Reverting the one-line change fails three of the four new tests; the fourth guards the explicit `False` opt-out and passes either way.

Prepared with Claude (Opus 5).

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default connection lifecycle for all Sentinel-managed reads except explicit `disconnect_on_error=False`; low blast radius but affects pooled connection reuse after read failures.
> 
> **Overview**
> **Fixes stale replies on Sentinel master connections** when a read is interrupted before the full response is consumed (e.g. `KeyboardInterrupt` at the socket read).
> 
> `SentinelManagedConnection.read_response()` now defaults **`disconnect_on_error` to `True`**, matching base `Connection`, the async Sentinel connection, and the behavior intended in #1128. With the old default of `False`, the socket stayed open and pooled connections could return the previous command’s reply on the next call (e.g. `ping()` → wrong result, `get()` → `PONG`). Callers that need to keep the connection open (e.g. PubSub with an explicit `disconnect_on_error=False`) are unchanged.
> 
> Tests are updated to expect the new default and add sync/async coverage that checks **socket teardown and the next reply**, including an interrupted transactional pipeline recycled through `SentinelConnectionPool`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed39ad8bb548aff89fa2a9fb05b3a272d7247c8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->