### PR TITLE
Fix typos in example notebooks

### DIFF
--- a/docs/examples/asyncio_examples.ipynb
+++ b/docs/examples/asyncio_examples.ipynb
@@ -333,7 +333,7 @@
    "metadata": {},
    "source": [
     "## Connecting to Redis instances by specifying a URL scheme.\n",
-    "Parameters are passed to the following schems, as parameters to the url scheme.\n",
+    "Parameters are passed to the following schemes, as parameters to the url scheme.\n",
     "\n",
     "Three URL schemes are supported:\n",
     "\n",

--- a/docs/examples/connection_examples.ipynb
+++ b/docs/examples/connection_examples.ipynb
@@ -360,7 +360,7 @@
    "metadata": {},
    "source": [
     "## Connecting to Redis instances by specifying a URL scheme.\n",
-    "Parameters are passed to the following schems, as parameters to the url scheme.\n",
+    "Parameters are passed to the following schemes, as parameters to the url scheme.\n",
     "\n",
     "Three URL schemes are supported:\n",
     "\n",

--- a/docs/examples/pipeline_examples.ipynb
+++ b/docs/examples/pipeline_examples.ipynb
@@ -123,7 +123,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The responses of the three commands are stored in a list. In the above example, the two first boolean indicates that the `set` commands were successful and the last element of the list is the result of the `get(\"a\")` comand."
+    "The responses of the three commands are stored in a list. In the above example, the two first boolean indicates that the `set` commands were successful and the last element of the list is the result of the `get(\"a\")` command."
    ]
   },
   {
@@ -132,7 +132,7 @@
    "source": [
     "## Chained call\n",
     "\n",
-    "The same result as above can be obtained in one line of code by chaining the opperations."
+    "The same result as above can be obtained in one line of code by chaining the operations."
    ]
   },
   {
@@ -223,7 +223,7 @@
    "source": [
     "## Performance comparison\n",
     "\n",
-    "Using pipelines can improve performance, for more informations, see [Redis documentation about pipelining](https://redis.io/docs/manual/pipelining/). Here is a simple comparison test of performance between basic and pipelined commands (we simply increment a value and measure the time taken by both method)."
+    "Using pipelines can improve performance, for more information, see [Redis documentation about pipelining](https://redis.io/docs/manual/pipelining/). Here is a simple comparison test of performance between basic and pipelined commands (we simply increment a value and measure the time taken by both method)."
    ]
   },
   {

--- a/docs/examples/timeseries_examples.ipynb
+++ b/docs/examples/timeseries_examples.ipynb
@@ -300,7 +300,7 @@
    "source": [
     "### Get the last sample matching specific label\n",
     "\n",
-    "Get the last sample that matches \"label1=1\", see [Redis documentation](https://redis.io/commands/ts.mget/) to see the posible filter values."
+    "Get the last sample that matches \"label1=1\", see [Redis documentation](https://redis.io/commands/ts.mget/) to see the possible filter values."
    ]
   },
   {
@@ -521,7 +521,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more informations about duplicate policies, see [Redis documentation](https://redis.io/commands/ts.add/)."
+    "For more information about duplicate policies, see [Redis documentation](https://redis.io/commands/ts.add/)."
    ]
   },
   {


### PR DESCRIPTION
Fixes 7 spelling errors in the prose of the example notebooks (all in markdown cells — no code or outputs changed):

- `docs/examples/asyncio_examples.ipynb`, `docs/examples/connection_examples.ipynb`: "schems" → "schemes"
- `docs/examples/pipeline_examples.ipynb`: "comand" → "command", "opperations" → "operations", "informations" → "information"
- `docs/examples/timeseries_examples.ipynb`: "posible" → "possible", "informations" → "information"

How I checked: ran `codespell` over the repo and manually verified each hit is notebook prose. The intentionally misspelled query terms in `doctests/search_quickstart.py`, the `overridee` demo value, and the `FT.SUGGET` command name are deliberately left untouched. All four `.ipynb` files still parse as valid JSON.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only prose edits in example notebooks with no runtime or API impact.
> 
> **Overview**
> Corrects **seven spelling mistakes** in markdown cells across four documentation example notebooks (`asyncio_examples`, `connection_examples`, `pipeline_examples`, `timeseries_examples`). No executable code or notebook outputs are modified.
> 
> URL-scheme connection sections in the asyncio and connection notebooks now say **"schemes"** instead of "schems". The pipeline notebook fixes **command**, **operations**, and **information** (was comand / opperations / informations). The timeseries notebook fixes **possible** and another **information** wording fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 457ca04f13939ef6f31e1a64cef56fe982608001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->