### PR TITLE
fix(cluster): initialize async Pub/Sub before routing

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -664,10 +664,8 @@ class RedisCluster(
         self.command_flags = self.__class__.COMMAND_FLAGS.copy()
         self.response_callbacks = kwargs["response_callbacks"]
         self.result_callbacks = self.__class__.RESULT_CALLBACKS.copy()
-        self.result_callbacks["CLUSTER SLOTS"] = (
-            lambda cmd, res, **kwargs: parse_cluster_slots(
-                list(res.values())[0], **kwargs
-            )
+        self.result_callbacks["CLUSTER SLOTS"] = lambda cmd, res, **kwargs: (
+            parse_cluster_slots(list(res.values())[0], **kwargs)
         )
 
         self._initialize = True
@@ -4039,12 +4037,15 @@ class ClusterPubSub(PubSub):
 
         if not args:
             return
-        await self._ensure_cluster_initialized()
 
         # Serialize against reinitialize_shard_subscriptions: the reverse
         # index and node_pubsub_mapping must not change between the lookup
         # and the per-node sunsubscribe call below.
         async with self._shard_state_lock:
+            # Initialization dispatches a slots-changed notification. Keep
+            # the resulting reconciler behind this lock until the channels
+            # below have been marked as pending unsubscription.
+            await self._ensure_cluster_initialized()
             for s_channel in args:
                 normalized_key = next(iter(self._normalize_keys({s_channel: None})))
                 # Route via the reverse index so we unsubscribe on the node
@@ -4076,6 +4077,8 @@ class ClusterPubSub(PubSub):
         first_migrate_error: Optional[BaseException] = None
         async with self._shard_state_lock:
             for channel, handler in list(self.shard_channels.items()):
+                if channel in self.pending_unsubscribe_shard_channels:
+                    continue
                 try:
                     new_node = self.cluster.get_node_from_key(channel)
                 except SlotNotCoveredError:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -4070,17 +4070,16 @@ class ClusterPubSub(PubSub):
         else:
             args = list(self.shard_channels.keys())
 
-        if not args:
+        # Keep initialization outside the shard-state lock: it can dispatch a
+        # topology refresh whose reconciler must remain able to make progress.
+        await self._ensure_cluster_initialized()
+        if not self.node_pubsub_mapping:
             return
 
         # Serialize against reinitialize_shard_subscriptions: the reverse
         # index and node_pubsub_mapping must not change between the lookup
         # and the per-node sunsubscribe call below.
         async with self._shard_state_lock:
-            # Initialization dispatches a slots-changed notification. Keep
-            # the resulting reconciler behind this lock until the channels
-            # below have been marked as pending unsubscription.
-            await self._ensure_cluster_initialized()
             for s_channel in args:
                 normalized_key = next(iter(self._normalize_keys({s_channel: None})))
                 # Route via the reverse index so we unsubscribe on the node

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2217,7 +2217,7 @@ class NodesManager:
                 )
                 return self.slots_cache[slot][node_idx]
             return self.slots_cache[slot][0]
-        except (IndexError, TypeError):
+        except (IndexError, KeyError, TypeError):
             raise SlotNotCoveredError(
                 f'Slot "{slot}" not covered by the cluster. '
                 f'"require_full_coverage={self.require_full_coverage}"'
@@ -3982,6 +3982,9 @@ class ClusterPubSub(PubSub):
         """
         s_channels = parse_pubsub_subscriptions(args, kwargs)
 
+        if self.cluster._initialize:
+            await self.cluster.initialize()
+
         # Serialize against reinitialize_shard_subscriptions (background
         # task) so the reverse index, shard_channels, and node_pubsub_mapping
         # are not mutated concurrently. _migrate_shard_channel below does not
@@ -4024,6 +4027,8 @@ class ClusterPubSub(PubSub):
 
         :param args: Channel names to unsubscribe from. If empty, unsubscribe from all.
         """
+        if self.cluster._initialize:
+            await self.cluster.initialize()
         if args:
             args = list_or_args(args[0], args[1:])
         else:
@@ -4299,6 +4304,9 @@ class ClusterPubSub(PubSub):
         # NOTE: don't parse the response in this function -- it could pull a
         # legitimate message off the stack if the connection is already
         # subscribed to one or more channels
+
+        if self.cluster._initialize:
+            await self.cluster.initialize()
 
         # For shard commands, route to appropriate node
         command = args[0].upper() if args else ""

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -4027,12 +4027,15 @@ class ClusterPubSub(PubSub):
 
         :param args: Channel names to unsubscribe from. If empty, unsubscribe from all.
         """
-        if self.cluster._initialize:
-            await self.cluster.initialize()
         if args:
             args = list_or_args(args[0], args[1:])
         else:
             args = list(self.shard_channels.keys())
+
+        if not args:
+            return
+        if self.cluster._initialize:
+            await self.cluster.initialize()
 
         # Serialize against reinitialize_shard_subscriptions: the reverse
         # index and node_pubsub_mapping must not change between the lookup

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -4070,11 +4070,11 @@ class ClusterPubSub(PubSub):
         else:
             args = list(self.shard_channels.keys())
 
+        if not self.node_pubsub_mapping:
+            return
         # Keep initialization outside the shard-state lock: it can dispatch a
         # topology refresh whose reconciler must remain able to make progress.
         await self._ensure_cluster_initialized()
-        if not self.node_pubsub_mapping:
-            return
 
         # Serialize against reinitialize_shard_subscriptions: the reverse
         # index and node_pubsub_mapping must not change between the lookup

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -3982,6 +3982,8 @@ class ClusterPubSub(PubSub):
         """
         s_channels = parse_pubsub_subscriptions(args, kwargs)
 
+        if not s_channels:
+            return
         if self.cluster._initialize:
             await self.cluster.initialize()
 

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -3799,6 +3799,10 @@ class ClusterPubSub(PubSub):
             AsyncAfterSlotsCacheRefreshEvent,
         )
 
+    async def _ensure_cluster_initialized(self) -> None:
+        if self.cluster._initialize:
+            await self.cluster.initialize()
+
     def set_pubsub_node(
         self,
         cluster: "RedisCluster",
@@ -3984,8 +3988,7 @@ class ClusterPubSub(PubSub):
 
         if not s_channels:
             return
-        if self.cluster._initialize:
-            await self.cluster.initialize()
+        await self._ensure_cluster_initialized()
 
         # Serialize against reinitialize_shard_subscriptions (background
         # task) so the reverse index, shard_channels, and node_pubsub_mapping
@@ -4036,8 +4039,7 @@ class ClusterPubSub(PubSub):
 
         if not args:
             return
-        if self.cluster._initialize:
-            await self.cluster.initialize()
+        await self._ensure_cluster_initialized()
 
         # Serialize against reinitialize_shard_subscriptions: the reverse
         # index and node_pubsub_mapping must not change between the lookup
@@ -4310,8 +4312,7 @@ class ClusterPubSub(PubSub):
         # legitimate message off the stack if the connection is already
         # subscribed to one or more channels
 
-        if self.cluster._initialize:
-            await self.cluster.initialize()
+        await self._ensure_cluster_initialized()
 
         # For shard commands, route to appropriate node
         command = args[0].upper() if args else ""

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3448,6 +3448,8 @@ class ClusterPubSub(PubSub):
         first_migrate_error: Optional[BaseException] = None
         with self._shard_state_lock:
             for channel, handler in list(self.shard_channels.items()):
+                if channel in self.pending_unsubscribe_shard_channels:
+                    continue
                 try:
                     new_node = self.cluster.get_node_from_key(channel)
                 except SlotNotCoveredError:

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -5775,7 +5775,10 @@ class TestClusterPubSubWithMocks:
 
         cluster.initialize.assert_awaited_once_with()
 
-    async def test_empty_sunsubscribe_does_not_initialize_cluster(self) -> None:
+    @pytest.mark.parametrize("method", ["ssubscribe", "sunsubscribe"])
+    async def test_empty_shard_command_does_not_initialize_cluster(
+        self, method
+    ) -> None:
         cluster = Mock()
         cluster._initialize = True
         cluster.initialize = mock.AsyncMock()
@@ -5783,7 +5786,7 @@ class TestClusterPubSubWithMocks:
         cluster.load_balancing_strategy = None
         pubsub = self._make_pubsub(cluster)
 
-        await pubsub.sunsubscribe()
+        await getattr(pubsub, method)()
 
         cluster.initialize.assert_not_awaited()
 

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -5775,6 +5775,18 @@ class TestClusterPubSubWithMocks:
 
         cluster.initialize.assert_awaited_once_with()
 
+    async def test_empty_sunsubscribe_does_not_initialize_cluster(self) -> None:
+        cluster = Mock()
+        cluster._initialize = True
+        cluster.initialize = mock.AsyncMock()
+        cluster.read_from_replicas = False
+        cluster.load_balancing_strategy = None
+        pubsub = self._make_pubsub(cluster)
+
+        await pubsub.sunsubscribe()
+
+        cluster.initialize.assert_not_awaited()
+
     async def test_get_node_pubsub_uses_adapter(self) -> None:
         """
         _get_node_pubsub must build a PubSub backed by a

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -5743,37 +5743,18 @@ class TestClusterPubSubWithMocks:
         assert pubsub.node is None
         assert pubsub.connection_pool is None
 
-    @pytest.mark.parametrize(
-        "method", ["execute_command", "ssubscribe", "sunsubscribe"]
-    )
-    async def test_pubsub_commands_initialize_cluster(self, method) -> None:
-        cluster = Mock()
-        cluster._initialize = True
-        cluster.initialize = mock.AsyncMock()
-        cluster.read_from_replicas = False
-        cluster.load_balancing_strategy = None
-        node = ClusterNode("127.0.0.1", 7000)
-
-        def get_node(*_args):
-            if cluster.initialize.await_count == 0:
-                raise KeyError
-            return node
-
-        cluster.nodes_manager.get_node_from_slot.side_effect = get_node
-        cluster.get_node_from_key.side_effect = get_node
-        pubsub = self._make_pubsub(cluster)
-        if method == "execute_command":
-            args = ("SUBSCRIBE", "channel")
-        else:
-            args = ("channel",)
+    async def test_subscribe_initializes_cluster(self) -> None:
+        client = await get_mocked_redis_client(host=default_host, port=default_port)
+        client._initialize = True
+        client.initialize = mock.AsyncMock()
+        pubsub = client.pubsub()
 
         with mock.patch(
-            f"redis.asyncio.client.PubSub.{method}",
-            new=mock.AsyncMock(return_value=None),
+            "redis.asyncio.client.PubSub.execute_command", new=mock.AsyncMock()
         ):
-            await getattr(pubsub, method)(*args)
+            await pubsub.subscribe("channel")
 
-        cluster.initialize.assert_awaited_once_with()
+        client.initialize.assert_awaited_once_with()
 
     @pytest.mark.parametrize("method", ["ssubscribe", "sunsubscribe"])
     async def test_empty_shard_command_does_not_initialize_cluster(

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -53,6 +53,7 @@ from redis.exceptions import (
     RedisClusterException,
     RedisError,
     ResponseError,
+    SlotNotCoveredError,
 )
 from redis.himport import HIMPORT_SET
 from redis.utils import str_if_bytes
@@ -2870,6 +2871,12 @@ class TestNodesManager:
     """
     Tests for the NodesManager class
     """
+
+    async def test_get_node_from_slot_with_missing_slot(self) -> None:
+        nodes_manager = NodesManager([], False, {})
+
+        with pytest.raises(SlotNotCoveredError):
+            nodes_manager.get_node_from_slot(42)
 
     @pytest.mark.onlycluster
     async def test_load_balancer(self, r: RedisCluster) -> None:
@@ -5735,6 +5742,38 @@ class TestClusterPubSubWithMocks:
 
         assert pubsub.node is None
         assert pubsub.connection_pool is None
+
+    @pytest.mark.parametrize(
+        "method", ["execute_command", "ssubscribe", "sunsubscribe"]
+    )
+    async def test_pubsub_commands_initialize_cluster(self, method) -> None:
+        cluster = Mock()
+        cluster._initialize = True
+        cluster.initialize = mock.AsyncMock()
+        cluster.read_from_replicas = False
+        cluster.load_balancing_strategy = None
+        node = ClusterNode("127.0.0.1", 7000)
+
+        def get_node(*_args):
+            if cluster.initialize.await_count == 0:
+                raise KeyError
+            return node
+
+        cluster.nodes_manager.get_node_from_slot.side_effect = get_node
+        cluster.get_node_from_key.side_effect = get_node
+        pubsub = self._make_pubsub(cluster)
+        if method == "execute_command":
+            args = ("SUBSCRIBE", "channel")
+        else:
+            args = ("channel",)
+
+        with mock.patch(
+            f"redis.asyncio.client.PubSub.{method}",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            await getattr(pubsub, method)(*args)
+
+        cluster.initialize.assert_awaited_once_with()
 
     async def test_get_node_pubsub_uses_adapter(self) -> None:
         """

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -5745,8 +5745,12 @@ class TestClusterPubSubWithMocks:
 
     async def test_subscribe_initializes_cluster(self) -> None:
         client = await get_mocked_redis_client(host=default_host, port=default_port)
+        slots_cache = client.nodes_manager.slots_cache
+        client.nodes_manager.slots_cache = {}
         client._initialize = True
-        client.initialize = mock.AsyncMock()
+        client.initialize = mock.AsyncMock(
+            side_effect=lambda: client.nodes_manager.slots_cache.update(slots_cache)
+        )
         pubsub = client.pubsub()
 
         with mock.patch(
@@ -5754,7 +5758,7 @@ class TestClusterPubSubWithMocks:
         ):
             await pubsub.subscribe("channel")
 
-        client.initialize.assert_awaited_once_with()
+        assert pubsub.node in client.get_nodes()
 
     @pytest.mark.parametrize("method", ["ssubscribe", "sunsubscribe"])
     async def test_empty_shard_command_does_not_initialize_cluster(

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -2127,6 +2127,38 @@ class TestClusterPubSubSlotMigration:
         new_ps.ssubscribe.assert_not_awaited()
         assert pubsub._shard_channel_to_node[channel] == old_node.name
 
+    async def test_initialize_refresh_does_not_restore_sunsubscribed_channel(self):
+        pubsub = self._make_cluster_pubsub()
+        old_node = self._make_node("127.0.0.1:7000")
+        new_node = self._make_node("127.0.0.1:7001")
+        channel = b"foo"
+        old_ps = self._make_node_pubsub({channel: None})
+        new_ps = self._make_node_pubsub()
+        pubsub.node_pubsub_mapping = {old_node.name: old_ps, new_node.name: new_ps}
+        pubsub.shard_channels = {channel: None}
+        pubsub._shard_channel_to_node = {channel: old_node.name}
+        pubsub.cluster._initialize = True
+        pubsub.cluster.get_node_from_key.return_value = new_node
+        old_ps.sunsubscribe.side_effect = lambda *_: (
+            pubsub.pending_unsubscribe_shard_channels.add(channel)
+        )
+        reconcile_task = None
+
+        async def initialize():
+            nonlocal reconcile_task
+            pubsub.cluster._initialize = False
+            reconcile_task = asyncio.create_task(
+                pubsub.reinitialize_shard_subscriptions()
+            )
+
+        pubsub.cluster.initialize = AsyncMock(side_effect=initialize)
+
+        await pubsub.sunsubscribe(channel)
+        await reconcile_task
+
+        new_ps.ssubscribe.assert_not_awaited()
+        assert channel in pubsub.pending_unsubscribe_shard_channels
+
     async def test_reinitialize_tolerates_old_node_disconnect(self):
         """
         When the old node is still part of the cluster topology but just

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -2047,6 +2047,7 @@ class TestClusterPubSubSlotMigration:
         pubsub.ignore_subscribe_messages = False
         # ClusterPubSub-specific state.
         pubsub.cluster = MagicMock()
+        pubsub.cluster._initialize = False
         pubsub.node_pubsub_mapping = {}
         pubsub._shard_channel_to_node = {}
         pubsub._shard_state_lock = asyncio.Lock()

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -2106,6 +2106,27 @@ class TestClusterPubSubSlotMigration:
         owner_ps.ssubscribe.assert_not_awaited()
         assert pubsub._shard_channel_to_node[channel] == owner.name
 
+    async def test_reinitialize_skips_pending_unsubscribe(self):
+        """A topology refresh must not restore a channel being removed."""
+        pubsub = self._make_cluster_pubsub()
+        old_node = self._make_node("127.0.0.1:7000")
+        new_node = self._make_node("127.0.0.1:7001")
+        channel = b"foo"
+        old_ps = self._make_node_pubsub({channel: None})
+        new_ps = self._make_node_pubsub()
+        pubsub.node_pubsub_mapping[old_node.name] = old_ps
+        pubsub.node_pubsub_mapping[new_node.name] = new_ps
+        pubsub.shard_channels = {channel: None}
+        pubsub.pending_unsubscribe_shard_channels = {channel}
+        pubsub._shard_channel_to_node = {channel: old_node.name}
+        pubsub.cluster.get_node_from_key.return_value = new_node
+
+        await pubsub.reinitialize_shard_subscriptions()
+
+        old_ps.sunsubscribe.assert_not_awaited()
+        new_ps.ssubscribe.assert_not_awaited()
+        assert pubsub._shard_channel_to_node[channel] == old_node.name
+
     async def test_reinitialize_tolerates_old_node_disconnect(self):
         """
         When the old node is still part of the cluster topology but just

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2602,6 +2602,33 @@ class TestClusterPubSubSlotMigration:
         owner_ps.ssubscribe.assert_not_called()
         assert pubsub._shard_channel_to_node[channel] == owner.name
 
+    def test_concurrent_refresh_does_not_restore_sunsubscribed_channel(self):
+        pubsub = self._make_cluster_pubsub()
+        old_node = self._make_node("127.0.0.1:7000")
+        new_node = self._make_node("127.0.0.1:7001")
+        channel = b"foo"
+        old_ps = self._make_node_pubsub({channel: None})
+        new_ps = self._make_node_pubsub()
+        pubsub.node_pubsub_mapping = {old_node.name: old_ps, new_node.name: new_ps}
+        pubsub.shard_channels = {channel: None}
+        pubsub._shard_channel_to_node = {channel: old_node.name}
+        pubsub.cluster.get_node_from_key.return_value = new_node
+        worker = None
+
+        def sunsubscribe(*_):
+            nonlocal worker
+            worker = threading.Thread(target=pubsub.reinitialize_shard_subscriptions)
+            worker.start()
+            pubsub.pending_unsubscribe_shard_channels.add(channel)
+
+        old_ps.sunsubscribe.side_effect = sunsubscribe
+
+        pubsub.sunsubscribe(channel)
+        worker.join()
+
+        new_ps.ssubscribe.assert_not_called()
+        assert channel in pubsub.pending_unsubscribe_shard_channels
+
     def test_reinitialize_tolerates_old_node_disconnect(self):
         """
         When the old node is still part of the cluster topology but just


### PR DESCRIPTION
### Description of change

Fixes #4296.

Initialize an asynchronous `RedisCluster` before `ClusterPubSub` hashes a channel and looks it up in the slot cache. This makes a first-operation `subscribe()` follow the same lazy-initialization contract as `RedisCluster.execute_command()` instead of leaking a `KeyError` from an empty cache.

Also convert a genuinely uncovered async slot to the public `SlotNotCoveredError`, matching the synchronous node manager's behavior.

Regression coverage verifies that initialization happens before Pub/Sub slot routing and that a missing slot no longer leaks `KeyError`.

Validation:

```text
pytest -q tests/test_asyncio/test_cluster.py::TestClusterPubSubWithMocks tests/test_asyncio/test_cluster.py::TestNodesManager::test_get_node_from_slot_with_missing_slot
6 passed

ruff check redis/asyncio/cluster.py tests/test_asyncio/test_cluster.py
All checks passed!

ruff format --check tests/test_asyncio/test_cluster.py
1 file already formatted
```

The broader `invoke fixed-client-tests` run reached 1,357 passes but could not complete cleanly because the prescribed local Redis Cluster/proxy services were unavailable. `invoke devenv` itself stalled in Docker Compose cleanup before starting those services. The failures were connection/proxy setup failures outside the changed tests.

### Pull Request check-list

- [ ] Do tests and lints pass with this change? (Focused tests and Ruff pass; the service-backed aggregate run is noted above.)
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)? (Pending.)
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (N/A; no API change.)
- [x] Is there an example added to the examples folder (if applicable)? (N/A.)

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster Pub/Sub routing, lazy initialization, and slot-migration reconciliation; race fixes are subtle but scoped with new regression tests.
> 
> **Overview**
> Fixes lazy-init gaps in **async `ClusterPubSub`**: shard subscribe/unsubscribe and `execute_command` now call **`_ensure_cluster_initialized()`** before hashing channels against the slot cache, so a first `subscribe()`/`ssubscribe()` no longer raises **`KeyError`** on an empty cache (aligned with `RedisCluster.execute_command()`). Empty **`ssubscribe`/`sunsubscribe`** and **`sunsubscribe`** with no per-node pubsubs return early without initializing.
> 
> **`NodesManager.get_node_from_slot`** now maps a missing slot (`KeyError`) to **`SlotNotCoveredError`**, matching sync behavior.
> 
> **Shard reconciliation** (`reinitialize_shard_subscriptions` in async and sync) **skips channels in `pending_unsubscribe_shard_channels`**, so a topology refresh during **`sunsubscribe`** does not re-**`ssubscribe`** on the new owner. **`sunsubscribe`** runs cluster init outside **`_shard_state_lock`** so refresh listeners can still reconcile.
> 
> Tests cover missing-slot errors, subscribe-triggered init, no-init on empty shard commands, and concurrent refresh vs unsubscribe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d81d0bfbf59e263f229a2fd685f8a54d5b8124c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->