### PR TITLE
Do not lose pool capacity when connection construction fails

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3414,7 +3414,6 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
         "Create a new connection"
         if self._created_connections >= self.max_connections:
             raise MaxConnectionsError("Too many connections")
-        self._created_connections += 1
 
         kwargs = dict(self.connection_kwargs)
 
@@ -3425,6 +3424,9 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
             )
         else:
             connection = self.connection_class(**kwargs)
+
+        # Only a connection that exists can be released, so count it here.
+        self._created_connections += 1
 
         # Record new connection created (starts as IDLE) - only after successful construction
         record_connection_count(
@@ -3798,7 +3800,12 @@ class BlockingConnectionPool(ConnectionPool):
             if connection is None:
                 # Start timing for observability
                 start_time_created = time.monotonic()
-                connection = self.make_connection()
+                try:
+                    connection = self.make_connection()
+                except BaseException:
+                    # Hand the slot back, or the pool shrinks on every failure.
+                    self.pool.put_nowait(None)
+                    raise
                 is_created = True
         finally:
             if self._locked:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3804,7 +3804,10 @@ class BlockingConnectionPool(ConnectionPool):
                     connection = self.make_connection()
                 except BaseException:
                     # Hand the slot back, or the pool shrinks on every failure.
-                    self.pool.put_nowait(None)
+                    try:
+                        self.pool.put_nowait(None)
+                    except Full:
+                        pass
                     raise
                 is_created = True
         finally:

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -71,6 +71,24 @@ class DummyConnection:
         pass
 
 
+class ConstructionFailure(Exception):
+    """Raised by ``failing_connection_class`` instead of building a connection."""
+
+
+def failing_connection_class(failures):
+    """A ``DummyConnection`` whose constructor raises the first ``failures`` times."""
+    remaining = [failures]
+
+    class FailingConnection(DummyConnection):
+        def __init__(self, **kwargs):
+            if remaining[0] > 0:
+                remaining[0] -= 1
+                raise ConstructionFailure("could not build a connection")
+            super().__init__(**kwargs)
+
+    return FailingConnection
+
+
 class TestConnectionPool:
     def get_pool(
         self,
@@ -144,6 +162,20 @@ class TestConnectionPool:
         pool = self.get_pool(max_connections=2, connection_class=DummyConnection)
         pool.get_connection()
         pool.get_connection()
+        with pytest.raises(redis.MaxConnectionsError):
+            pool.get_connection()
+
+    def test_capacity_survives_failed_connection_creation(self):
+        pool = self.get_pool(
+            max_connections=2, connection_class=failing_connection_class(2)
+        )
+        for _ in range(2):
+            with pytest.raises(ConstructionFailure):
+                pool.get_connection()
+
+        c1 = pool.get_connection()
+        c2 = pool.get_connection()
+        assert c1 != c2
         with pytest.raises(redis.MaxConnectionsError):
             pool.get_connection()
 
@@ -252,6 +284,22 @@ class TestBlockingConnectionPool:
         c1 = pool.get_connection()
         c2 = pool.get_connection()
         assert c1 != c2
+
+    def test_capacity_survives_failed_connection_creation(self):
+        pool = redis.BlockingConnectionPool(
+            connection_class=failing_connection_class(2),
+            max_connections=2,
+            timeout=0.1,
+        )
+        for _ in range(2):
+            with pytest.raises(ConstructionFailure):
+                pool.get_connection()
+
+        c1 = pool.get_connection()
+        c2 = pool.get_connection()
+        assert c1 != c2
+        with pytest.raises(redis.ConnectionError):
+            pool.get_connection()
 
     def test_connection_pool_blocks_until_timeout(self, master_host):
         "When out of connections, block for timeout seconds, then raise"


### PR DESCRIPTION
A connection pool permanently loses capacity when connection construction fails, and never
recovers — even after the underlying problem clears.

`ConnectionPool.make_connection` (`redis/connection.py:3417`) counts the connection before it
exists:

```python
if self._created_connections >= self.max_connections:
    raise MaxConnectionsError("Too many connections")
self._created_connections += 1          # <-- before the object exists

kwargs = dict(self.connection_kwargs)

# Create the connection first, then record metrics only on success
if self.cache is not None:
    connection = CacheProxyConnection(self.connection_class(**kwargs), self.cache, self._lock)
else:
    connection = self.connection_class(**kwargs)   # <-- can raise
```

The comment two lines below already says the metric is recorded "only after successful
construction" — the counter is the one thing left on the other side of the call. If
`connection_class(**kwargs)` raises, no object exists, so it can never reach `release()`, and
`release()` is the only place `_created_connections` is decremented (`connection.py:3479`). The
slot is gone for the life of the pool.

`BlockingConnectionPool.get_connection` (`connection.py:3798`) has the same shape: it pops a `None`
placeholder off `self.pool`, and if `make_connection()` raises, the `finally` releases only the
lock — the placeholder is never put back, so the queue shrinks by one on every failure.

### Reproduction

No server needed — `make_connection` is pure construction and fails before any socket work.

```python
class Flaky(Connection):
    fails_left = 0
    def __init__(self, **kw):
        if Flaky.fails_left > 0:
            Flaky.fails_left -= 1
            raise OSError("transient failure")
        super().__init__(**kw)
```

```
A) same pool: 2 handled construction failures, then the problem clears
   attempt 0 -> handled OSError: transient failure
   attempt 1 -> handled OSError: transient failure
   _created_connections=2  (real connections: 0)
   make_connection() -> MaxConnectionsError: Too many connections   <-- DEAD

B) CONTROL: fresh pool, identical config, same now-healthy class
   make_connection() -> OK Flaky  _created=1

C) is A permanently dead?
   retry 0 -> MaxConnectionsError
   retry 1 -> MaxConnectionsError
```

B is the point: same config, same class, now healthy — a new pool works and the old one never
does. The only difference is the earlier *handled* failures.

`BlockingConnectionPool`, same shape:

```
queue size at start                    = 2
attempt 0 -> handled OSError
attempt 1 -> handled OSError
queue size after 2 handled failures    = 0     (expected 2)
problem cleared -> ConnectionError: No connection available.
```

A stock reproduction with no custom class: three `SSLConnection` attempts with a bad
`ssl_cert_reqs` value leak three slots, and afterwards the real error
(`Invalid SSL Certificate Requirements Flag`) is permanently replaced by `Too many connections` —
including after the operator fixes the config.

### Change

Move the increment after construction, matching what the existing comment already does for the
metric, and hand the placeholder back in `BlockingConnectionPool`. `get_connection` already holds
`self._lock` across `make_connection`, so no locking change.

This is the same defect class as #4187 / #4193, which fixed the sibling leak in `release()`'s
not-owned path; these are the two remaining paths where a slot is taken and never returned.

`pytest tests/test_connection_pool.py` gives **7 failed, 96 passed** both before and after, with a
byte-identical failure list (auth and busy-loading cases that need a differently configured
server).

---

Disclosure: prepared with AI assistance; I verified both reproductions, the control, and the
before/after test runs myself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pool accounting on every new connection; behavior change is narrowly scoped to failure paths and is covered by new tests, but incorrect edge cases could still affect max-connection limits under load.
> 
> **Overview**
> Fixes a bug where **connection pools permanently lost slots** after a failed `connection_class(**kwargs)` during `make_connection`, so pools could hit `MaxConnectionsError` or “No connection available” even after the underlying error was fixed.
> 
> In **`ConnectionPool.make_connection`**, `_created_connections` is incremented **only after** the connection object is built successfully, aligned with existing “metrics only on success” behavior.
> 
> In **`BlockingConnectionPool.get_connection`**, if `make_connection()` raises after dequeuing a `None` placeholder, the code **returns that placeholder to the queue** so the pool does not shrink on each failure.
> 
> Adds tests with a `failing_connection_class` helper for both pool types: two construction failures, then full capacity is still obtainable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c20c9498a94f8ccdcd0344b3faadc1af695fb901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->