### PR TITLE
Fix integration tests for Redis Enterprise runs

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -110,13 +110,21 @@ def fixed_client_tests(c, uvloop=False, profile=False):
     """Run tests that use the fixed client fixture."""
     _ensure_junit_results_dir()
     profile_arg = "--profile" if profile else ""
+    # Ignore the scenario suites explicitly, as standalone_tests and cluster_tests
+    # do. `-m fixed_client` deselects after collection, so without this pytest still
+    # imports them - and the maint-notification scenario modules call
+    # generate_params() inside @pytest.mark.parametrize, which queries the fault
+    # injector at class-definition time and fails collection where none is running.
+    ignore_scenario = (
+        "--ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario"
+    )
     if uvloop:
         run(
-            f"pytest {profile_arg} --uvloop --cov=./ --cov-report=xml:coverage_fixed_client_uvloop.xml --junit-xml=junit-results/fixed_client-uvloop-results.xml -m fixed_client"
+            f"pytest {profile_arg} {ignore_scenario} --uvloop --cov=./ --cov-report=xml:coverage_fixed_client_uvloop.xml --junit-xml=junit-results/fixed_client-uvloop-results.xml -m fixed_client"
         )
     else:
         run(
-            f"pytest {profile_arg} --cov=./ --cov-report=xml:coverage_fixed_client.xml --junit-xml=junit-results/fixed_client-results.xml -m fixed_client"
+            f"pytest {profile_arg} {ignore_scenario} --cov=./ --cov-report=xml:coverage_fixed_client.xml --junit-xml=junit-results/fixed_client-results.xml -m fixed_client"
         )
 
 

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -41,6 +41,7 @@ from tests.conftest import (
     expects_resp3_shape,
     expects_unified_shape,
     expected_response_shape,
+    skip_if_redis_enterprise,
     skip_if_server_version_gte,
     skip_if_server_version_lt,
     skip_unless_arch_bits,
@@ -836,6 +837,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_start_basic(self, r: redis.Redis):
         """Test basic HOTKEYS START command with CPU metric"""
         # Reset any previous session
@@ -850,6 +852,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_start_with_all_metrics(self, r: redis.Redis):
         """Test HOTKEYS START with both CPU and NET metrics"""
         try:
@@ -864,6 +867,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_start_with_duration(self, r: redis.Redis):
         """Test HOTKEYS START with duration parameter"""
         try:
@@ -878,6 +882,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_start_with_sample_ratio(self, r: redis.Redis):
         """Test HOTKEYS START with sample ratio"""
         try:
@@ -892,6 +897,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_start_with_slots_fail_on_non_cluster_setup(
         self, r: redis.Redis
     ):
@@ -907,6 +913,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_start_with_all_parameters(self, r: redis.Redis):
         """Test HOTKEYS START with all optional parameters"""
         try:
@@ -924,6 +931,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_stop(self, r: redis.Redis):
         """Test HOTKEYS STOP command"""
         try:
@@ -940,6 +948,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_reset(self, r: redis.Redis):
         """Test HOTKEYS RESET command"""
         try:
@@ -981,6 +990,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_get_ongoing_session(self, r: redis.Redis):
         """Test HOTKEYS GET during an ongoing collection session"""
         try:
@@ -1013,6 +1023,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_get_terminated_session(self, r: redis.Redis):
         """Test HOTKEYS GET after stopping a collection session"""
         try:
@@ -1042,6 +1053,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_get_all_fields(self, r: redis.Redis):
         """Test HOTKEYS GET returns all documented fields"""
         try:
@@ -1092,6 +1104,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     async def test_hotkeys_get_all_fields_decoded(self, decoded_r: redis.Redis):
         """Test HOTKEYS GET returns all documented fields"""
         try:

--- a/tests/test_asyncio/test_lock.py
+++ b/tests/test_asyncio/test_lock.py
@@ -170,18 +170,17 @@ class TestLock:
                 await asyncio.sleep(0.15)
 
     async def test_context_manager_not_raise_on_release_lock_error(self, r):
+        # No lock timeout here: the error under test is the LockError raised by the
+        # redundant release in __aexit__, not the LockNotOwnedError of an expired lock
+        # (covered by test_context_manager_not_raise_on_release_lock_not_owned_error).
         try:
-            async with self.get_lock(
-                r, "foo", timeout=0.1, raise_on_release_error=False
-            ) as lock:
+            async with self.get_lock(r, "foo", raise_on_release_error=False) as lock:
                 await lock.release()
         except LockError:
             pytest.fail("LockError should not have been raised")
 
         with pytest.raises(LockError):
-            async with self.get_lock(
-                r, "foo", timeout=0.1, raise_on_release_error=True
-            ) as lock:
+            async with self.get_lock(r, "foo", raise_on_release_error=True) as lock:
                 await lock.release()
 
     async def test_high_sleep_small_blocking_timeout(self, r, fake_lock_time):

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -4174,9 +4174,12 @@ class TestHybridSearch(AsyncSearchTestsBase):
 
         hybrid_query = HybridQuery(search_query, vsim_query)
 
+        # MAXIDLE is expressed in milliseconds, and the two cursors created here
+        # are read over two further round trips. Keep the idle window wide enough
+        # to survive that when the target deployment is remote.
         res = await decoded_r.ft().hybrid_search(
             query=hybrid_query,
-            cursor=HybridCursorQuery(count=5, max_idle=100),
+            cursor=HybridCursorQuery(count=5, max_idle=10000),
             params_substitution={
                 "vec": np.array([1, 2, 7, 6], dtype=np.float32).tobytes()
             },

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -1200,15 +1200,20 @@ async def test_query_labels_server_errors(decoded_r: redis.Redis):
 async def test_uncompressed(decoded_r: redis.Redis):
     await decoded_r.ts().create("compressed")
     await decoded_r.ts().create("uncompressed", uncompressed=True)
+    # Append the samples with a single TS.MADD instead of 2000 individual TS.ADD
+    # round trips, which are slow enough to hit the test timeout when the target
+    # deployment is remote.
+    samples = []
     for i in range(1000):
-        await decoded_r.ts().add("compressed", i, i)
-        await decoded_r.ts().add("uncompressed", i, i)
+        samples.append(("compressed", i, i))
+        samples.append(("uncompressed", i, i))
+    assert len(await decoded_r.ts().madd(samples)) == 2000
     compressed_info = await decoded_r.ts().info("compressed")
     uncompressed_info = await decoded_r.ts().info("uncompressed")
     if is_resp2_connection(decoded_r):
-        assert compressed_info.memory_usage != uncompressed_info.memory_usage
+        assert compressed_info.memory_usage < uncompressed_info.memory_usage
     else:
-        assert compressed_info["memoryUsage"] != uncompressed_info["memoryUsage"]
+        assert compressed_info["memoryUsage"] < uncompressed_info["memoryUsage"]
 
 
 @pytest.mark.redismod

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1286,6 +1286,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_start_basic(self, r):
         """Test basic HOTKEYS START command with CPU metric"""
         # Reset any previous session
@@ -1300,6 +1301,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_start_with_all_metrics(self, r):
         """Test HOTKEYS START with both CPU and NET metrics"""
         try:
@@ -1314,6 +1316,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_start_with_duration(self, r):
         """Test HOTKEYS START with duration parameter"""
         try:
@@ -1328,6 +1331,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_start_with_sample_ratio(self, r):
         """Test HOTKEYS START with sample ratio"""
         try:
@@ -1342,6 +1346,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_start_fail__on_noncluster_setup_with_slots(self, r):
         """Test HOTKEYS START with specific hash slots"""
         try:
@@ -1357,6 +1362,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_start_with_all_parameters(self, r):
         """Test HOTKEYS START with all optional parameters"""
         try:
@@ -1374,6 +1380,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_stop(self, r):
         """Test HOTKEYS STOP command"""
         try:
@@ -1390,6 +1397,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_reset(self, r):
         """Test HOTKEYS RESET command"""
         try:
@@ -1431,6 +1439,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_get_ongoing_session(self, r):
         """Test HOTKEYS GET during an ongoing collection session"""
         try:
@@ -1463,6 +1472,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_get_terminated_session(self, r):
         """Test HOTKEYS GET after stopping a collection session"""
         try:
@@ -1493,6 +1503,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_get_all_fields(self, r):
         """Test HOTKEYS GET returns all documented fields"""
         try:
@@ -1544,6 +1555,7 @@ class TestRedisCommands:
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.5.240")
+    @skip_if_redis_enterprise()
     def test_hotkeys_get_all_fields_decoded(self, decoded_r: redis.Redis):
         """Test HOTKEYS GET returns all documented fields"""
         try:

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -165,18 +165,17 @@ class TestLock:
                 time.sleep(0.15)
 
     def test_context_manager_not_raise_on_release_lock_error(self, r):
+        # No lock timeout here: the error under test is the LockError raised by the
+        # redundant release in __exit__, not the LockNotOwnedError of an expired lock
+        # (covered by test_context_manager_not_raise_on_release_lock_not_owned_error).
         try:
-            with self.get_lock(
-                r, "foo", timeout=0.1, raise_on_release_error=False
-            ) as lock:
+            with self.get_lock(r, "foo", raise_on_release_error=False) as lock:
                 lock.release()
         except LockError:
             pytest.fail("LockError should not have been raised")
 
         with pytest.raises(LockError):
-            with self.get_lock(
-                r, "foo", timeout=0.1, raise_on_release_error=True
-            ) as lock:
+            with self.get_lock(r, "foo", raise_on_release_error=True) as lock:
                 lock.release()
 
     def test_high_sleep_small_blocking_timeout(self, r, fake_lock_time):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1601,17 +1601,23 @@ class TestBaseSearchFunctionality(SearchTestsBase):
         client.hset("hset:1", "txt", "a")
         client.hset("hset:2", "txt", "b")
         client.hset("hset:3", "txt", "c")
+        # Keep searching until the expiration window of hset:2 has passed. The
+        # loop is bounded by elapsed time rather than by a fixed iteration count,
+        # so it covers the same window without depending on how long a single
+        # search round trip takes.
         if expects_resp2_shape(client) or expects_unified_shape(client):
             assert 3 == client.ft().search(Query("*")).total
             client.pexpire("hset:2", 300)
-            for _ in range(500):
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline:
                 client.ft().search(Query("*")).docs[1]
             time.sleep(1)
             assert 2 == client.ft().search(Query("*")).total
         elif expects_resp3_shape(client):
             assert 3 == client.ft().search(Query("*"))["total_results"]
             client.pexpire("hset:2", 300)
-            for _ in range(500):
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline:
                 client.ft().search(Query("*"))["results"][1]
             time.sleep(1)
             assert 2 == client.ft().search(Query("*"))["total_results"]
@@ -6292,9 +6298,12 @@ class TestHybridSearch(SearchTestsBase):
 
         hybrid_query = HybridQuery(search_query, vsim_query)
 
+        # MAXIDLE is expressed in milliseconds, and the two cursors created here
+        # are read over two further round trips. Keep the idle window wide enough
+        # to survive that when the target deployment is remote.
         res = client.ft().hybrid_search(
             query=hybrid_query,
-            cursor=HybridCursorQuery(count=5, max_idle=100),
+            cursor=HybridCursorQuery(count=5, max_idle=10000),
             params_substitution={
                 "vec": np.array([1, 2, 7, 6], dtype=np.float32).tobytes()
             },

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1387,9 +1387,14 @@ def test_pipeline(client):
 def test_uncompressed(client):
     client.ts().create("compressed")
     client.ts().create("uncompressed", uncompressed=True)
+    # Append the samples with a single TS.MADD instead of 2000 individual TS.ADD
+    # round trips, which are slow enough to hit the test timeout when the target
+    # deployment is remote.
+    samples = []
     for i in range(1000):
-        client.ts().add("compressed", i, i)
-        client.ts().add("uncompressed", i, i)
+        samples.append(("compressed", i, i))
+        samples.append(("uncompressed", i, i))
+    assert len(client.ts().madd(samples)) == 2000
     compressed_info = client.ts().info("compressed")
     uncompressed_info = client.ts().info("uncompressed")
     if is_resp2_connection(client):

--- a/tests/test_vsets.py
+++ b/tests/test_vsets.py
@@ -7,6 +7,7 @@ from redis.commands.vectorset.commands import QuantizationOptions
 
 from .conftest import (
     _get_client,
+    skip_if_redis_enterprise,
     skip_if_server_version_lt,
 )
 
@@ -978,6 +979,7 @@ def _validate_quantization(original, quantized, tolerance=0.1):
 
 
 @skip_if_server_version_lt("8.4.0")
+@skip_if_redis_enterprise()
 def test_vrange_basic(d_client):
     """Test basic VRANGE functionality with lexicographical ordering."""
     # Add elements with different names
@@ -1000,6 +1002,7 @@ def test_vrange_basic(d_client):
 
 
 @skip_if_server_version_lt("8.4.0")
+@skip_if_redis_enterprise()
 def test_vrange_with_count(d_client):
     """Test VRANGE with count parameter."""
     # Add elements
@@ -1028,6 +1031,7 @@ def test_vrange_with_count(d_client):
 
 
 @skip_if_server_version_lt("8.4.0")
+@skip_if_redis_enterprise()
 def test_vrange_iteration(d_client):
     """Test VRANGE for stateless iteration."""
     # Add elements
@@ -1051,6 +1055,7 @@ def test_vrange_iteration(d_client):
 
 
 @skip_if_server_version_lt("8.4.0")
+@skip_if_redis_enterprise()
 def test_vrange_empty_key(d_client):
     """Test VRANGE on non-existent key."""
     result = d_client.vset().vrange("nonexistent", "-", "+")
@@ -1061,6 +1066,7 @@ def test_vrange_empty_key(d_client):
 
 
 @skip_if_server_version_lt("8.4.0")
+@skip_if_redis_enterprise()
 def test_vrange_special_characters(d_client):
     """Test VRANGE with elements containing special characters."""
     # Add elements with special characters
@@ -1077,6 +1083,7 @@ def test_vrange_special_characters(d_client):
 
 
 @skip_if_server_version_lt("8.4.0")
+@skip_if_redis_enterprise()
 def test_vrange_single_element(d_client):
     """Test VRANGE with a single element."""
     d_client.vset().vadd("myset", [1.0, 2.0], "single")
@@ -1092,6 +1099,7 @@ def test_vrange_single_element(d_client):
 
 
 @skip_if_server_version_lt("8.4.0")
+@skip_if_redis_enterprise()
 def test_vrange_lexicographical_order(d_client):
     """Test that VRANGE returns elements in correct lexicographical order."""
     # Add elements in random order
@@ -1106,6 +1114,7 @@ def test_vrange_lexicographical_order(d_client):
 
 
 @skip_if_server_version_lt("8.4.0")
+@skip_if_redis_enterprise()
 def test_vrange_numeric_strings(d_client):
     """Test VRANGE with numeric string elements."""
     # Add numeric strings (lexicographical order, not numeric)


### PR DESCRIPTION
Test fixes:
- skip HOTKEYS tests on Redis Enterprise (sync and async test_commands)
- fix search cursor and aggregation tests for RE (sync and async)
- fix timeseries and vsets tests for RE
- stabilize lock release-error tests (drop the 0.1s timeout that could expire mid-test)
- tasks.py: properly skip scenario tests when running fixed_client tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test harnesses and skips; no production Redis client code is modified.
> 
> **Overview**
> **Test-only changes** so the suite collects and passes against Redis Enterprise and slower remote deployments—no library behavior changes.
> 
> `fixed_client_tests` in `tasks.py` now passes `--ignore` for the scenario test trees (matching standalone/cluster runs), so pytest does not import modules that call the fault injector at collection time.
> 
> HOTKEYS coverage in sync/async `test_commands` is gated with `@skip_if_redis_enterprise()`. VRANGE tests in `test_vsets` get the same skip. Lock context-manager tests drop the short lock timeout so they exercise redundant `release` / `LockError` without racing lock expiry.
> 
> Stability tweaks for latency: hybrid search cursor tests raise `max_idle` to 10s; `test_expire_while_search` loops until a monotonic deadline instead of 500 fixed searches; `test_uncompressed` batches samples via `TS.MADD` and asserts compressed memory usage is **less than** uncompressed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1880e603d55d8206bad204e6556e525e84f211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->