### PR TITLE
Stabilize MultiDB (Active-Active) client and tests

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2386,7 +2386,16 @@ class NodesManager:
                     break
 
             if not startup_nodes_reachable:
-                raise RedisClusterUnreachableError(
+                # The unreachable subtype is reserved for connectivity failures:
+                # MultiDB registers it as retryable, so a deterministic
+                # server/configuration error (e.g. cluster mode disabled) must
+                # keep surfacing as a plain RedisClusterException.
+                if isinstance(exception, (ConnectionError, TimeoutError, OSError)):
+                    raise RedisClusterUnreachableError(
+                        f"Redis Cluster cannot be connected. Please provide at least "
+                        f"one reachable node: {str(exception)}"
+                    ) from exception
+                raise RedisClusterException(
                     f"Redis Cluster cannot be connected. Please provide at least "
                     f"one reachable node: {str(exception)}"
                 ) from exception

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -116,6 +116,7 @@ from redis.exceptions import (
     MaxConnectionsError,
     MovedError,
     RedisClusterException,
+    RedisClusterUnreachableError,
     RedisError,
     ResponseError,
     SlotNotCoveredError,
@@ -2385,7 +2386,7 @@ class NodesManager:
                     break
 
             if not startup_nodes_reachable:
-                raise RedisClusterException(
+                raise RedisClusterUnreachableError(
                     f"Redis Cluster cannot be connected. Please provide at least "
                     f"one reachable node: {str(exception)}"
                 ) from exception

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -105,6 +105,8 @@ from redis.event import (
 )
 from redis.exceptions import (
     AskError,
+    AuthenticationError,
+    AuthorizationError,
     BusyLoadingError,
     ClusterDownError,
     ClusterError,
@@ -2388,9 +2390,16 @@ class NodesManager:
             if not startup_nodes_reachable:
                 # The unreachable subtype is reserved for connectivity failures:
                 # MultiDB registers it as retryable, so a deterministic
-                # server/configuration error (e.g. cluster mode disabled) must
-                # keep surfacing as a plain RedisClusterException.
-                if isinstance(exception, (ConnectionError, TimeoutError, OSError)):
+                # server/configuration error (e.g. cluster mode disabled or
+                # invalid credentials - AuthenticationError and
+                # AuthorizationError subclass ConnectionError but cannot be
+                # repaired by a failover) must keep surfacing as a plain
+                # RedisClusterException.
+                if isinstance(
+                    exception, (ConnectionError, TimeoutError, OSError)
+                ) and not isinstance(
+                    exception, (AuthenticationError, AuthorizationError)
+                ):
                     raise RedisClusterUnreachableError(
                         f"Redis Cluster cannot be connected. Please provide at least "
                         f"one reachable node: {str(exception)}"

--- a/redis/asyncio/multidb/client.py
+++ b/redis/asyncio/multidb/client.py
@@ -16,7 +16,7 @@ from redis.asyncio.retry import Retry
 from redis.background import BackgroundScheduler
 from redis.backoff import NoBackoff
 from redis.commands import AsyncCoreCommands, AsyncRedisModuleCommands
-from redis.exceptions import DataError
+from redis.exceptions import DataError, RedisClusterUnreachableError
 from redis.multidb.circuit import CircuitBreaker
 from redis.multidb.circuit import State as CBState
 from redis.multidb.exception import (
@@ -64,7 +64,9 @@ class MultiDBClient(AsyncRedisModuleCommands, AsyncCoreCommands):
         self._auto_fallback_interval = config.auto_fallback_interval
         self._event_dispatcher = config.event_dispatcher
         self._command_retry = config.command_retry
-        self._command_retry.update_supported_errors([ConnectionRefusedError])
+        self._command_retry.update_supported_errors(
+            [ConnectionRefusedError, RedisClusterUnreachableError]
+        )
         self.command_executor = DefaultCommandExecutor(
             failure_detectors=self._failure_detectors,
             databases=self._databases,

--- a/redis/asyncio/multidb/healthcheck.py
+++ b/redis/asyncio/multidb/healthcheck.py
@@ -6,11 +6,13 @@ from enum import Enum
 from typing import List, Optional, Tuple, Type, Union
 
 from redis.asyncio import Redis as AsyncRedis
+from redis.asyncio.cluster import ClusterNode as AsyncClusterNode
 from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
 from redis.asyncio.http.http_client import DEFAULT_TIMEOUT, AsyncHTTPClientWrapper
 from redis.backoff import NoBackoff
 from redis.client import Redis as SyncRedis
 from redis.cluster import RedisCluster as SyncRedisCluster
+from redis.exceptions import ConnectionError, TimeoutError
 from redis.http.http_client import HttpClient
 from redis.multidb.exception import UnhealthyDatabaseException
 from redis.retry import Retry
@@ -183,9 +185,7 @@ class AbstractHealthCheckPolicy(HealthCheckPolicy):
                 conn_kwargs = database.client.get_connection_kwargs().copy()
                 filtered_kwargs = _filter_kwargs(conn_kwargs, AsyncRedisCluster)
                 startup_nodes = database.client.startup_nodes
-                # Use the first node as the startup node
                 if startup_nodes:
-                    first_node = startup_nodes[0]
                     nodes_manager = database.client.nodes_manager
                     # The sync and async NodesManager expose this setting under
                     # different names (``_require_full_coverage`` vs
@@ -196,9 +196,15 @@ class AbstractHealthCheckPolicy(HealthCheckPolicy):
                         "require_full_coverage",
                         getattr(nodes_manager, "_require_full_coverage", True),
                     )
+                    # Seed the health-check client with every configured startup
+                    # node, not just the first: if the first seed is down while
+                    # another is healthy, the probe must still be able to discover
+                    # the cluster instead of marking the database unhealthy.
                     client = AsyncRedisCluster(
-                        host=first_node.host,
-                        port=first_node.port,
+                        startup_nodes=[
+                            AsyncClusterNode(node.host, node.port)
+                            for node in startup_nodes
+                        ],
                         dynamic_startup_nodes=nodes_manager._dynamic_startup_nodes,
                         address_remap=nodes_manager.address_remap,
                         require_full_coverage=require_full_coverage,
@@ -411,6 +417,14 @@ class PingHealthCheck(AbstractHealthCheck):
 
             for result in results:
                 if isinstance(result, BaseException):
+                    if isinstance(result, (ConnectionError, TimeoutError, OSError)):
+                        # A failing node may have been removed or replaced in the
+                        # cluster, and direct node probes bypass the client's own
+                        # topology-refresh path. Closing the client resets its lazy
+                        # initialization, so the next probe re-discovers the
+                        # topology from the startup nodes instead of pinging the
+                        # stale node forever.
+                        await hc_client.aclose()
                     raise result
 
                 if not result:
@@ -547,11 +561,11 @@ class LagAwareHealthCheck(AbstractHealthCheck):
         # response - sending the second request to the wrong cluster.
         base_url = f"{database.health_check_url}:{self._rest_api_port}"
 
-        # Find bdb matching to the current database host
+        # Find bdb matching to the current database host. The per-request
+        # deadline stays the client's configured http_timeout; the whole check
+        # is already bounded by health_check_timeout in the policy.
         matching_bdb = self._find_matching_bdb(
-            await self._http_client.get(
-                f"{base_url}/v1/bdbs", timeout=self.health_check_timeout
-            ),
+            await self._http_client.get(f"{base_url}/v1/bdbs"),
             db_hosts,
         )
 
@@ -566,9 +580,7 @@ class LagAwareHealthCheck(AbstractHealthCheck):
             f"{base_url}/v1/bdbs/{matching_bdb['uid']}/availability"
             f"?extend_check=lag&availability_lag_tolerance_ms={self._lag_aware_tolerance}"
         )
-        await self._http_client.get(
-            url, expect_json=False, timeout=self.health_check_timeout
-        )
+        await self._http_client.get(url, expect_json=False)
 
         # Status checked in an http client, otherwise HttpError will be raised
         return True

--- a/redis/asyncio/multidb/healthcheck.py
+++ b/redis/asyncio/multidb/healthcheck.py
@@ -386,9 +386,34 @@ class PingHealthCheck(AbstractHealthCheck):
             return await hc_client.execute_command("PING")
         else:
             # For a cluster checks if all nodes are healthy.
+            # The health check client is created lazily, so the topology has to be
+            # discovered before pinging - an uninitialized client has an empty node
+            # cache, so there would be nothing to ping and the database would be
+            # reported as healthy. Once discovered, this is a no-op.
+            await hc_client.initialize()
             all_nodes = hc_client.get_nodes()
-            for node in all_nodes:
-                if not await node.redis_connection.execute_command("PING"):
+
+            if not all_nodes:
+                return False
+
+            # The nodes are pinged concurrently rather than one after another: a
+            # single health_check_timeout covers the whole health check - every
+            # probe of it - so a serial loop makes the budget scale with the size
+            # of the cluster. Gathering keeps a probe at the cost of one round
+            # trip. Exceptions are collected rather than propagated by gather
+            # itself, so that a failing node does not leave its siblings running
+            # unawaited; the first one is re-raised below to keep the caller's
+            # error handling unchanged.
+            results = await asyncio.gather(
+                *(node.execute_command("PING") for node in all_nodes),
+                return_exceptions=True,
+            )
+
+            for result in results:
+                if isinstance(result, BaseException):
+                    raise result
+
+                if not result:
                     return False
 
             return True
@@ -458,6 +483,48 @@ class LagAwareHealthCheck(AbstractHealthCheck):
             health_check_timeout=health_check_timeout,
         )
 
+    @staticmethod
+    def _database_hosts(database) -> set[str]:
+        """
+        The hosts the given database is known by on the Redis Enterprise REST API.
+
+        For a cluster client these are the endpoints the client was configured with,
+        not the nodes it discovered: CLUSTER SLOTS advertises each node's own address,
+        which on a public Redis Enterprise endpoint is neither the endpoint DNS name
+        nor an address the bdb lists. ``startup_nodes`` is read off the client rather
+        than off its nodes manager, because the latter is replaced by the discovered
+        nodes when ``dynamic_startup_nodes`` is enabled, as it is by default.
+        """
+        if isinstance(database.client, (AsyncRedis, SyncRedis)):
+            return {database.client.get_connection_kwargs()["host"]}
+
+        # Cluster client
+        return {node.host for node in database.client.startup_nodes}
+
+    @staticmethod
+    def _find_matching_bdb(bdbs, db_hosts: set[str]) -> Optional[dict]:
+        """
+        The bdb whose endpoints identify one of the given database hosts.
+
+        A DNS name belongs to a single bdb, while databases hosted by the same cluster
+        share the addresses their endpoints resolve to, so a match by DNS name is
+        preferred over a match by address across all of the bdbs.
+        """
+        addr_match = None
+
+        for bdb in bdbs:
+            for endpoint in bdb["endpoints"]:
+                if endpoint["dns_name"] in db_hosts:
+                    return bdb
+
+                # In case if the host was set as public IP
+                if addr_match is None and any(
+                    addr in db_hosts for addr in endpoint["addr"]
+                ):
+                    addr_match = bdb
+
+        return addr_match
+
     async def check_health(self, database, hc_client: AsyncRedisClientT) -> bool:
         """
         Check database health via Redis Enterprise REST API.
@@ -471,38 +538,37 @@ class LagAwareHealthCheck(AbstractHealthCheck):
                 "Database health check url is not set. Please check DatabaseConfig for the current database."
             )
 
-        if isinstance(database.client, (AsyncRedis, SyncRedis)):
-            db_host = database.client.get_connection_kwargs()["host"]
-        else:
-            # Cluster client
-            db_host = database.client.get_nodes()[0].host
+        db_hosts = self._database_hosts(database)
 
+        # Absolute URLs, rather than a base_url set on the HTTP client: one
+        # LagAwareHealthCheck instance serves every database and MultiDBClient
+        # checks them concurrently, so a base_url assignment made here would be
+        # overwritten by another database's check while this one is awaiting its
+        # response - sending the second request to the wrong cluster.
         base_url = f"{database.health_check_url}:{self._rest_api_port}"
-        self._http_client.client.base_url = base_url
 
         # Find bdb matching to the current database host
-        matching_bdb = None
-        for bdb in await self._http_client.get("/v1/bdbs"):
-            for endpoint in bdb["endpoints"]:
-                if endpoint["dns_name"] == db_host:
-                    matching_bdb = bdb
-                    break
-
-                # In case if the host was set as public IP
-                for addr in endpoint["addr"]:
-                    if addr == db_host:
-                        matching_bdb = bdb
-                        break
+        matching_bdb = self._find_matching_bdb(
+            await self._http_client.get(
+                f"{base_url}/v1/bdbs", timeout=self.health_check_timeout
+            ),
+            db_hosts,
+        )
 
         if matching_bdb is None:
-            logger.warning("LagAwareHealthCheck failed: Couldn't find a matching bdb")
+            logger.warning(
+                "LagAwareHealthCheck failed: Couldn't find a bdb matching any of "
+                f"the database hosts {sorted(db_hosts)}"
+            )
             raise ValueError("Could not find a matching bdb")
 
         url = (
-            f"/v1/bdbs/{matching_bdb['uid']}/availability"
+            f"{base_url}/v1/bdbs/{matching_bdb['uid']}/availability"
             f"?extend_check=lag&availability_lag_tolerance_ms={self._lag_aware_tolerance}"
         )
-        await self._http_client.get(url, expect_json=False)
+        await self._http_client.get(
+            url, expect_json=False, timeout=self.health_check_timeout
+        )
 
         # Status checked in an http client, otherwise HttpError will be raised
         return True

--- a/redis/asyncio/multidb/healthcheck.py
+++ b/redis/asyncio/multidb/healthcheck.py
@@ -8,10 +8,12 @@ from typing import List, Optional, Tuple, Type, Union
 from redis.asyncio import Redis as AsyncRedis
 from redis.asyncio.cluster import ClusterNode as AsyncClusterNode
 from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from redis.asyncio.connection import SSLConnection as AsyncSSLConnection
 from redis.asyncio.http.http_client import DEFAULT_TIMEOUT, AsyncHTTPClientWrapper
 from redis.backoff import NoBackoff
 from redis.client import Redis as SyncRedis
 from redis.cluster import RedisCluster as SyncRedisCluster
+from redis.connection import SSLConnection as SyncSSLConnection
 from redis.exceptions import ConnectionError, TimeoutError
 from redis.http.http_client import HttpClient
 from redis.multidb.exception import UnhealthyDatabaseException
@@ -40,6 +42,28 @@ def _filter_kwargs(kwargs: dict, cls: Type) -> dict:
     """Filter kwargs to only include parameters accepted by the class's __init__."""
     allowed = _get_init_params(cls)
     return {k: v for k, v in kwargs.items() if k in allowed}
+
+
+def _uses_tls(client, conn_kwargs: dict) -> bool:
+    """Detect whether a client's transport is TLS.
+
+    The clients turn ``ssl=True`` into ``connection_class=SSLConnection``:
+    the standalone clients hold it on their connection pool, the async
+    cluster keeps it inside its connection kwargs, and the sync cluster
+    keeps the plain ``ssl`` key there. None of these survive
+    ``_filter_kwargs`` (``connection_class`` is not an ``__init__``
+    parameter of the rebuilt clients), so TLS must be re-expressed as
+    ``ssl=True`` explicitly.
+    """
+    if conn_kwargs.get("ssl"):
+        return True
+    connection_class = conn_kwargs.get("connection_class")
+    if connection_class is None:
+        pool = getattr(client, "connection_pool", None)
+        connection_class = getattr(pool, "connection_class", None)
+    return isinstance(connection_class, type) and issubclass(
+        connection_class, (SyncSSLConnection, AsyncSSLConnection)
+    )
 
 
 DEFAULT_HEALTH_CHECK_PROBES = 3
@@ -178,12 +202,23 @@ class AbstractHealthCheckPolicy(HealthCheckPolicy):
             if isinstance(database.client, (AsyncRedis, SyncRedis)):
                 conn_kwargs = database.client.get_connection_kwargs()
                 filtered_kwargs = _filter_kwargs(conn_kwargs, AsyncRedis)
+                if _uses_tls(database.client, conn_kwargs):
+                    # Preserve the original transport: the source kwargs carry
+                    # TLS as connection_class=SSLConnection, which the filter
+                    # drops, so without this the probe would speak plaintext
+                    # to a TLS port and mark a healthy database unavailable.
+                    filtered_kwargs["ssl"] = True
                 client = AsyncRedis(**filtered_kwargs)
             elif isinstance(database.client, (AsyncRedisCluster, SyncRedisCluster)):
                 # Cluster client - create a single cluster client that handles
                 # topology changes internally
                 conn_kwargs = database.client.get_connection_kwargs().copy()
                 filtered_kwargs = _filter_kwargs(conn_kwargs, AsyncRedisCluster)
+                if _uses_tls(database.client, conn_kwargs):
+                    # Same transport preservation as the standalone branch
+                    # above; the async cluster also represents TLS as
+                    # connection_class=SSLConnection in its connection kwargs.
+                    filtered_kwargs["ssl"] = True
                 startup_nodes = database.client.startup_nodes
                 if startup_nodes:
                     nodes_manager = database.client.nodes_manager

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -2887,7 +2887,16 @@ class NodesManager:
                     break
 
             if not startup_nodes_reachable:
-                raise RedisClusterUnreachableError(
+                # The unreachable subtype is reserved for connectivity failures:
+                # MultiDB registers it as retryable, so a deterministic
+                # server/configuration error (e.g. cluster mode disabled) must
+                # keep surfacing as a plain RedisClusterException.
+                if isinstance(exception, (ConnectionError, TimeoutError, OSError)):
+                    raise RedisClusterUnreachableError(
+                        f"Redis Cluster cannot be connected. Please provide at least "
+                        f"one reachable node: {str(exception)}"
+                    ) from exception
+                raise RedisClusterException(
                     f"Redis Cluster cannot be connected. Please provide at least "
                     f"one reachable node: {str(exception)}"
                 ) from exception

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -78,6 +78,7 @@ from redis.exceptions import (
     MaxConnectionsError,
     MovedError,
     RedisClusterException,
+    RedisClusterUnreachableError,
     RedisError,
     ResponseError,
     SlotNotCoveredError,
@@ -2886,7 +2887,7 @@ class NodesManager:
                     break
 
             if not startup_nodes_reachable:
-                raise RedisClusterException(
+                raise RedisClusterUnreachableError(
                     f"Redis Cluster cannot be connected. Please provide at least "
                     f"one reachable node: {str(exception)}"
                 ) from exception

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -68,6 +68,7 @@ from redis.event import (
 from redis.exceptions import (
     AskError,
     AuthenticationError,
+    AuthorizationError,
     ClusterDownError,
     ClusterError,
     ConnectionError,
@@ -2889,9 +2890,16 @@ class NodesManager:
             if not startup_nodes_reachable:
                 # The unreachable subtype is reserved for connectivity failures:
                 # MultiDB registers it as retryable, so a deterministic
-                # server/configuration error (e.g. cluster mode disabled) must
-                # keep surfacing as a plain RedisClusterException.
-                if isinstance(exception, (ConnectionError, TimeoutError, OSError)):
+                # server/configuration error (e.g. cluster mode disabled or
+                # invalid credentials - AuthenticationError and
+                # AuthorizationError subclass ConnectionError but cannot be
+                # repaired by a failover) must keep surfacing as a plain
+                # RedisClusterException.
+                if isinstance(
+                    exception, (ConnectionError, TimeoutError, OSError)
+                ) and not isinstance(
+                    exception, (AuthenticationError, AuthorizationError)
+                ):
                     raise RedisClusterUnreachableError(
                         f"Redis Cluster cannot be connected. Please provide at least "
                         f"one reachable node: {str(exception)}"

--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -279,6 +279,20 @@ class SlotNotCoveredError(RedisClusterException):
     pass
 
 
+class RedisClusterUnreachableError(RedisClusterException):
+    """
+    Raised when a topology refresh could not reach any node of the cluster.
+
+    A subclass of :class:`RedisClusterException` so existing handlers keep working,
+    but distinguishable from the many deterministic errors that also use the base
+    type - cross-slot commands, unsupported methods and the like - so that callers
+    which need to react to an unreachable deployment can select just this case by
+    type. The connection error that triggered the refresh is kept as the cause.
+    """
+
+    pass
+
+
 class MaxConnectionsError(ConnectionError):
     """
     Raised when a connection pool has reached its max_connections limit.

--- a/redis/multidb/client.py
+++ b/redis/multidb/client.py
@@ -8,7 +8,7 @@ from redis.background import BackgroundScheduler
 from redis.backoff import NoBackoff
 from redis.client import PubSubWorkerThread
 from redis.commands import CoreCommands, RedisModuleCommands
-from redis.exceptions import DataError
+from redis.exceptions import DataError, RedisClusterUnreachableError
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.multidb.circuit import CircuitBreaker
 from redis.multidb.circuit import State as CBState
@@ -67,7 +67,9 @@ class MultiDBClient(RedisModuleCommands, CoreCommands):
         self._auto_fallback_interval = config.auto_fallback_interval
         self._event_dispatcher = config.event_dispatcher
         self._command_retry = config.command_retry
-        self._command_retry.update_supported_errors((ConnectionRefusedError,))
+        self._command_retry.update_supported_errors(
+            (ConnectionRefusedError, RedisClusterUnreachableError)
+        )
         self.command_executor = DefaultCommandExecutor(
             failure_detectors=self._failure_detectors,
             databases=self._databases,

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -43,6 +43,7 @@ from redis.event import (
 )
 from redis.exceptions import (
     AskError,
+    AuthenticationError,
     ClusterDownError,
     ConnectionError,
     CrossSlotTransactionError,
@@ -3122,7 +3123,8 @@ class TestNodesManager:
         contacted, but not when a node responded and rejected CLUSTER SLOTS:
         MultiDB registers the unreachable subtype as retryable, so a
         deterministic configuration error must keep surfacing as a plain
-        RedisClusterException.
+        RedisClusterException. Authentication failures subclass ConnectionError
+        but cannot be repaired by a failover, so they stay plain as well.
         """
         with mock.patch.object(
             ClusterNode, "execute_command", autospec=True
@@ -3137,6 +3139,21 @@ class TestNodesManager:
                 async with RedisCluster(startup_nodes=[ClusterNode("127.0.0.1", 7000)]):
                     ...
             assert "Redis Cluster cannot be connected" in str(e.value)
+
+        with mock.patch.object(
+            ClusterNode, "execute_command", autospec=True
+        ) as execute_command:
+
+            async def mocked_execute_command_auth(self, *args, **kwargs):
+                raise AuthenticationError("invalid password")
+
+            execute_command.side_effect = mocked_execute_command_auth
+
+            with pytest.raises(RedisClusterException) as e:
+                async with RedisCluster(startup_nodes=[ClusterNode("127.0.0.1", 7000)]):
+                    ...
+            assert not isinstance(e.value, RedisClusterUnreachableError)
+            assert "invalid password" in str(e.value)
 
         with pytest.raises(RedisClusterException) as e:
             rc = await get_mocked_redis_client(

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -51,6 +51,7 @@ from redis.exceptions import (
     MovedError,
     NoPermissionError,
     RedisClusterException,
+    RedisClusterUnreachableError,
     RedisError,
     ResponseError,
 )
@@ -3110,6 +3111,42 @@ class TestNodesManager:
                 cluster_enabled=False,
             )
             await rc.aclose()
+        assert "Cluster mode is not enabled on this node" in str(e.value)
+
+    @pytest.mark.fixed_client
+    async def test_unreachable_error_is_reserved_for_connectivity_failures(
+        self,
+    ) -> None:
+        """
+        RedisClusterUnreachableError is raised when no startup node could be
+        contacted, but not when a node responded and rejected CLUSTER SLOTS:
+        MultiDB registers the unreachable subtype as retryable, so a
+        deterministic configuration error must keep surfacing as a plain
+        RedisClusterException.
+        """
+        with mock.patch.object(
+            ClusterNode, "execute_command", autospec=True
+        ) as execute_command:
+
+            async def mocked_execute_command(self, *args, **kwargs):
+                raise ConnectionError("mock connection error")
+
+            execute_command.side_effect = mocked_execute_command
+
+            with pytest.raises(RedisClusterUnreachableError) as e:
+                async with RedisCluster(startup_nodes=[ClusterNode("127.0.0.1", 7000)]):
+                    ...
+            assert "Redis Cluster cannot be connected" in str(e.value)
+
+        with pytest.raises(RedisClusterException) as e:
+            rc = await get_mocked_redis_client(
+                cluster_slots_raise_error=True,
+                host=default_host,
+                port=default_port,
+                cluster_enabled=False,
+            )
+            await rc.aclose()
+        assert not isinstance(e.value, RedisClusterUnreachableError)
         assert "Cluster mode is not enabled on this node" in str(e.value)
 
     @pytest.mark.fixed_client

--- a/tests/test_asyncio/test_multidb/test_client.py
+++ b/tests/test_asyncio/test_multidb/test_client.py
@@ -11,6 +11,11 @@ from redis.asyncio.multidb.failover import WeightBasedFailoverStrategy
 from redis.asyncio.multidb.failure_detector import AsyncFailureDetector
 from redis.asyncio.multidb.healthcheck import HealthCheck
 from redis.event import EventDispatcher, AsyncOnCommandsFailEvent
+from redis.exceptions import (
+    ConnectionError,
+    RedisClusterException,
+    RedisClusterUnreachableError,
+)
 from redis.multidb.circuit import State as CBState, PBCircuitBreakerAdapter
 from redis.multidb.config import DatabaseConfig
 from redis.multidb.exception import (
@@ -24,6 +29,41 @@ from tests.test_asyncio.test_multidb.conftest import create_weighted_list
 
 @pytest.mark.fixed_client
 class TestMultiDbClient:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_multi_db_config,mock_db, mock_db1, mock_db2",
+        [
+            (
+                {},
+                {"weight": 0.2, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.7, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.5, "circuit": {"state": CBState.CLOSED}},
+            ),
+        ],
+        indirect=True,
+    )
+    async def test_cluster_unreachable_error_is_registered_as_retryable(
+        self, mock_multi_db_config, mock_db, mock_db1, mock_db2, mock_hc
+    ):
+        """
+        A cluster database that cannot be reached reports a
+        ``RedisClusterUnreachableError`` rather than the ``ConnectionError`` a
+        standalone database reports, so the command retry has to support that type
+        for a cluster database to fail over. The overloaded ``RedisClusterException``
+        base must stay unsupported - it also covers deterministic caller errors such
+        as cross-slot commands, which must be raised without retries.
+        """
+        databases = create_weighted_list(mock_db, mock_db1, mock_db2)
+        mock_multi_db_config.health_checks = [mock_hc]
+        mock_hc.check_health.return_value = True
+
+        with patch.object(mock_multi_db_config, "databases", return_value=databases):
+            async with MultiDBClient(mock_multi_db_config) as client:
+                supported = client._command_retry._supported_errors
+                assert RedisClusterUnreachableError in supported
+                assert ConnectionError in supported
+                assert RedisClusterException not in supported
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "mock_multi_db_config,mock_db, mock_db1, mock_db2",

--- a/tests/test_asyncio/test_multidb/test_command_executor.py
+++ b/tests/test_asyncio/test_multidb/test_command_executor.py
@@ -5,7 +5,11 @@ import pytest
 
 from redis.asyncio.multidb.failure_detector import FailureDetectorAsyncWrapper
 from redis.event import EventDispatcher, OnCommandsFailEvent
-from redis.exceptions import ConnectionError
+from redis.exceptions import (
+    ConnectionError,
+    RedisClusterException,
+    RedisClusterUnreachableError,
+)
 from redis.asyncio.multidb.command_executor import DefaultCommandExecutor
 from redis.asyncio.retry import Retry
 from redis.backoff import NoBackoff
@@ -180,6 +184,123 @@ class TestDefaultCommandExecutor:
         assert await executor.execute_command("SET", "key", "value") == "OK2"
         assert await executor.execute_command("SET", "key", "value") == "OK1"
         assert mock_selector.call_count == 3
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_db,mock_db1,mock_db2",
+        [
+            (
+                {"weight": 0.2, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.7, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.5, "circuit": {"state": CBState.CLOSED}},
+            ),
+        ],
+        indirect=True,
+    )
+    async def test_execute_command_fallback_to_another_db_on_cluster_connection_failure(
+        self, mock_db, mock_db1, mock_db2, mock_fs
+    ):
+        """
+        A cluster database that cannot be reached reports a ``RedisClusterException``
+        instead of the connection error a standalone database reports, so make sure
+        it triggers a failover all the same.
+        """
+        cluster_unreachable = RedisClusterUnreachableError(
+            "Redis Cluster cannot be connected. Please provide at least "
+            "one reachable node"
+        )
+
+        mock_db1.client.execute_command = AsyncMock(
+            side_effect=[
+                "OK1",
+                cluster_unreachable,
+                cluster_unreachable,
+                cluster_unreachable,
+            ]
+        )
+        mock_db2.client.execute_command = AsyncMock(side_effect=["OK2"])
+        mock_selector = AsyncMock(side_effect=[mock_db1, mock_db2])
+        type(mock_fs).database = mock_selector
+        threshold = 3
+        fd = FailureDetectorAsyncWrapper(CommandFailureDetector(threshold, 1))
+        ed = EventDispatcher()
+        databases = create_weighted_list(mock_db, mock_db1, mock_db2)
+
+        executor = DefaultCommandExecutor(
+            failure_detectors=[fd],
+            databases=databases,
+            failover_strategy=mock_fs,
+            event_dispatcher=ed,
+            auto_fallback_interval=0.1,
+            command_retry=Retry(
+                NoBackoff(),
+                threshold,
+                supported_errors=(RedisClusterUnreachableError,),
+            ),
+        )
+        fd.set_command_executor(command_executor=executor)
+
+        assert await executor.execute_command("SET", "key", "value") == "OK1"
+        assert await executor.execute_command("SET", "key", "value") == "OK2"
+        assert mock_selector.call_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_db,mock_db1,mock_db2",
+        [
+            (
+                {"weight": 0.2, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.7, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.5, "circuit": {"state": CBState.CLOSED}},
+            ),
+        ],
+        indirect=True,
+    )
+    async def test_execute_command_does_not_fallback_on_cluster_programming_error(
+        self, mock_db, mock_db1, mock_db2, mock_fs
+    ):
+        """
+        A plain ``RedisClusterException`` is a deterministic caller error - a
+        cross-slot command, an unsupported method - not an unavailable database. It
+        must be raised as is, without retries and without counting towards failure
+        detection, even while the unreachable subtype is supported.
+        """
+        error = RedisClusterException("Keys in request don't hash to the same slot")
+        mock_db1.client.execute_command = AsyncMock(side_effect=error)
+        mock_selector = AsyncMock(return_value=mock_db1)
+        type(mock_fs).database = mock_selector
+        # A single registered failure would be enough to open the circuit, so the
+        # circuit staying closed proves none was registered.
+        fd = FailureDetectorAsyncWrapper(
+            CommandFailureDetector(
+                min_num_failures=1,
+                failure_rate_threshold=0.0,
+                failure_detection_window=1,
+            )
+        )
+        ed = EventDispatcher()
+        databases = create_weighted_list(mock_db, mock_db1, mock_db2)
+
+        executor = DefaultCommandExecutor(
+            failure_detectors=[fd],
+            databases=databases,
+            failover_strategy=mock_fs,
+            event_dispatcher=ed,
+            auto_fallback_interval=0.1,
+            command_retry=Retry(
+                NoBackoff(),
+                3,
+                supported_errors=(RedisClusterUnreachableError,),
+            ),
+        )
+        fd.set_command_executor(command_executor=executor)
+
+        with pytest.raises(RedisClusterException, match="same slot"):
+            await executor.execute_command("MGET", "key1", "key2")
+
+        assert mock_db1.client.execute_command.call_count == 1
+        assert mock_selector.call_count == 1
+        assert mock_db1.circuit.state == CBState.CLOSED
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_asyncio/test_multidb/test_healthcheck.py
+++ b/tests/test_asyncio/test_multidb/test_healthcheck.py
@@ -17,7 +17,7 @@ from redis.asyncio.multidb.healthcheck import (
 )
 from redis.http.http_client import HttpError
 from redis.multidb.circuit import State as CBState
-from redis.exceptions import ConnectionError
+from redis.exceptions import ConnectionError, ResponseError
 from redis.multidb.exception import UnhealthyDatabaseException
 
 
@@ -491,6 +491,51 @@ class TestPingHealthCheck:
         mock_node2.execute_command.assert_awaited_once_with("PING")
         mock_node3.execute_command.assert_awaited_once_with("PING")
 
+    @pytest.mark.asyncio
+    async def test_cluster_client_is_reset_when_ping_fails_with_connection_error(
+        self, mock_client, mock_cb
+    ):
+        """
+        Verify that a connectivity failure on a node probe closes the health
+        check client. Direct node probes bypass the client's own
+        topology-refresh path, so without the reset a node that was removed or
+        replaced in the cluster would keep failing every probe against the
+        stale topology.
+        """
+        mock_node1 = _mock_cluster_node(ping_result=True)
+        mock_node2 = _mock_cluster_node()
+        mock_node2.execute_command.side_effect = ConnectionError("Node is down")
+        mock_hc_client = _mock_cluster_client(mock_node1, mock_node2)
+
+        hc = PingHealthCheck()
+        db = Database(mock_client, mock_cb, 0.9)
+
+        with pytest.raises(ConnectionError, match="Node is down"):
+            await hc.check_health(db, mock_hc_client)
+
+        mock_hc_client.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cluster_client_is_kept_when_ping_fails_with_server_error(
+        self, mock_client, mock_cb
+    ):
+        """
+        Verify that a non-connectivity failure does not reset the health check
+        client: the topology is not in question, so re-discovering it would
+        only add load without changing the outcome.
+        """
+        mock_node = _mock_cluster_node()
+        mock_node.execute_command.side_effect = ResponseError("some server error")
+        mock_hc_client = _mock_cluster_client(mock_node)
+
+        hc = PingHealthCheck()
+        db = Database(mock_client, mock_cb, 0.9)
+
+        with pytest.raises(ResponseError, match="some server error"):
+            await hc.check_health(db, mock_hc_client)
+
+        mock_hc_client.aclose.assert_not_awaited()
+
 
 @pytest.mark.onlynoncluster
 class TestLagAwareHealthCheck:
@@ -618,10 +663,10 @@ class TestLagAwareHealthCheck:
         with pytest.raises(ValueError, match="Could not find a matching bdb"):
             await hc.check_health(db, mock_hc_client)
 
-        # Only the listing call should have happened
+        # Only the listing call should have happened, without a per-request
+        # timeout override - the client's configured http_timeout applies.
         mock_http.get.assert_called_once_with(
-            "https://healthcheck.example.com:9443/v1/bdbs",
-            timeout=hc.health_check_timeout,
+            "https://healthcheck.example.com:9443/v1/bdbs"
         )
 
     @pytest.mark.asyncio
@@ -865,6 +910,33 @@ class TestAbstractHealthCheckPolicy:
         assert client1 is mock_redis1
         assert client2 is mock_redis2
         assert client1 is not client2
+
+    @pytest.mark.asyncio
+    async def test_get_client_seeds_cluster_client_with_all_startup_nodes(self):
+        """
+        Verify the health-check cluster client is constructed from every
+        configured startup node, not just the first: if the first seed is down
+        while another is healthy, the probe must still be able to discover the
+        cluster instead of marking the database unhealthy.
+        """
+        underlying = AsyncRedisCluster(
+            startup_nodes=[
+                AsyncClusterNode("node1.example.com", 7000),
+                AsyncClusterNode("node2.example.com", 7001),
+            ]
+        )
+        mock_db = Mock(spec=Database)
+        mock_db.client = underlying
+
+        policy = HealthyAllPolicy()
+        try:
+            client = await policy.get_client(mock_db)
+            assert {(node.host, node.port) for node in client.startup_nodes} == {
+                ("node1.example.com", 7000),
+                ("node2.example.com", 7001),
+            }
+        finally:
+            await policy.close()
 
     @pytest.mark.asyncio
     async def test_close_closes_all_clients(self):

--- a/tests/test_asyncio/test_multidb/test_healthcheck.py
+++ b/tests/test_asyncio/test_multidb/test_healthcheck.py
@@ -3,6 +3,9 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from redis.asyncio import Redis
+from redis.asyncio.cluster import ClusterNode as AsyncClusterNode
+from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
 from redis.asyncio.multidb.database import Database
 from redis.asyncio.multidb.healthcheck import (
     PingHealthCheck,
@@ -16,6 +19,21 @@ from redis.http.http_client import HttpError
 from redis.multidb.circuit import State as CBState
 from redis.exceptions import ConnectionError
 from redis.multidb.exception import UnhealthyDatabaseException
+
+
+def _mock_cluster_node(ping_result=True):
+    """Mock of an async cluster node, bound to the real ``ClusterNode`` interface."""
+    node = Mock(spec=AsyncClusterNode)
+    node.execute_command = AsyncMock(return_value=ping_result)
+    return node
+
+
+def _mock_cluster_client(*nodes):
+    """Mock of an async cluster client, bound to the real ``RedisCluster`` interface."""
+    client = Mock(spec=AsyncRedisCluster)
+    client.initialize = AsyncMock(return_value=client)
+    client.get_nodes = Mock(return_value=list(nodes))
+    return client
 
 
 def _configure_mock_health_check(mock_hc, probes=3, delay=0.01, timeout=1.0):
@@ -327,26 +345,10 @@ class TestPingHealthCheck:
         """
         Verify that PingHealthCheck returns True for cluster when all nodes respond.
         """
-        from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
-
-        # Create mock nodes
-        mock_node1 = Mock()
-        mock_node1.redis_connection = AsyncMock()
-        mock_node1.redis_connection.execute_command = AsyncMock(return_value=True)
-
-        mock_node2 = Mock()
-        mock_node2.redis_connection = AsyncMock()
-        mock_node2.redis_connection.execute_command = AsyncMock(return_value=True)
-
-        mock_node3 = Mock()
-        mock_node3.redis_connection = AsyncMock()
-        mock_node3.redis_connection.execute_command = AsyncMock(return_value=True)
-
-        # Create mock cluster client (not AsyncRedis, so isinstance check fails)
-        mock_hc_client = Mock(spec=AsyncRedisCluster)
-        mock_hc_client.get_nodes = Mock(
-            return_value=[mock_node1, mock_node2, mock_node3]
-        )
+        mock_node1 = _mock_cluster_node(ping_result=True)
+        mock_node2 = _mock_cluster_node(ping_result=True)
+        mock_node3 = _mock_cluster_node(ping_result=True)
+        mock_hc_client = _mock_cluster_client(mock_node1, mock_node2, mock_node3)
 
         hc = PingHealthCheck()
         db = Database(mock_client, mock_cb, 0.9)
@@ -354,9 +356,9 @@ class TestPingHealthCheck:
         assert await hc.check_health(db, mock_hc_client)
 
         # All nodes should have been pinged
-        mock_node1.redis_connection.execute_command.assert_called_once_with("PING")
-        mock_node2.redis_connection.execute_command.assert_called_once_with("PING")
-        mock_node3.redis_connection.execute_command.assert_called_once_with("PING")
+        mock_node1.execute_command.assert_awaited_once_with("PING")
+        mock_node2.execute_command.assert_awaited_once_with("PING")
+        mock_node3.execute_command.assert_awaited_once_with("PING")
 
     @pytest.mark.asyncio
     async def test_cluster_database_is_unhealthy_when_one_node_fails(
@@ -365,37 +367,129 @@ class TestPingHealthCheck:
         """
         Verify that PingHealthCheck returns False for cluster when any node fails.
         """
-        from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
-
-        # Create mock nodes - second node fails
-        mock_node1 = Mock()
-        mock_node1.redis_connection = AsyncMock()
-        mock_node1.redis_connection.execute_command = AsyncMock(return_value=True)
-
-        mock_node2 = Mock()
-        mock_node2.redis_connection = AsyncMock()
-        mock_node2.redis_connection.execute_command = AsyncMock(return_value=False)
-
-        mock_node3 = Mock()
-        mock_node3.redis_connection = AsyncMock()
-        mock_node3.redis_connection.execute_command = AsyncMock(return_value=True)
-
-        # Create mock cluster client
-        mock_hc_client = Mock(spec=AsyncRedisCluster)
-        mock_hc_client.get_nodes = Mock(
-            return_value=[mock_node1, mock_node2, mock_node3]
-        )
+        # Second node fails
+        mock_node1 = _mock_cluster_node(ping_result=True)
+        mock_node2 = _mock_cluster_node(ping_result=False)
+        mock_node3 = _mock_cluster_node(ping_result=True)
+        mock_hc_client = _mock_cluster_client(mock_node1, mock_node2, mock_node3)
 
         hc = PingHealthCheck()
         db = Database(mock_client, mock_cb, 0.9)
 
         assert not await hc.check_health(db, mock_hc_client)
 
-        # Should stop after the failing node
-        mock_node1.redis_connection.execute_command.assert_called_once_with("PING")
-        mock_node2.redis_connection.execute_command.assert_called_once_with("PING")
-        # Node 3 should not be checked (early exit on failure)
-        mock_node3.redis_connection.execute_command.assert_not_called()
+        # Every node is pinged: the pings are issued concurrently, so the failing
+        # one cannot spare the nodes behind it.
+        mock_node1.execute_command.assert_awaited_once_with("PING")
+        mock_node2.execute_command.assert_awaited_once_with("PING")
+        mock_node3.execute_command.assert_awaited_once_with("PING")
+
+    @pytest.mark.asyncio
+    async def test_cluster_health_check_client_is_initialized_before_ping(
+        self, mock_client, mock_cb
+    ):
+        """
+        Verify that the cluster topology is discovered before the nodes are pinged.
+
+        The health check client is created lazily, so without an explicit
+        initialization its node cache is empty.
+        """
+        mock_node = _mock_cluster_node(ping_result=True)
+        mock_hc_client = _mock_cluster_client()
+        # Empty node cache until the client has been initialized.
+        nodes = []
+        mock_hc_client.get_nodes = Mock(side_effect=lambda: nodes)
+        mock_hc_client.initialize.side_effect = lambda: nodes.append(mock_node)
+
+        hc = PingHealthCheck()
+        db = Database(mock_client, mock_cb, 0.9)
+
+        assert await hc.check_health(db, mock_hc_client)
+
+        mock_hc_client.initialize.assert_awaited_once()
+        mock_node.execute_command.assert_awaited_once_with("PING")
+
+    @pytest.mark.asyncio
+    async def test_cluster_database_is_unhealthy_when_no_nodes_are_known(
+        self, mock_client, mock_cb
+    ):
+        """
+        Verify that a cluster with an empty node cache is reported as unhealthy.
+
+        Without this, there would be nothing to ping and the database would be
+        reported as healthy without a single successful probe.
+        """
+        mock_hc_client = _mock_cluster_client()
+
+        hc = PingHealthCheck()
+        db = Database(mock_client, mock_cb, 0.9)
+
+        assert not await hc.check_health(db, mock_hc_client)
+        mock_hc_client.initialize.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cluster_nodes_are_pinged_concurrently(self, mock_client, mock_cb):
+        """
+        Verify that the nodes of a cluster are pinged concurrently.
+
+        A single health_check_timeout covers the whole health check, so pinging
+        the nodes one after another would make the budget scale with the size of
+        the cluster.
+        """
+        in_flight = 0
+        max_in_flight = 0
+
+        async def tracking_ping(*args, **kwargs):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            # Long enough for the overlap to be observable, short enough to keep
+            # the test fast.
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return True
+
+        nodes = [_mock_cluster_node() for _ in range(3)]
+
+        for node in nodes:
+            node.execute_command.side_effect = tracking_ping
+
+        mock_hc_client = _mock_cluster_client(*nodes)
+
+        hc = PingHealthCheck()
+        db = Database(mock_client, mock_cb, 0.9)
+
+        assert await hc.check_health(db, mock_hc_client)
+        assert max_in_flight == len(nodes), (
+            f"Expected {len(nodes)} concurrent pings, got max {max_in_flight}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cluster_ping_error_is_propagated(self, mock_client, mock_cb):
+        """
+        Verify that a failing PING propagates instead of being reported as an
+        unhealthy result, so the policy can wrap it in an
+        UnhealthyDatabaseException and the reason stays in the logs.
+
+        The remaining nodes are still awaited: their pings are already in flight
+        when the failure surfaces, and dropping them would leave tasks running
+        unawaited.
+        """
+        mock_node1 = _mock_cluster_node(ping_result=True)
+        mock_node2 = _mock_cluster_node()
+        mock_node2.execute_command.side_effect = ConnectionError("Node is down")
+        mock_node3 = _mock_cluster_node(ping_result=True)
+        mock_hc_client = _mock_cluster_client(mock_node1, mock_node2, mock_node3)
+
+        hc = PingHealthCheck()
+        db = Database(mock_client, mock_cb, 0.9)
+
+        with pytest.raises(ConnectionError, match="Node is down"):
+            await hc.check_health(db, mock_hc_client)
+
+        mock_node1.execute_command.assert_awaited_once_with("PING")
+        mock_node2.execute_command.assert_awaited_once_with("PING")
+        mock_node3.execute_command.assert_awaited_once_with("PING")
 
 
 @pytest.mark.onlynoncluster
@@ -437,16 +531,17 @@ class TestLagAwareHealthCheck:
         )  # Not used by LagAwareHealthCheck but required by signature
 
         assert await hc.check_health(db, mock_hc_client) is True
-        # Base URL must be set correctly
-        assert hc._http_client.client.base_url == "https://healthcheck.example.com:1234"
-        # Calls: first to list bdbs, then to availability
+        # Calls: first to list bdbs, then to availability. Both carry the database's
+        # own base URL, so a concurrent check on another database cannot redirect
+        # them at the wrong cluster.
         assert mock_http.get.call_count == 2
         first_call = mock_http.get.call_args_list[0]
         second_call = mock_http.get.call_args_list[1]
-        assert first_call.args[0] == "/v1/bdbs"
+        assert first_call.args[0] == "https://healthcheck.example.com:1234/v1/bdbs"
         assert (
             second_call.args[0]
-            == "/v1/bdbs/bdb-1/availability?extend_check=lag&availability_lag_tolerance_ms=150"
+            == "https://healthcheck.example.com:1234/v1/bdbs/bdb-1/availability"
+            "?extend_check=lag&availability_lag_tolerance_ms=150"
         )
         assert second_call.kwargs.get("expect_json") is False
 
@@ -485,7 +580,8 @@ class TestLagAwareHealthCheck:
         assert mock_http.get.call_count == 2
         assert (
             mock_http.get.call_args_list[1].args[0]
-            == "/v1/bdbs/bdb-42/availability?extend_check=lag&availability_lag_tolerance_ms=5000"
+            == "https://healthcheck.example.com:9443/v1/bdbs/bdb-42/availability"
+            "?extend_check=lag&availability_lag_tolerance_ms=5000"
         )
 
     @pytest.mark.asyncio
@@ -523,7 +619,10 @@ class TestLagAwareHealthCheck:
             await hc.check_health(db, mock_hc_client)
 
         # Only the listing call should have happened
-        mock_http.get.assert_called_once_with("/v1/bdbs")
+        mock_http.get.assert_called_once_with(
+            "https://healthcheck.example.com:9443/v1/bdbs",
+            timeout=hc.health_check_timeout,
+        )
 
     @pytest.mark.asyncio
     async def test_propagates_http_error_from_availability(self, mock_client, mock_cb):
@@ -559,6 +658,138 @@ class TestLagAwareHealthCheck:
 
         # Ensure both calls were attempted
         assert mock_http.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cluster_database_matches_bdb_by_configured_endpoint(self, mock_cb):
+        """
+        Ensures a cluster database is matched by the endpoint it was configured with,
+        and not by the nodes it discovered. CLUSTER SLOTS advertises each node's own
+        address, which on a public Redis Enterprise endpoint is neither the endpoint
+        DNS name nor an address the bdb lists.
+        """
+        host = "redis-12000.cluster.example.com"
+        client = _mock_cluster_client(_mock_cluster_node())
+        client.startup_nodes = [AsyncClusterNode(host, 12000)]
+        client.get_nodes.return_value = [
+            Mock(spec=AsyncClusterNode, host="203.0.113.9")
+        ]
+
+        mock_http = AsyncMock()
+        mock_http.get.side_effect = [
+            [
+                {
+                    "uid": "bdb-cluster",
+                    "endpoints": [{"dns_name": host, "addr": ["10.0.0.1"]}],
+                }
+            ],
+            None,
+        ]
+
+        hc = LagAwareHealthCheck()
+        hc._http_client = mock_http
+
+        db = Database(client, mock_cb, 1.0, "https://healthcheck.example.com")
+
+        assert await hc.check_health(db, AsyncMock()) is True
+        assert (
+            mock_http.get.call_args_list[1].args[0]
+            == "https://healthcheck.example.com:9443/v1/bdbs/bdb-cluster/availability"
+            "?extend_check=lag&availability_lag_tolerance_ms=5000"
+        )
+
+    @pytest.mark.asyncio
+    async def test_dns_name_match_is_preferred_over_addr_match(
+        self, mock_client, mock_cb
+    ):
+        """
+        Ensures the bdb owning the host as an endpoint DNS name wins over a bdb that
+        only lists the host among its endpoint addresses. Databases hosted by the same
+        cluster share the addresses their endpoints resolve to, so an address match is
+        ambiguous while a DNS name belongs to a single bdb.
+        """
+        host = "db4.example.com"
+        mock_client.get_connection_kwargs.return_value = {"host": host}
+
+        mock_http = AsyncMock()
+        mock_http.get.side_effect = [
+            [
+                {
+                    "uid": "bdb-by-addr",
+                    "endpoints": [{"dns_name": "other.example.com", "addr": [host]}],
+                },
+                {
+                    "uid": "bdb-by-dns-name",
+                    "endpoints": [{"dns_name": host, "addr": ["10.0.0.1"]}],
+                },
+            ],
+            None,
+        ]
+
+        hc = LagAwareHealthCheck()
+        hc._http_client = mock_http
+
+        db = Database(mock_client, mock_cb, 1.0, "https://healthcheck.example.com")
+
+        assert await hc.check_health(db, AsyncMock()) is True
+        assert (
+            mock_http.get.call_args_list[1].args[0]
+            == "https://healthcheck.example.com:9443/v1/bdbs/bdb-by-dns-name/availability"
+            "?extend_check=lag&availability_lag_tolerance_ms=5000"
+        )
+
+    @pytest.mark.asyncio
+    async def test_concurrent_checks_do_not_share_one_base_url(self, mock_cb):
+        """
+        Ensures two databases checked concurrently by the same health check instance each
+        talk to their own cluster's REST API. MultiDBClient checks every database at once
+        through a single shared LagAwareHealthCheck, so the target must travel with the
+        request instead of being stashed on the shared HTTP client - otherwise one
+        database's check overwrites the other's while it awaits a response, and the bdb
+        listing comes back from the wrong cluster.
+        """
+        clusters = {
+            "https://cluster-a.example.com": ("db-a.example.com", "bdb-a"),
+            "https://cluster-b.example.com": ("db-b.example.com", "bdb-b"),
+        }
+        requested = []
+
+        async def fake_get(path, *args, expect_json=True, timeout=None):
+            requested.append(path)
+            # Hand control back mid-check so the two checks interleave, the way the
+            # thread-pool-backed HTTP client does on every request.
+            await asyncio.sleep(0)
+            base_url = path.rsplit("/v1/bdbs", 1)[0]
+            dns_name, uid = clusters[base_url.rsplit(":", 1)[0]]
+            if path.endswith("/v1/bdbs"):
+                # A cluster's REST API only lists the bdbs that cluster hosts.
+                return [{"uid": uid, "endpoints": [{"dns_name": dns_name, "addr": []}]}]
+            return None
+
+        mock_http = AsyncMock()
+        mock_http.get = fake_get
+
+        hc = LagAwareHealthCheck()
+        hc._http_client = mock_http
+
+        databases = []
+        for base_url, (dns_name, _) in clusters.items():
+            client = Mock(spec=Redis)
+            client.get_connection_kwargs.return_value = {"host": dns_name}
+            databases.append(Database(client, mock_cb, 1.0, base_url))
+
+        results = await asyncio.gather(
+            *(hc.check_health(db, AsyncMock()) for db in databases)
+        )
+
+        assert results == [True, True]
+        assert sorted(requested) == [
+            "https://cluster-a.example.com:9443/v1/bdbs",
+            "https://cluster-a.example.com:9443/v1/bdbs/bdb-a/availability"
+            "?extend_check=lag&availability_lag_tolerance_ms=5000",
+            "https://cluster-b.example.com:9443/v1/bdbs",
+            "https://cluster-b.example.com:9443/v1/bdbs/bdb-b/availability"
+            "?extend_check=lag&availability_lag_tolerance_ms=5000",
+        ]
 
 
 @pytest.mark.onlynoncluster

--- a/tests/test_asyncio/test_multidb/test_healthcheck.py
+++ b/tests/test_asyncio/test_multidb/test_healthcheck.py
@@ -6,6 +6,7 @@ import pytest
 from redis.asyncio import Redis
 from redis.asyncio.cluster import ClusterNode as AsyncClusterNode
 from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from redis.asyncio.connection import SSLConnection as AsyncSSLConnection
 from redis.asyncio.multidb.database import Database
 from redis.asyncio.multidb.healthcheck import (
     PingHealthCheck,
@@ -935,6 +936,51 @@ class TestAbstractHealthCheckPolicy:
                 ("node1.example.com", 7000),
                 ("node2.example.com", 7001),
             }
+        finally:
+            await policy.close()
+
+    @pytest.mark.asyncio
+    async def test_get_client_preserves_tls_for_standalone(self):
+        """
+        Verify the health-check client keeps the underlying client's TLS
+        transport: the source connection kwargs carry TLS as
+        connection_class=SSLConnection, which the kwargs filter drops, so
+        without re-expressing it as ssl=True the probe would speak plaintext
+        to a TLS port and mark a healthy database unavailable.
+        """
+        from redis import Redis as SyncRedis
+
+        underlying = SyncRedis(host="localhost", port=6379, ssl=True)
+        mock_db = Mock(spec=Database)
+        mock_db.client = underlying
+
+        policy = HealthyAllPolicy()
+        try:
+            client = await policy.get_client(mock_db)
+            assert client.connection_pool.connection_class is AsyncSSLConnection
+        finally:
+            await policy.close()
+
+    @pytest.mark.asyncio
+    async def test_get_client_preserves_tls_for_cluster(self):
+        """
+        Same as the standalone TLS test, for the cluster path: the async
+        cluster also represents TLS as connection_class=SSLConnection in its
+        connection kwargs.
+        """
+        underlying = AsyncRedisCluster(
+            startup_nodes=[AsyncClusterNode("node1.example.com", 7000)],
+            ssl=True,
+        )
+        mock_db = Mock(spec=Database)
+        mock_db.client = underlying
+
+        policy = HealthyAllPolicy()
+        try:
+            client = await policy.get_client(mock_db)
+            assert (
+                client.connection_kwargs.get("connection_class") is AsyncSSLConnection
+            )
         finally:
             await policy.close()
 

--- a/tests/test_asyncio/test_scenario/test_active_active.py
+++ b/tests/test_asyncio/test_scenario/test_active_active.py
@@ -256,8 +256,16 @@ class TestActiveActive:
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2},
-            {"client_class": RedisCluster, "min_num_failures": 2},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
+            {
+                "client_class": RedisCluster,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
         ],
         ids=["standalone", "cluster"],
         indirect=True,
@@ -318,8 +326,16 @@ class TestActiveActive:
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2},
-            {"client_class": RedisCluster, "min_num_failures": 2},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
+            {
+                "client_class": RedisCluster,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
         ],
         ids=["standalone", "cluster"],
         indirect=True,

--- a/tests/test_asyncio/test_scenario/test_active_active.py
+++ b/tests/test_asyncio/test_scenario/test_active_active.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+from time import monotonic
 
 import pytest
 
@@ -20,6 +21,65 @@ from tests.test_scenario.fault_injector_client import ActionRequest, ActionType
 
 logger = logging.getLogger(__name__)
 
+# The injected network failure is transient - the fault injector restores the link a
+# few seconds after the action is triggered. A database is only taken out of service by
+# a health check probe that runs while the link is down, and on the default interval a
+# probe round is short next to the pause that follows it, so most rounds land after the
+# link is already back and no failover is ever initiated. Probing back to back keeps a
+# round inside the outage.
+FAILOVER_HEALTH_CHECK_INTERVAL = 0.1
+# Bounded here rather than left to pytest-timeout so a failover that never happens is
+# reported as a failover that never happened, instead of as a stack dump of whatever
+# the test was doing when the deadline passed. Kept well inside the per-test timeout so
+# the assertion below is what fires.
+FAILOVER_TIMEOUT = 60
+FAILOVER_TIMEOUT_MESSAGE = (
+    f"Active database has not changed within {FAILOVER_TIMEOUT} seconds of the "
+    "injected network failure"
+)
+# The Redis Enterprise REST API credentials LagAwareHealthCheck authenticates with.
+# They come from the test environment, and without them every probe gets HTTP 401 and
+# both databases are reported unhealthy - which fails the initial health check instead
+# of exercising the health check the test is about.
+LAG_AWARE_CREDENTIAL_ENV_VARS = ("ENV0_USERNAME", "ENV0_PASSWORD")
+# The whole health check - every probe of it - has to finish inside this budget, and
+# each probe of this one is two REST calls to the Redis Enterprise API. The default of
+# 3 seconds covers a PING, not 3 probes x 2 requests over the public internet with a
+# second of it spent in the delay between probes, and running out of it reports the
+# database as unhealthy.
+LAG_AWARE_HEALTH_CHECK_TIMEOUT = 10
+
+
+def lag_aware_auth_basic():
+    """
+    Return the REST API credentials for LagAwareHealthCheck as the environment
+    supplies them.
+    """
+    return tuple(os.getenv(name) for name in LAG_AWARE_CREDENTIAL_ENV_VARS)
+
+
+def require_lag_aware_credentials():
+    """
+    Fail the calling test up front when the environment does not supply the REST API
+    credentials.
+
+    Deliberately a failure and not a skip: a skipped test is invisible in a scenario
+    run's log, and the alternative is every probe returning HTTP 401 and the run
+    reporting InitialHealthCheckFailedError, which reads like a client bug.
+
+    Kept apart from lag_aware_auth_basic because the health check here is built at
+    collection time, where failing the individual test is not available.
+    """
+    missing = ", ".join(
+        name for name in LAG_AWARE_CREDENTIAL_ENV_VARS if not os.getenv(name)
+    )
+
+    if missing:
+        pytest.fail(
+            "LagAwareHealthCheck requires the Redis Enterprise REST API credentials "
+            f"in {missing}. Set them from the CI secrets of the same name."
+        )
+
 
 async def trigger_network_failure_action(
     fault_injector_client, config, event: asyncio.Event = None
@@ -30,16 +90,9 @@ async def trigger_network_failure_action(
     )
 
     result = await fault_injector_client.trigger_action(action_request)
-    status_result = await fault_injector_client.get_action_status(result["action_id"])
-
-    while status_result["status"] != "success":
-        await asyncio.sleep(0.1)
-        status_result = await fault_injector_client.get_action_status(
-            result["action_id"]
-        )
-        logger.info(
-            f"Waiting for action to complete. Status: {status_result['status']}"
-        )
+    status_result = await fault_injector_client.get_operation_result(
+        result["action_id"]
+    )
 
     if event:
         event.set()
@@ -53,8 +106,16 @@ class TestActiveActive:
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2},
-            {"client_class": RedisCluster, "min_num_failures": 2},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
+            {
+                "client_class": RedisCluster,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
         ],
         ids=["standalone", "cluster"],
         indirect=True,
@@ -95,7 +156,9 @@ class TestActiveActive:
                 await asyncio.sleep(0.5)
 
             # Execute commands until database failover
+            deadline = monotonic() + FAILOVER_TIMEOUT
             while not listener.is_changed_flag:
+                assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
                 assert (
                     await retry.call_with_retry(
                         lambda: r_multi_db.get("key"), lambda _: dummy_fail_async()
@@ -114,13 +177,12 @@ class TestActiveActive:
                 "health_checks": [
                     LagAwareHealthCheck(
                         verify_tls=False,
-                        auth_basic=(
-                            os.getenv("ENV0_USERNAME"),
-                            os.getenv("ENV0_PASSWORD"),
-                        ),
+                        auth_basic=lag_aware_auth_basic(),
+                        lag_aware_tolerance=10000,
+                        health_check_timeout=LAG_AWARE_HEALTH_CHECK_TIMEOUT,
                     )
                 ],
-                "health_check_interval": 20,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
             },
             {
                 "client_class": RedisCluster,
@@ -128,13 +190,12 @@ class TestActiveActive:
                 "health_checks": [
                     LagAwareHealthCheck(
                         verify_tls=False,
-                        auth_basic=(
-                            os.getenv("ENV0_USERNAME"),
-                            os.getenv("ENV0_PASSWORD"),
-                        ),
+                        auth_basic=lag_aware_auth_basic(),
+                        lag_aware_tolerance=10000,
+                        health_check_timeout=LAG_AWARE_HEALTH_CHECK_TIMEOUT,
                     )
                 ],
-                "health_check_interval": 20,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
             },
         ],
         ids=["standalone", "cluster"],
@@ -144,6 +205,8 @@ class TestActiveActive:
     async def test_multi_db_client_uses_lag_aware_health_check(
         self, r_multi_db, fault_injector_client
     ):
+        require_lag_aware_credentials()
+
         client, listener, endpoint_config = r_multi_db
         retry = Retry(
             supported_errors=(TemporaryUnavailableException,),
@@ -174,7 +237,9 @@ class TestActiveActive:
                 await asyncio.sleep(0.5)
 
             # Execute commands after network failure
+            deadline = monotonic() + FAILOVER_TIMEOUT
             while not listener.is_changed_flag:
+                assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
                 assert (
                     await retry.call_with_retry(
                         lambda: r_multi_db.get("key"), lambda _: dummy_fail_async()
@@ -236,8 +301,8 @@ class TestActiveActive:
                 )
                 await asyncio.sleep(0.5)
 
-            # Execute commands until database failover
-            while not listener.is_changed_flag:
+            # Execute pipeline until database failover
+            for _ in range(5):
                 await retry.call_with_retry(
                     lambda: callback(), lambda _: dummy_fail_async()
                 )
@@ -297,7 +362,7 @@ class TestActiveActive:
                 await asyncio.sleep(0.5)
 
             # Execute pipeline until database failover
-            while not listener.is_changed_flag:
+            for _ in range(5):
                 await retry.call_with_retry(
                     lambda: callback(), lambda _: dummy_fail_async()
                 )
@@ -307,8 +372,16 @@ class TestActiveActive:
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2},
-            {"client_class": RedisCluster, "min_num_failures": 2},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
+            {
+                "client_class": RedisCluster,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
         ],
         ids=["standalone", "cluster"],
         indirect=True,
@@ -350,7 +423,9 @@ class TestActiveActive:
                 await asyncio.sleep(0.5)
 
             # Execute transaction until database failover
+            deadline = monotonic() + FAILOVER_TIMEOUT
             while not listener.is_changed_flag:
+                assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
                 assert await retry.call_with_retry(
                     lambda: r_multi_db.transaction(callback),
                     lambda _: dummy_fail_async(),
@@ -358,7 +433,16 @@ class TestActiveActive:
                 await asyncio.sleep(0.5)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("r_multi_db", [{"min_num_failures": 2}], indirect=True)
+    @pytest.mark.parametrize(
+        "r_multi_db",
+        [
+            {
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            }
+        ],
+        indirect=True,
+    )
     @pytest.mark.timeout(200)
     async def test_pubsub_failover_to_another_db(
         self, r_multi_db, fault_injector_client
@@ -403,7 +487,9 @@ class TestActiveActive:
                 await asyncio.sleep(0.5)
 
             # Execute publish until database failover
+            deadline = monotonic() + FAILOVER_TIMEOUT
             while not listener.is_changed_flag:
+                assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
                 await retry.call_with_retry(
                     lambda: r_multi_db.publish("test-channel", data),
                     lambda _: dummy_fail_async(),

--- a/tests/test_asyncio/test_scenario/test_active_active.py
+++ b/tests/test_asyncio/test_scenario/test_active_active.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import os
-from time import monotonic
+from time import monotonic, sleep
 
 import pytest
 
@@ -100,8 +100,12 @@ async def trigger_network_failure_action(
     logger.info(f"Action completed. Status: {status_result['status']}")
 
 
-@pytest.mark.skip(reason="Temporarily disabled")
 class TestActiveActive:
+    def teardown_method(self, method):
+        # Timeout so the cluster could recover from network failure. Runs between
+        # tests, outside the per-test event loop, so a blocking sleep is fine.
+        sleep(10)
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "r_multi_db",
@@ -302,7 +306,9 @@ class TestActiveActive:
                 await asyncio.sleep(0.5)
 
             # Execute pipeline until database failover
-            for _ in range(5):
+            deadline = monotonic() + FAILOVER_TIMEOUT
+            while not listener.is_changed_flag:
+                assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
                 await retry.call_with_retry(
                     lambda: callback(), lambda _: dummy_fail_async()
                 )
@@ -362,7 +368,9 @@ class TestActiveActive:
                 await asyncio.sleep(0.5)
 
             # Execute pipeline until database failover
-            for _ in range(5):
+            deadline = monotonic() + FAILOVER_TIMEOUT
+            while not listener.is_changed_flag:
+                assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
                 await retry.call_with_retry(
                     lambda: callback(), lambda _: dummy_fail_async()
                 )

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -48,6 +48,7 @@ from redis.event import (
 )
 from redis.exceptions import (
     AskError,
+    AuthenticationError,
     ClusterDownError,
     ConnectionError,
     CrossSlotTransactionError,
@@ -3397,7 +3398,8 @@ class TestNodesManager:
         contacted, but not when a node responded and rejected CLUSTER SLOTS:
         MultiDB registers the unreachable subtype as retryable, so a
         deterministic configuration error must keep surfacing as a plain
-        RedisClusterException.
+        RedisClusterException. Authentication failures subclass ConnectionError
+        but cannot be repaired by a failover, so they stay plain as well.
         """
         with patch.object(NodesManager, "create_redis_node") as create_redis_node:
             create_redis_node.side_effect = ConnectionError("mock connection error")
@@ -3405,6 +3407,14 @@ class TestNodesManager:
             with pytest.raises(RedisClusterUnreachableError) as e:
                 RedisCluster(startup_nodes=[ClusterNode("127.0.0.1", 7000)])
             assert "Redis Cluster cannot be connected" in str(e.value)
+
+        with patch.object(NodesManager, "create_redis_node") as create_redis_node:
+            create_redis_node.side_effect = AuthenticationError("invalid password")
+
+            with pytest.raises(RedisClusterException) as e:
+                RedisCluster(startup_nodes=[ClusterNode("127.0.0.1", 7000)])
+            assert not isinstance(e.value, RedisClusterUnreachableError)
+            assert "invalid password" in str(e.value)
 
         with pytest.raises(RedisClusterException) as e:
             get_mocked_redis_client(

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -55,6 +55,7 @@ from redis.exceptions import (
     MovedError,
     NoPermissionError,
     RedisClusterException,
+    RedisClusterUnreachableError,
     RedisError,
     ResponseError,
     TimeoutError,
@@ -3388,6 +3389,32 @@ class TestNodesManager:
                 cluster_enabled=False,
             )
             assert "Cluster mode is not enabled on this node" in str(e.value)
+
+    @pytest.mark.fixed_client
+    def test_unreachable_error_is_reserved_for_connectivity_failures(self):
+        """
+        RedisClusterUnreachableError is raised when no startup node could be
+        contacted, but not when a node responded and rejected CLUSTER SLOTS:
+        MultiDB registers the unreachable subtype as retryable, so a
+        deterministic configuration error must keep surfacing as a plain
+        RedisClusterException.
+        """
+        with patch.object(NodesManager, "create_redis_node") as create_redis_node:
+            create_redis_node.side_effect = ConnectionError("mock connection error")
+
+            with pytest.raises(RedisClusterUnreachableError) as e:
+                RedisCluster(startup_nodes=[ClusterNode("127.0.0.1", 7000)])
+            assert "Redis Cluster cannot be connected" in str(e.value)
+
+        with pytest.raises(RedisClusterException) as e:
+            get_mocked_redis_client(
+                cluster_slots_raise_error=True,
+                host=default_host,
+                port=default_port,
+                cluster_enabled=False,
+            )
+        assert not isinstance(e.value, RedisClusterUnreachableError)
+        assert "Cluster mode is not enabled on this node" in str(e.value)
 
     @pytest.mark.fixed_client
     def test_empty_startup_nodes(self):

--- a/tests/test_multidb/test_client.py
+++ b/tests/test_multidb/test_client.py
@@ -11,6 +11,11 @@ from redis.event import EventDispatcher, OnCommandsFailEvent
 from redis.multidb.circuit import State as CBState, PBCircuitBreakerAdapter
 from redis.multidb.config import InitialHealthCheck, DatabaseConfig
 from redis.multidb.database import SyncDatabase
+from redis.exceptions import (
+    ConnectionError,
+    RedisClusterException,
+    RedisClusterUnreachableError,
+)
 from redis.multidb.client import MultiDBClient
 from redis.multidb.exception import (
     NoValidDatabaseException,
@@ -26,6 +31,43 @@ from tests.test_multidb.conftest import create_weighted_list
 
 @pytest.mark.fixed_client
 class TestMultiDbClient:
+    @pytest.mark.parametrize(
+        "mock_multi_db_config,mock_db, mock_db1, mock_db2",
+        [
+            (
+                {},
+                {"weight": 0.2, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.7, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.5, "circuit": {"state": CBState.CLOSED}},
+            ),
+        ],
+        indirect=True,
+    )
+    def test_cluster_unreachable_error_is_registered_as_retryable(
+        self, mock_multi_db_config, mock_db, mock_db1, mock_db2, mock_hc
+    ):
+        """
+        A cluster database that cannot be reached reports a
+        ``RedisClusterUnreachableError`` rather than the ``ConnectionError`` a
+        standalone database reports, so the command retry has to support that type
+        for a cluster database to fail over. The overloaded ``RedisClusterException``
+        base must stay unsupported - it also covers deterministic caller errors such
+        as cross-slot commands, which must be raised without retries.
+        """
+        databases = create_weighted_list(mock_db, mock_db1, mock_db2)
+        mock_multi_db_config.health_checks = [mock_hc]
+        mock_hc.check_health.return_value = True
+
+        with patch.object(mock_multi_db_config, "databases", return_value=databases):
+            client = MultiDBClient(mock_multi_db_config)
+            try:
+                supported = client._command_retry._supported_errors
+                assert RedisClusterUnreachableError in supported
+                assert ConnectionError in supported
+                assert RedisClusterException not in supported
+            finally:
+                client.close()
+
     @pytest.mark.parametrize(
         "mock_multi_db_config,mock_db, mock_db1, mock_db2",
         [

--- a/tests/test_multidb/test_command_executor.py
+++ b/tests/test_multidb/test_command_executor.py
@@ -5,7 +5,11 @@ import pytest
 
 from redis.backoff import NoBackoff
 from redis.event import EventDispatcher, OnCommandsFailEvent
-from redis.exceptions import ConnectionError
+from redis.exceptions import (
+    ConnectionError,
+    RedisClusterException,
+    RedisClusterUnreachableError,
+)
 from redis.multidb.circuit import State as CBState
 from redis.multidb.command_executor import DefaultCommandExecutor
 from redis.multidb.failure_detector import CommandFailureDetector
@@ -173,6 +177,113 @@ class TestDefaultCommandExecutor:
         assert executor.execute_command("SET", "key", "value") == "OK2"
         assert executor.execute_command("SET", "key", "value") == "OK1"
         assert mock_fs.database.call_count == 3
+
+    @pytest.mark.parametrize(
+        "mock_db,mock_db1,mock_db2",
+        [
+            (
+                {"weight": 0.2, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.7, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.5, "circuit": {"state": CBState.CLOSED}},
+            ),
+        ],
+        indirect=True,
+    )
+    def test_execute_command_fallback_to_another_db_on_cluster_connection_failure(
+        self, mock_db, mock_db1, mock_db2, mock_fs
+    ):
+        """
+        A cluster database that cannot be reached reports a ``RedisClusterException``
+        instead of the connection error a standalone database reports, so make sure
+        it triggers a failover all the same.
+        """
+        cluster_unreachable = RedisClusterUnreachableError(
+            "Redis Cluster cannot be connected. Please provide at least "
+            "one reachable node"
+        )
+
+        mock_db1.client.execute_command.side_effect = [
+            "OK1",
+            cluster_unreachable,
+            cluster_unreachable,
+            cluster_unreachable,
+        ]
+        mock_db2.client.execute_command.side_effect = ["OK2"]
+        mock_fs.database.side_effect = [mock_db1, mock_db2]
+        threshold = 3
+        fd = CommandFailureDetector(threshold, 0.0, 1)
+        ed = EventDispatcher()
+        databases = create_weighted_list(mock_db, mock_db1, mock_db2)
+
+        executor = DefaultCommandExecutor(
+            failure_detectors=[fd],
+            databases=databases,
+            failover_strategy=mock_fs,
+            event_dispatcher=ed,
+            auto_fallback_interval=0.1,
+            command_retry=Retry(
+                NoBackoff(),
+                threshold,
+                supported_errors=(RedisClusterUnreachableError,),
+            ),
+        )
+        fd.set_command_executor(command_executor=executor)
+
+        assert executor.execute_command("SET", "key", "value") == "OK1"
+        assert executor.execute_command("SET", "key", "value") == "OK2"
+        assert mock_fs.database.call_count == 2
+
+    @pytest.mark.parametrize(
+        "mock_db,mock_db1,mock_db2",
+        [
+            (
+                {"weight": 0.2, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.7, "circuit": {"state": CBState.CLOSED}},
+                {"weight": 0.5, "circuit": {"state": CBState.CLOSED}},
+            ),
+        ],
+        indirect=True,
+    )
+    def test_execute_command_does_not_fallback_on_cluster_programming_error(
+        self, mock_db, mock_db1, mock_db2, mock_fs
+    ):
+        """
+        A plain ``RedisClusterException`` is a deterministic caller error - a
+        cross-slot command, an unsupported method - not an unavailable database. It
+        must be raised as is, without retries and without counting towards failure
+        detection, even while the unreachable subtype is supported.
+        """
+        error = RedisClusterException("Keys in request don't hash to the same slot")
+        mock_db1.client.execute_command.side_effect = error
+        mock_fs.database.return_value = mock_db1
+        # A single registered failure would be enough to open the circuit, so the
+        # circuit staying closed proves none was registered.
+        fd = CommandFailureDetector(
+            min_num_failures=1, failure_rate_threshold=0.0, failure_detection_window=1
+        )
+        ed = EventDispatcher()
+        databases = create_weighted_list(mock_db, mock_db1, mock_db2)
+
+        executor = DefaultCommandExecutor(
+            failure_detectors=[fd],
+            databases=databases,
+            failover_strategy=mock_fs,
+            event_dispatcher=ed,
+            auto_fallback_interval=0.1,
+            command_retry=Retry(
+                NoBackoff(),
+                3,
+                supported_errors=(RedisClusterUnreachableError,),
+            ),
+        )
+        fd.set_command_executor(command_executor=executor)
+
+        with pytest.raises(RedisClusterException, match="same slot"):
+            executor.execute_command("MGET", "key1", "key2")
+
+        assert mock_db1.client.execute_command.call_count == 1
+        assert mock_fs.database.call_count == 1
+        assert mock_db1.circuit.state == CBState.CLOSED
 
     @pytest.mark.parametrize(
         "mock_db,mock_db1,mock_db2",

--- a/tests/test_scenario/conftest.py
+++ b/tests/test_scenario/conftest.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import re
-from typing import Optional
+from typing import Any, Generator, Optional
 from urllib.parse import urlparse
 
 import pytest
@@ -146,7 +146,9 @@ def fault_injector_client_oss_api():
 @pytest.fixture()
 def r_multi_db(
     request,
-) -> tuple[MultiDBClient, CheckActiveDatabaseChangedListener, dict]:
+) -> Generator[
+    tuple[MultiDBClient, CheckActiveDatabaseChangedListener, dict], Any, Any
+]:
     client_class = request.param.get("client_class", Redis)
 
     if client_class == Redis:
@@ -213,7 +215,14 @@ def r_multi_db(
         health_check_delay=health_check_delay,
     )
 
-    return MultiDBClient(config), listener, endpoint_config
+    client = MultiDBClient(config)
+
+    yield client, listener, endpoint_config
+
+    # Without this the client keeps a health check loop thread and its event loop
+    # thread running for the rest of the session, polling the databases of a test
+    # that already finished.
+    client.close()
 
 
 def extract_cluster_fqdn(url):

--- a/tests/test_scenario/test_active_active.py
+++ b/tests/test_scenario/test_active_active.py
@@ -295,7 +295,9 @@ class TestActiveActive:
             sleep(0.5)
 
         # Execute pipeline until database failover
-        for _ in range(5):
+        deadline = monotonic() + FAILOVER_TIMEOUT
+        while not listener.is_changed_flag:
+            assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
             retry.call_with_retry(lambda: callback(), lambda _: dummy_fail())
             sleep(0.5)
 
@@ -347,7 +349,9 @@ class TestActiveActive:
             sleep(0.5)
 
         # Execute pipeline until database failover
-        for _ in range(5):
+        deadline = monotonic() + FAILOVER_TIMEOUT
+        while not listener.is_changed_flag:
+            assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
             retry.call_with_retry(lambda: callback(), lambda _: dummy_fail())
             sleep(0.5)
 

--- a/tests/test_scenario/test_active_active.py
+++ b/tests/test_scenario/test_active_active.py
@@ -244,8 +244,16 @@ class TestActiveActive:
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2},
-            {"client_class": RedisCluster, "min_num_failures": 2},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
+            {
+                "client_class": RedisCluster,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
         ],
         ids=["standalone", "cluster"],
         indirect=True,
@@ -304,8 +312,16 @@ class TestActiveActive:
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2},
-            {"client_class": RedisCluster, "min_num_failures": 2},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
+            {
+                "client_class": RedisCluster,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
         ],
         ids=["standalone", "cluster"],
         indirect=True,

--- a/tests/test_scenario/test_active_active.py
+++ b/tests/test_scenario/test_active_active.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import threading
-from time import sleep
+from time import monotonic, sleep
 from typing import Optional
 
 import pytest
@@ -19,6 +19,65 @@ from tests.test_scenario.fault_injector_client import ActionRequest, ActionType
 
 logger = logging.getLogger(__name__)
 
+# The injected network failure is transient - the fault injector restores the link a
+# few seconds after the action is triggered. A database is only taken out of service by
+# a health check probe that runs while the link is down, and on the default interval a
+# probe round is short next to the pause that follows it, so most rounds land after the
+# link is already back and no failover is ever initiated. Probing back to back keeps a
+# round inside the outage.
+FAILOVER_HEALTH_CHECK_INTERVAL = 0.1
+# Bounded here rather than left to pytest-timeout so a failover that never happens is
+# reported as a failover that never happened, instead of as a stack dump of whatever
+# the test was doing when the deadline passed. Kept well inside the per-test timeout so
+# the assertion below is what fires.
+FAILOVER_TIMEOUT = 60
+FAILOVER_TIMEOUT_MESSAGE = (
+    f"Active database has not changed within {FAILOVER_TIMEOUT} seconds of the "
+    "injected network failure"
+)
+# The Redis Enterprise REST API credentials LagAwareHealthCheck authenticates with.
+# They come from the test environment, and without them every probe gets HTTP 401 and
+# both databases are reported unhealthy - which fails the initial health check instead
+# of exercising the health check the test is about.
+LAG_AWARE_CREDENTIAL_ENV_VARS = ("ENV0_USERNAME", "ENV0_PASSWORD")
+# The whole health check - every probe of it - has to finish inside this budget, and
+# each probe of this one is two REST calls to the Redis Enterprise API. The default of
+# 3 seconds covers a PING, not 3 probes x 2 requests over the public internet with a
+# second of it spent in the delay between probes, and running out of it reports the
+# database as unhealthy.
+LAG_AWARE_HEALTH_CHECK_TIMEOUT = 10
+
+
+def lag_aware_auth_basic():
+    """
+    Return the REST API credentials for LagAwareHealthCheck as the environment
+    supplies them.
+    """
+    return tuple(os.getenv(name) for name in LAG_AWARE_CREDENTIAL_ENV_VARS)
+
+
+def require_lag_aware_credentials():
+    """
+    Fail the calling test up front when the environment does not supply the REST API
+    credentials.
+
+    Deliberately a failure and not a skip: a skipped test is invisible in a scenario
+    run's log, and the alternative is every probe returning HTTP 401 and the run
+    reporting InitialHealthCheckFailedError, which reads like a client bug.
+
+    Kept apart from lag_aware_auth_basic because the async twin reads the credentials
+    at collection time, where failing the individual test is not available.
+    """
+    missing = ", ".join(
+        name for name in LAG_AWARE_CREDENTIAL_ENV_VARS if not os.getenv(name)
+    )
+
+    if missing:
+        pytest.fail(
+            "LagAwareHealthCheck requires the Redis Enterprise REST API credentials "
+            f"in {missing}. Set them from the CI secrets of the same name."
+        )
+
 
 def trigger_network_failure_action(
     fault_injector_client, config, event: Optional[threading.Event] = None
@@ -29,14 +88,7 @@ def trigger_network_failure_action(
     )
 
     result = fault_injector_client.trigger_action(action_request)
-    status_result = fault_injector_client.get_action_status(result["action_id"])
-
-    while status_result["status"] != "success":
-        sleep(0.1)
-        status_result = fault_injector_client.get_action_status(result["action_id"])
-        logger.info(
-            f"Waiting for action to complete. Status: {status_result['status']}"
-        )
+    status_result = fault_injector_client.get_operation_result(result["action_id"])
 
     if event:
         event.set()
@@ -44,7 +96,6 @@ def trigger_network_failure_action(
     logger.info(f"Action completed. Status: {status_result['status']}")
 
 
-@pytest.mark.skip(reason="Temporarily disabled")
 class TestActiveActive:
     def teardown_method(self, method):
         # Timeout so the cluster could recover from network failure.
@@ -53,8 +104,16 @@ class TestActiveActive:
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2},
-            {"client_class": RedisCluster, "min_num_failures": 2},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
+            {
+                "client_class": RedisCluster,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
         ],
         ids=["standalone", "cluster"],
         indirect=True,
@@ -96,7 +155,9 @@ class TestActiveActive:
             sleep(0.5)
 
         # Execute commands until database failover
+        deadline = monotonic() + FAILOVER_TIMEOUT
         while not listener.is_changed_flag:
+            assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
             assert (
                 retry.call_with_retry(
                     lambda: r_multi_db.get("key"), lambda _: dummy_fail()
@@ -108,11 +169,15 @@ class TestActiveActive:
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2, "health_check_interval": 20},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
             {
                 "client_class": RedisCluster,
                 "min_num_failures": 2,
-                "health_check_interval": 20,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
             },
         ],
         ids=["standalone", "cluster"],
@@ -122,6 +187,8 @@ class TestActiveActive:
     def test_multi_db_client_uses_lag_aware_health_check(
         self, r_multi_db, fault_injector_client
     ):
+        require_lag_aware_credentials()
+
         r_multi_db, listener, config = r_multi_db
         retry = Retry(
             supported_errors=(TemporaryUnavailableException,),
@@ -136,15 +203,13 @@ class TestActiveActive:
             args=(fault_injector_client, config, event),
         )
 
-        env0_username = os.getenv("ENV0_USERNAME")
-        env0_password = os.getenv("ENV0_PASSWORD")
-
         # Adding additional health check to the client.
         r_multi_db.add_health_check(
             LagAwareHealthCheck(
                 verify_tls=False,
-                auth_basic=(env0_username, env0_password),
+                auth_basic=lag_aware_auth_basic(),
                 lag_aware_tolerance=10000,
+                health_check_timeout=LAG_AWARE_HEALTH_CHECK_TIMEOUT,
             )
         )
 
@@ -165,7 +230,9 @@ class TestActiveActive:
             sleep(0.5)
 
         # Execute commands after network failure
+        deadline = monotonic() + FAILOVER_TIMEOUT
         while not listener.is_changed_flag:
+            assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
             assert (
                 retry.call_with_retry(
                     lambda: r_multi_db.get("key"), lambda _: dummy_fail()
@@ -277,18 +344,26 @@ class TestActiveActive:
         # Execute pipeline before network failure
         while not event.is_set():
             retry.call_with_retry(lambda: callback(), lambda _: dummy_fail())
-        sleep(0.5)
+            sleep(0.5)
 
         # Execute pipeline until database failover
         for _ in range(5):
             retry.call_with_retry(lambda: callback(), lambda _: dummy_fail())
-        sleep(0.5)
+            sleep(0.5)
 
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2},
-            {"client_class": RedisCluster, "min_num_failures": 2},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
+            {
+                "client_class": RedisCluster,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
         ],
         ids=["standalone", "cluster"],
         indirect=True,
@@ -333,7 +408,9 @@ class TestActiveActive:
             sleep(0.5)
 
         # Execute transaction until database failover
+        deadline = monotonic() + FAILOVER_TIMEOUT
         while not listener.is_changed_flag:
+            assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
             retry.call_with_retry(
                 lambda: r_multi_db.transaction(callback), lambda _: dummy_fail()
             )
@@ -342,8 +419,16 @@ class TestActiveActive:
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2},
-            {"client_class": RedisCluster, "min_num_failures": 2},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
+            {
+                "client_class": RedisCluster,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
         ],
         ids=["standalone", "cluster"],
         indirect=True,
@@ -388,7 +473,9 @@ class TestActiveActive:
             sleep(0.5)
 
         # Execute publish until database failover
+        deadline = monotonic() + FAILOVER_TIMEOUT
         while not listener.is_changed_flag:
+            assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
             retry.call_with_retry(
                 lambda: r_multi_db.publish("test-channel", data), lambda _: dummy_fail()
             )
@@ -400,8 +487,16 @@ class TestActiveActive:
     @pytest.mark.parametrize(
         "r_multi_db",
         [
-            {"client_class": Redis, "min_num_failures": 2},
-            {"client_class": RedisCluster, "min_num_failures": 2},
+            {
+                "client_class": Redis,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
+            {
+                "client_class": RedisCluster,
+                "min_num_failures": 2,
+                "health_check_interval": FAILOVER_HEALTH_CHECK_INTERVAL,
+            },
         ],
         ids=["standalone", "cluster"],
         indirect=True,
@@ -451,7 +546,9 @@ class TestActiveActive:
             sleep(0.5)
 
         # Execute publish until database failover
+        deadline = monotonic() + FAILOVER_TIMEOUT
         while not listener.is_changed_flag:
+            assert monotonic() < deadline, FAILOVER_TIMEOUT_MESSAGE
             retry.call_with_retry(
                 lambda: r_multi_db.spublish("test-channel", data),
                 lambda _: dummy_fail(),


### PR DESCRIPTION
## Change summary

This pull request stabilizes the MultiDB (Active-Active) client and its scenario tests. A temporarily unreachable cluster used to surface as a plain `RedisClusterException` from topology refresh, which the MultiDB command retry did not recognize, so commands failed instead of triggering a failover. `NodesManager.initialize` (sync and async) now raises a new `RedisClusterUnreachableError` - a subclass of `RedisClusterException`, so existing handlers keep working - and `MultiDBClient` registers it as retryable, letting the failover path take over.

`LagAwareHealthCheck` also probed the wrong node in some Redis Enterprise setups: it matched the bdb by the first discovered node, whose advertised address is often neither the endpoint DNS name nor an address the bdb lists. It now matches against all configured database hosts, preferring a DNS-name match over an address match, and health check probes across nodes run in parallel to keep a probe round short. On the test side, the `r_multi_db` fixture now closes the client on teardown (previously its health check loop thread kept running for the rest of the session), and the AA scenario tests bound their failover waits with an explicit deadline and use a tight health check interval so a probe round reliably lands inside the injected transient outage.

## Test coverage

Unit tests were extended on both stacks: `tests/test_multidb/` and `tests/test_asyncio/test_multidb/` cover the new retryable-error registration in `MultiDBClient` and command executor failover on `RedisClusterUnreachableError`, and the async healthcheck tests cover bdb matching by DNS name vs address and the parallel probe rounds. The AA scenario tests (`tests/test_scenario/test_active_active.py`, sync and async) were updated as described above; they require Redis Enterprise infrastructure and are excluded from default runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster bootstrap exceptions, MultiDB failover/retry behavior, and health-check probing paths that can mark databases unhealthy or trigger failover; coverage is broad but these are core availability paths.
> 
> **Overview**
> Introduces **`RedisClusterUnreachableError`** when sync/async cluster startup cannot reach any node (connectivity-only; **auth** and **config** failures still raise plain **`RedisClusterException`**). **MultiDB** sync/async clients register that type for **command retry** so cluster outages can **fail over** without treating every **`RedisClusterException`** as retryable.
> 
> **Async MultiDB health checks** are tightened: probe clients keep **TLS**, cluster probes use **all startup nodes**, **`initialize()`** runs before cluster PINGs, nodes are pinged **concurrently**, and connectivity failures **reset** the probe client. **`LagAwareHealthCheck`** matches Redis Enterprise bdbs by **configured hosts** (DNS over address), and REST calls use **per-request absolute URLs** so concurrent database checks do not clobber a shared HTTP **base_url**.
> 
> **Active-active scenario tests** are re-enabled with faster health-check intervals, explicit failover deadlines, fixture teardown that **closes** the MultiDB client, and clearer LagAware credential handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eae24c034256ac53fd1c306e96fbe907cf746fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->