### PR TITLE
Stabilize maint notifications tests and add connection diagnostics

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import inspect
+import logging
 import math
 import re
 import time
@@ -39,6 +40,7 @@ from redis._defaults import (
 from redis._parsers.helpers import bool_ok, get_response_callbacks
 from redis.asyncio import _himport_exec
 from redis.asyncio.connection import (
+    AbstractConnection,
     Connection,
     ConnectionPool,
     SSLConnection,
@@ -120,6 +122,31 @@ _NormalizeKeysT = TypeVar("_NormalizeKeysT", bound=Mapping[ChannelT, object])
 if TYPE_CHECKING:
     from redis.asyncio.keyspace_notifications import AsyncKeyspaceNotifications
     from redis.commands.core import Script
+
+
+logger = logging.getLogger(__name__)
+
+
+def is_debug_log_enabled():
+    return logger.isEnabledFor(logging.DEBUG)
+
+
+def add_debug_log_for_operation_failure(
+    connection: AbstractConnection,
+    error: BaseException | None = None,
+    args: Iterable[Any] | None = None,
+):
+    details = connection.extract_connection_details() if connection else "no connection"
+    prefix = (
+        f"{type(error).__name__} received" if error is not None else "Operation failed"
+    )
+    command = (
+        f" for command {truncate_text(' '.join(map(safe_str, args)))}" if args else ""
+    )
+    suffix = f", error: {error}" if error is not None else ""
+    logger.debug(
+        f"{prefix}{command}, with connection: {connection}, details: {details}{suffix}",
+    )
 
 
 class ResponseCallbackProtocol(Protocol):
@@ -935,6 +962,8 @@ class Redis(
         actual_retry_attempts = 0
 
         def failure_callback(error, failure_count):
+            if is_debug_log_enabled():
+                add_debug_log_for_operation_failure(conn, error, args)
             nonlocal actual_retry_attempts
             actual_retry_attempts = failure_count
             return self._close_connection(
@@ -1347,6 +1376,8 @@ class PubSub:
         actual_retry_attempts = 0
 
         def failure_callback(error, failure_count):
+            if is_debug_log_enabled():
+                add_debug_log_for_operation_failure(conn, error, args)
             nonlocal actual_retry_attempts
             actual_retry_attempts = failure_count
             return self._reconnect(conn, error, failure_count, start_time, command_name)
@@ -1968,6 +1999,8 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
         actual_retry_attempts = 0
 
         def failure_callback(error, failure_count):
+            if is_debug_log_enabled():
+                add_debug_log_for_operation_failure(conn, error, args)
             nonlocal actual_retry_attempts
             actual_retry_attempts = failure_count
             return self._disconnect_reset_raise_on_watching(
@@ -2253,6 +2286,8 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
         actual_retry_attempts = 0
 
         def failure_callback(error, failure_count):
+            if is_debug_log_enabled():
+                add_debug_log_for_operation_failure(conn, error, (operation_name,))
             nonlocal actual_retry_attempts
             actual_retry_attempts = failure_count
             return self._disconnect_raise_on_watching(

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -20,6 +20,7 @@ from typing import (
     MutableMapping,
     Optional,
     Protocol,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -134,15 +135,15 @@ def is_debug_log_enabled():
 def add_debug_log_for_operation_failure(
     connection: AbstractConnection,
     error: BaseException | None = None,
-    args: Iterable[Any] | None = None,
+    args: Sequence[Any] | None = None,
 ):
     details = connection.extract_connection_details() if connection else "no connection"
     prefix = (
         f"{type(error).__name__} received" if error is not None else "Operation failed"
     )
-    command = (
-        f" for command {truncate_text(' '.join(map(safe_str, args)))}" if args else ""
-    )
+    # Log only the command name - argument values can carry secrets
+    # (AUTH, CONFIG SET requirepass, ACL SETUSER) or user data.
+    command = f" for command {safe_str(args[0])}" if args else ""
     suffix = f", error: {error}" if error is not None else ""
     logger.debug(
         f"{prefix}{command}, with connection: {connection}, details: {details}{suffix}",

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2291,6 +2291,11 @@ class NodesManager:
                                 self.connection_kwargs.get("credential_provider", None),
                             )
                         )
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "Topology refresh: querying CLUSTER SLOTS on "
+                                f"{startup_node.name}"
+                            )
                         cluster_slots = await startup_node.execute_command(
                             "CLUSTER SLOTS"
                         )
@@ -2302,6 +2307,11 @@ class NodesManager:
                 except Exception as e:
                     # Try the next startup node.
                     # The exception is saved and raised only if we have no more nodes.
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(
+                            "Topology refresh: CLUSTER SLOTS failed on "
+                            f"{startup_node.name}: {type(e).__name__}: {e}"
+                        )
                     exception = e
                     continue
 
@@ -2381,6 +2391,12 @@ class NodesManager:
                     if i not in tmp_slots:
                         fully_covered = False
                         break
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        f"Topology refresh: CLUSTER SLOTS from {startup_node.name} "
+                        f"reported nodes {sorted(tmp_nodes_cache)}; "
+                        f"slots fully covered: {fully_covered}"
+                    )
                 if fully_covered:
                     break
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import copy
 import inspect
+import logging
 import math
 import socket
 import sys
@@ -131,6 +132,32 @@ if HIREDIS_AVAILABLE:
 else:
     DefaultParser = _AsyncRESP3Parser
 
+logger = logging.getLogger(__name__)
+
+
+def add_debug_log_for_connection_failure(
+    connection: "AbstractConnection",
+    error: BaseException,
+    operation: str,
+) -> None:
+    """
+    Render the connection's live state on a failure that is about to close it.
+
+    Must be called *before* ``disconnect()``. ``extract_connection_details()``
+    reads the local port and the in-flight read deadline off the transport, so
+    once it is gone it can only report ``not connected`` - which hides exactly
+    the state needed to explain the failure. In particular it is what tells
+    apart a read that ran under the original timeout from one that ran under a
+    relaxed maintenance timeout.
+    """
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            f"{type(error).__name__} while {operation}, "
+            f"with connection: {connection}, "
+            f"details: {connection.extract_connection_details()}, "
+            f"error: {error}",
+        )
+
 
 class ConnectCallbackProtocol(Protocol):
     def __call__(self, connection: "AbstractConnection"): ...
@@ -218,6 +245,10 @@ class AsyncMaintNotificationsAbstractConnection:
 
     @abstractmethod
     def getpeername(self) -> str | None:
+        pass
+
+    @abstractmethod
+    def extract_connection_details(self) -> str:
         pass
 
     def _configure_maintenance_notifications(
@@ -424,9 +455,6 @@ class AsyncMaintNotificationsAbstractConnection:
                 and maint_notifications_config.enabled == "auto"
             ):
                 # Log warning but don't fail the connection
-                import logging
-
-                logger = logging.getLogger(__name__)
                 logger.debug(f"Failed to enable maintenance notifications: {e}")
             else:
                 raise
@@ -816,6 +844,63 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             return str(peername[0])
         return None
 
+    def extract_connection_details(self) -> str:
+        """
+        Render the connection's identity, maintenance state and effective timeouts.
+
+        This is what the debug logs use to explain a failed or timed out command:
+
+        - ``host`` vs ``orig host`` says whether the connection still points at the
+          node being moved away from, or has already been repointed at the new one.
+        - ``state`` says whether maintenance handling touched this connection at
+          all, so an unaffected node's connections are distinguishable.
+        - ``socket_timeout`` vs ``active read timeout`` says which timeout the read
+          actually ran under. ``active read timeout`` is the remaining deadline of
+          the in-flight ``read_response`` (``None`` when no read is in flight), so
+          the two diverge for a command that was already reading when the relaxed
+          timeout was applied.
+        """
+        writer = self._writer
+        if writer is None:
+            return "not connected"
+
+        socket_address = None
+        try:
+            socket_name = writer.get_extra_info("sockname")
+            # AF_UNIX sockets report a path string rather than a (host, port) tuple
+            if isinstance(socket_name, tuple) and len(socket_name) > 1:
+                socket_address = socket_name[1]
+        except (AttributeError, OSError):
+            pass
+
+        # Unlike the sync client there is no timeout armed on the socket; the
+        # deadline lives in the timeout context wrapping the in-flight read.
+        active_read_timeout = None
+        timeout_context = self._active_read_timeout
+        if timeout_context is not None:
+            try:
+                when = timeout_context.when()
+                if when is not None:
+                    active_read_timeout = round(
+                        when - asyncio.get_running_loop().time(), 3
+                    )
+            except (AttributeError, RuntimeError):
+                pass
+
+        state = getattr(self.maintenance_state, "value", self.maintenance_state)
+        return (
+            f"connected to ip {self.get_resolved_ip()}, "
+            f"local socket port: {socket_address}, "
+            f"host: {self._host_error()} "
+            f"(orig: {getattr(self, 'orig_host_address', None)}), "
+            f"state: {state}, "
+            f"socket_timeout: {self.socket_timeout} "
+            f"(orig: {getattr(self, 'orig_socket_timeout', None)}), "
+            f"active read timeout: {active_read_timeout}, "
+            f"should_reconnect: {self.should_reconnect()}, "
+            f"notification_hash: {self.maintenance_notification_hash}"
+        )
+
     async def connect(self):
         """Connects to the Redis server if not already connected"""
         # try once the socket connect with the handshake, retry the whole
@@ -1204,10 +1289,12 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
                 )
             else:
                 await self._send_packed_command(command)
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
+            add_debug_log_for_connection_failure(self, e, "writing command")
             await self.disconnect(nowait=True)
             raise TimeoutError("Timeout writing to socket") from None
         except OSError as e:
+            add_debug_log_for_connection_failure(self, e, "writing command")
             await self.disconnect(nowait=True)
             if len(e.args) == 1:
                 err_no, errmsg = "UNKNOWN", e.args[0]
@@ -1217,11 +1304,12 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             raise ConnectionError(
                 f"Error {err_no} while writing to socket. {errmsg}."
             ) from e
-        except BaseException:
+        except BaseException as e:
             # BaseExceptions can be raised when a socket send operation is not
             # finished, e.g. due to a timeout.  Ideally, a caller could then re-try
             # to send un-sent data. However, the send_packed_command() API
             # does not support it so there is no point in keeping the connection open.
+            add_debug_log_for_connection_failure(self, e, "writing command")
             await self.disconnect(nowait=True)
             raise
 
@@ -1316,23 +1404,26 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
                     disable_decoding=disable_decoding,
                     push_request=push_request,
                 )
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             if timeout is not None:
                 # user requested timeout, return None. Operation can be retried
                 return None
             # it was a self.socket_timeout error.
             if disconnect_on_error:
+                add_debug_log_for_connection_failure(self, e, "reading response")
                 await self.disconnect(nowait=True)
             raise TimeoutError(f"Timeout reading from {host_error}")
         except OSError as e:
             if disconnect_on_error:
+                add_debug_log_for_connection_failure(self, e, "reading response")
                 await self.disconnect(nowait=True)
             raise ConnectionError(f"Error while reading from {host_error} : {e.args}")
-        except BaseException:
+        except BaseException as e:
             # Also by default close in case of BaseException.  A lot of code
             # relies on this behaviour when doing Command/Response pairs.
             # See #1128.
             if disconnect_on_error:
+                add_debug_log_for_connection_failure(self, e, "reading response")
                 await self.disconnect(nowait=True)
             raise
 
@@ -2264,6 +2355,11 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                         "Either maint_notifications_pool_handler or "
                         "oss_cluster_maint_notifications_handler must be set"
                     )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "Marking active connection for reconnect after config update "
+                        f"config update: {conn}, {conn.extract_connection_details()}"
+                    )
                 conn.mark_for_reconnect()
 
     def _should_update_connection(
@@ -2460,6 +2556,12 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         changes must happen under one pool-owned lock; otherwise a connection
         can move between active/free lists and escape handling.
         """
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"Applying MOVING notification to pool: {notification}, "
+                f"moving address src: {moving_address_src}, "
+                f"proactive reconnect: {run_proactive_reconnect}"
+            )
         async with self._get_pool_lock():
             # Opt BlockingConnectionPool into serializing its get/release
             # with this critical section. Other pools do not define
@@ -2514,10 +2616,16 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         reused by larger atomic operations that already hold the non-reentrant
         `asyncio.Lock`.
         """
+        debug = logger.isEnabledFor(logging.DEBUG)
         for conn in self._get_in_use_connections():
             if self._should_update_connection(
                 conn, "connected_address", moving_address_src
             ):
+                if debug:
+                    logger.debug(
+                        f"Marking active connection for reconnect: {conn}, "
+                        f"{conn.extract_connection_details()}"
+                    )
                 conn.mark_for_reconnect()
 
         free_connections = [
@@ -2527,6 +2635,12 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                 conn, "connected_address", moving_address_src
             )
         ]
+        if debug:
+            for conn in free_connections:
+                logger.debug(
+                    f"Disconnecting free connection: {conn}, "
+                    f"{conn.extract_connection_details()}"
+                )
         await self._disconnect_connections(free_connections)
 
     async def cleanup_moving_notification(
@@ -2543,6 +2657,12 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         acquire/release interleave, which can leave stale MOVING state or undo a
         newer overlapping MOVING notification.
         """
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Cleaning up MOVING pool state for notification hash "
+                f"{notification_hash}, reset_relaxed_timeout="
+                f"{reset_relaxed_timeout}, reset_host_address={reset_host_address}"
+            )
         async with self._get_pool_lock():
             kwargs = _build_moving_cleanup_connection_kwargs(
                 self.connection_kwargs, notification_hash
@@ -2920,6 +3040,11 @@ class ConnectionPool(
             self._in_use_connections.remove(connection)
 
             if connection.should_reconnect():
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "Disconnecting released connection marked for reconnect: "
+                        f"{connection}, {connection.extract_connection_details()}"
+                    )
                 await connection.disconnect()
 
             self._available_connections.append(connection)
@@ -2968,8 +3093,14 @@ class ConnectionPool(
         """
         Mark all active connections for reconnect.
         """
+        debug = logger.isEnabledFor(logging.DEBUG)
         async with self._lock:
             for conn in self._in_use_connections:
+                if debug:
+                    logger.debug(
+                        f"Marking active connection for reconnect: {conn}, "
+                        f"{conn.extract_connection_details()}"
+                    )
                 conn.mark_for_reconnect()
 
     async def aclose(self) -> None:

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -56,28 +56,17 @@ def add_debug_log_for_notification(
     if not logger.isEnabledFor(logging.DEBUG):
         return
 
-    socket_address = None
+    details = "no connection"
     try:
-        writer = getattr(connection, "_writer", None)
-        socket_name = writer.get_extra_info("sockname") if writer else None
-        socket_address = (
-            socket_name[1] if socket_name and len(socket_name) > 1 else None
-        )
+        extract = getattr(connection, "extract_connection_details", None)
+        if callable(extract):
+            details = extract()
     except (AttributeError, OSError, TypeError):
-        pass
-
-    resolved_ip = None
-    try:
-        get_resolved_ip = getattr(connection, "get_resolved_ip", None)
-        if callable(get_resolved_ip):
-            resolved_ip = get_resolved_ip()
-    except (AttributeError, OSError):
         pass
 
     logger.debug(
         f"Handling maintenance notification: {notification}, "
-        f"with connection: {connection}, connected to ip {resolved_ip}, "
-        f"local socket port: {socket_address}",
+        f"with connection: {connection}, {details}",
     )
 
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -116,10 +116,21 @@ def is_debug_log_enabled():
     return logger.isEnabledFor(logging.DEBUG)
 
 
-def add_debug_log_for_operation_failure(connection: "AbstractConnection"):
+def add_debug_log_for_operation_failure(
+    connection: AbstractConnection,
+    error: BaseException | None = None,
+    args: Iterable[Any] | None = None,
+):
+    details = connection.extract_connection_details() if connection else "no connection"
+    prefix = (
+        f"{type(error).__name__} received" if error is not None else "Operation failed"
+    )
+    command = (
+        f" for command {truncate_text(' '.join(map(safe_str, args)))}" if args else ""
+    )
+    suffix = f", error: {error}" if error is not None else ""
     logger.debug(
-        f"Operation failed, "
-        f"with connection: {connection}, details: {connection.extract_connection_details() if connection else 'no connection'}",
+        f"{prefix}{command}, with connection: {connection}, details: {details}{suffix}",
     )
 
 
@@ -903,7 +914,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
 
         def failure_callback(error, failure_count):
             if is_debug_log_enabled():
-                add_debug_log_for_operation_failure(conn)
+                add_debug_log_for_operation_failure(conn, error, args)
             actual_retry_attempts[0] = failure_count
             self._close_connection(conn, error, failure_count, start_time, command_name)
 
@@ -1324,6 +1335,8 @@ class PubSub:
         actual_retry_attempts = [0]
 
         def failure_callback(error, failure_count):
+            if is_debug_log_enabled():
+                add_debug_log_for_operation_failure(conn, error, args)
             actual_retry_attempts[0] = failure_count
             self._reconnect(conn, error, failure_count, start_time, command_name)
 
@@ -1981,7 +1994,7 @@ class Pipeline(Redis):
 
         def failure_callback(error, failure_count):
             if is_debug_log_enabled():
-                add_debug_log_for_operation_failure(conn)
+                add_debug_log_for_operation_failure(conn, error, args)
             actual_retry_attempts[0] = failure_count
             self._disconnect_reset_raise_on_watching(
                 conn, error, failure_count, start_time, command_name
@@ -2247,7 +2260,7 @@ class Pipeline(Redis):
 
         def failure_callback(error, failure_count):
             if is_debug_log_enabled():
-                add_debug_log_for_operation_failure(conn)
+                add_debug_log_for_operation_failure(conn, error, (operation_name,))
             actual_retry_attempts[0] = failure_count
             self._disconnect_raise_on_watching(
                 conn, error, failure_count, start_time, operation_name

--- a/redis/client.py
+++ b/redis/client.py
@@ -14,6 +14,7 @@ from typing import (
     Literal,
     Mapping,
     Optional,
+    Sequence,
     Set,
     Type,
     Union,
@@ -119,15 +120,15 @@ def is_debug_log_enabled():
 def add_debug_log_for_operation_failure(
     connection: AbstractConnection,
     error: BaseException | None = None,
-    args: Iterable[Any] | None = None,
+    args: Sequence[Any] | None = None,
 ):
     details = connection.extract_connection_details() if connection else "no connection"
     prefix = (
         f"{type(error).__name__} received" if error is not None else "Operation failed"
     )
-    command = (
-        f" for command {truncate_text(' '.join(map(safe_str, args)))}" if args else ""
-    )
+    # Log only the command name - argument values can carry secrets
+    # (AUTH, CONFIG SET requirepass, ACL SETUSER) or user data.
+    command = f" for command {safe_str(args[0])}" if args else ""
     suffix = f", error: {error}" if error is not None else ""
     logger.debug(
         f"{prefix}{command}, with connection: {connection}, details: {details}{suffix}",

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1932,7 +1932,9 @@ class RedisCluster(
                         if connection
                         else "no connection"
                     )
-                    args_log_str = truncate_text(" ".join(map(safe_str, args)))
+                    # Log only the command name - argument values can carry
+                    # secrets or user data.
+                    args_log_str = safe_str(args[0])
                     logger.debug(
                         f"{type(e).__name__} received for command {args_log_str}, on node {target_node.name}, "
                         f"and connection: {connection}, {connection_details}, error: {e}"
@@ -1979,7 +1981,9 @@ class RedisCluster(
                         if connection
                         else "no connection"
                     )
-                    args_log_str = truncate_text(" ".join(map(safe_str, args)))
+                    # Log only the command name - argument values can carry
+                    # secrets or user data.
+                    args_log_str = safe_str(args[0])
                     logger.debug(
                         f"MOVED error received for command {args_log_str}, on node {target_node.name}, "
                         f"and connection: {connection}, {connection_details}, error: {e}"
@@ -2021,7 +2025,9 @@ class RedisCluster(
                         if connection
                         else "no connection"
                     )
-                    args_log_str = truncate_text(" ".join(map(safe_str, args)))
+                    # Log only the command name - argument values can carry
+                    # secrets or user data.
+                    args_log_str = safe_str(args[0])
                     logger.debug(
                         f"TRYAGAIN error received for command {args_log_str}, on node {target_node.name}, "
                         f"and connection: {connection}, {connection_details}"
@@ -2046,7 +2052,9 @@ class RedisCluster(
                         if connection
                         else "no connection"
                     )
-                    args_log_str = truncate_text(" ".join(map(safe_str, args)))
+                    # Log only the command name - argument values can carry
+                    # secrets or user data.
+                    args_log_str = safe_str(args[0])
                     logger.debug(
                         f"ASK error received for command {args_log_str}, on node {target_node.name}, "
                         f"and connection: {connection}, {connection_details}, error: {e}"

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1925,11 +1925,15 @@ class RedisCluster(
                 raise
             except (ConnectionError, TimeoutError) as e:
                 if is_debug_log_enabled():
-                    socket_address = self._extracts_socket_address(connection)
+                    connection_details = (
+                        connection.extract_connection_details()
+                        if connection
+                        else "no connection"
+                    )
                     args_log_str = truncate_text(" ".join(map(safe_str, args)))
                     logger.debug(
                         f"{type(e).__name__} received for command {args_log_str}, on node {target_node.name}, "
-                        f"and connection: {connection} using local socket address: {socket_address}, error: {e}"
+                        f"and connection: {connection}, {connection_details}, error: {e}"
                     )
                 # this is used to report the metrics based on host and port info
                 e.connection = connection if connection else target_node
@@ -1968,11 +1972,15 @@ class RedisCluster(
                 raise e
             except MovedError as e:
                 if is_debug_log_enabled():
-                    socket_address = self._extracts_socket_address(connection)
+                    connection_details = (
+                        connection.extract_connection_details()
+                        if connection
+                        else "no connection"
+                    )
                     args_log_str = truncate_text(" ".join(map(safe_str, args)))
                     logger.debug(
                         f"MOVED error received for command {args_log_str}, on node {target_node.name}, "
-                        f"and connection: {connection} using local socket address: {socket_address}, error: {e}"
+                        f"and connection: {connection}, {connection_details}, error: {e}"
                     )
                 # First, we will try to patch the slots/nodes cache with the
                 # redirected node output and try again. If MovedError exceeds
@@ -2006,11 +2014,15 @@ class RedisCluster(
                 )
             except TryAgainError as e:
                 if is_debug_log_enabled():
-                    socket_address = self._extracts_socket_address(connection)
+                    connection_details = (
+                        connection.extract_connection_details()
+                        if connection
+                        else "no connection"
+                    )
                     args_log_str = truncate_text(" ".join(map(safe_str, args)))
                     logger.debug(
                         f"TRYAGAIN error received for command {args_log_str}, on node {target_node.name}, "
-                        f"and connection: {connection} using local socket address: {socket_address}"
+                        f"and connection: {connection}, {connection_details}"
                     )
                 if ttl < self.RedisClusterRequestTTL / 2:
                     time.sleep(0.05)
@@ -2027,11 +2039,15 @@ class RedisCluster(
                 )
             except AskError as e:
                 if is_debug_log_enabled():
-                    socket_address = self._extracts_socket_address(connection)
+                    connection_details = (
+                        connection.extract_connection_details()
+                        if connection
+                        else "no connection"
+                    )
                     args_log_str = truncate_text(" ".join(map(safe_str, args)))
                     logger.debug(
                         f"ASK error received for command {args_log_str}, on node {target_node.name}, "
-                        f"and connection: {connection} using local socket address: {socket_address}, error: {e}"
+                        f"and connection: {connection}, {connection_details}, error: {e}"
                     )
                 redirect_addr = get_node_name(host=e.host, port=e.port)
                 asking = True
@@ -2157,20 +2173,6 @@ class RedisCluster(
             retry_attempts=retry_attempts if retry_attempts is not None else 0,
             is_internal=is_internal,
         )
-
-    def _extracts_socket_address(
-        self, connection: Optional[Connection]
-    ) -> Optional[int]:
-        if connection is None:
-            return None
-        try:
-            socket_address = (
-                connection._sock.getsockname() if connection._sock else None
-            )
-            socket_address = socket_address[1] if socket_address else None
-        except (AttributeError, OSError):
-            pass
-        return socket_address
 
     def close(self) -> None:
         try:
@@ -2801,6 +2803,11 @@ class NodesManager:
                         else:
                             startup_node.redis_connection = r
                     try:
+                        if is_debug_log_enabled():
+                            logger.debug(
+                                "Topology refresh: querying CLUSTER SLOTS on "
+                                f"{startup_node.name}"
+                            )
                         # Make sure cluster mode is enabled on this node
                         cluster_slots = str_if_bytes(r.execute_command("CLUSTER SLOTS"))
                         if disconnect_startup_nodes_pools:
@@ -2819,6 +2826,11 @@ class NodesManager:
                 except Exception as e:
                     # Try the next startup node.
                     # The exception is saved and raised only if we have no more nodes.
+                    if is_debug_log_enabled():
+                        logger.debug(
+                            "Topology refresh: CLUSTER SLOTS failed on "
+                            f"{startup_node.name}: {type(e).__name__}: {e}"
+                        )
                     exception = e
                     continue
 
@@ -2880,6 +2892,12 @@ class NodesManager:
                                     )
 
                 fully_covered = self.check_slots_coverage(tmp_slots)
+                if is_debug_log_enabled():
+                    logger.debug(
+                        f"Topology refresh: CLUSTER SLOTS from {startup_node.name} "
+                        f"reported nodes {sorted(tmp_nodes_cache)}; "
+                        f"slots fully covered: {fully_covered}"
+                    )
                 if fully_covered:
                     # Don't need to continue to the next startup node if all
                     # slots are covered

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import os
 import socket
 import sys
@@ -123,6 +124,32 @@ if HIREDIS_AVAILABLE:
     DefaultParser = _HiredisParser
 else:
     DefaultParser = _RESP2Parser
+
+logger = logging.getLogger(__name__)
+
+
+def add_debug_log_for_connection_failure(
+    connection: "AbstractConnection",
+    error: BaseException,
+    operation: str,
+) -> None:
+    """
+    Render the connection's live state on a failure that is about to close it.
+
+    Must be called *before* ``disconnect()``. ``extract_connection_details()``
+    reads the resolved ip, local port and armed read timeout off the socket, so
+    once the socket is gone it can only report ``not connected`` - which hides
+    exactly the state needed to explain the failure. In particular it is what
+    tells apart a read that ran under the original timeout from one that ran
+    under a relaxed maintenance timeout.
+    """
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            f"{type(error).__name__} while {operation}, "
+            f"with connection: {connection}, "
+            f"details: {connection.extract_connection_details()}, "
+            f"error: {error}",
+        )
 
 
 class HiredisRespSerializer:
@@ -664,9 +691,6 @@ class MaintNotificationsAbstractConnection:
                 and maint_notifications_config.enabled == "auto"
             ):
                 # Log warning but don't fail the connection
-                import logging
-
-                logger = logging.getLogger(__name__)
                 logger.debug(f"Failed to enable maintenance notifications: {e}")
             else:
                 raise
@@ -689,8 +713,10 @@ class MaintNotificationsAbstractConnection:
             conn_socket = self._get_socket()
             if conn_socket is not None:
                 peer_addr = conn_socket.getpeername()
-                if peer_addr and len(peer_addr) >= 1:
-                    # For TCP sockets, peer_addr is typically (host, port) tuple
+                # For TCP sockets, peer_addr is typically a (host, port) tuple.
+                # AF_UNIX sockets report a path string instead, and indexing it
+                # would yield the first character of the path.
+                if isinstance(peer_addr, tuple) and peer_addr:
                     # Return just the host part
                     return peer_addr[0]
         except (AttributeError, OSError):
@@ -763,12 +789,22 @@ class MaintNotificationsAbstractConnection:
             # will lead to a deadlock
             if conn_socket.gettimeout() != 0:
                 conn_socket.settimeout(timeout)
+            # Deliberately outside the guard above. The parser caches this value
+            # to restore after a per-call timeout override, so while a can_read
+            # probe holds the socket at 0 the cache *is* the pending restore
+            # value: writing it is how the new timeout gets armed without
+            # flipping the socket back to blocking mid-read. Skipping it here
+            # instead would let the probe restore the pre-relaxation timeout and
+            # lose a maintenance relaxation for the life of the connection.
             self.update_parser_timeout(timeout)
 
     def update_parser_timeout(self, timeout: Optional[float] = None):
         parser = self._get_parser()
         if parser and parser._buffer:
-            if isinstance(parser, _RESP3Parser) and timeout:
+            # Both parsers cache this value to restore after a per-call timeout
+            # override, so both must receive exactly what was armed on the
+            # socket - including None, which means "block indefinitely".
+            if isinstance(parser, _RESP3Parser):
                 parser._buffer.socket_timeout = timeout
             elif isinstance(parser, _HiredisParser):
                 parser._socket_timeout = timeout
@@ -1350,10 +1386,12 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                 command = [command]
             for item in command:
                 self._sock.sendall(item)
-        except socket.timeout:
+        except socket.timeout as e:
+            add_debug_log_for_connection_failure(self, e, "writing command")
             self.disconnect()
             raise TimeoutError("Timeout writing to socket")
         except OSError as e:
+            add_debug_log_for_connection_failure(self, e, "writing command")
             self.disconnect()
             if len(e.args) == 1:
                 errno, errmsg = "UNKNOWN", e.args[0]
@@ -1361,11 +1399,12 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                 errno = e.args[0]
                 errmsg = e.args[1]
             raise ConnectionError(f"Error {errno} while writing to socket. {errmsg}.")
-        except BaseException:
+        except BaseException as e:
             # BaseExceptions can be raised when a socket send operation is not
             # finished, e.g. due to a timeout.  Ideally, a caller could then re-try
             # to send un-sent data. However, the send_packed_command() API
             # does not support it so there is no point in keeping the connection open.
+            add_debug_log_for_connection_failure(self, e, "writing command")
             self.disconnect()
             raise
 
@@ -1416,19 +1455,31 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                 response = self._parser.read_response(
                     disable_decoding=disable_decoding, timeout=timeout
                 )
-        except socket.timeout:
+        except socket.timeout as e:
             if disconnect_on_error:
+                add_debug_log_for_connection_failure(self, e, "reading response")
+                self.disconnect()
+            raise TimeoutError(f"Timeout reading from {host_error}")
+        except TimeoutError as e:
+            # The parsers raise redis.exceptions.TimeoutError, which is not an
+            # OSError, so without this branch it would fall through to
+            # BaseException and keep the parser's undecorated message. Re-raise
+            # it with the host, matching what the async stack already reports.
+            if disconnect_on_error:
+                add_debug_log_for_connection_failure(self, e, "reading response")
                 self.disconnect()
             raise TimeoutError(f"Timeout reading from {host_error}")
         except OSError as e:
             if disconnect_on_error:
+                add_debug_log_for_connection_failure(self, e, "reading response")
                 self.disconnect()
             raise ConnectionError(f"Error while reading from {host_error} : {e.args}")
-        except BaseException:
+        except BaseException as e:
             # Also by default close in case of BaseException.  A lot of code
             # relies on this behaviour when doing Command/Response pairs.
             # See #1128.
             if disconnect_on_error:
+                add_debug_log_for_connection_failure(self, e, "reading response")
                 self.disconnect()
             raise
 
@@ -1520,16 +1571,48 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         self._socket_connect_timeout = value
 
     def extract_connection_details(self) -> str:
-        socket_address = None
+        """
+        Render the connection's identity, maintenance state and effective timeouts.
+
+        This is what the debug logs use to explain a failed or timed out command:
+
+        - ``host`` vs ``orig host`` says whether the connection still points at the
+          node being moved away from, or has already been repointed at the new one.
+        - ``state`` says whether maintenance handling touched this connection at
+          all, so an unaffected node's connections are distinguishable.
+        - ``socket_timeout`` vs ``active read timeout`` says which timeout the read
+          actually ran under. They diverge for a command that was already in flight
+          when the relaxed timeout was applied.
+        """
         if self._sock is None:
             return "not connected"
+
+        socket_address = None
+        active_read_timeout = None
         try:
-            socket_address = self._sock.getsockname() if self._sock else None
-            socket_address = socket_address[1] if socket_address else None
+            socket_name = self._sock.getsockname()
+            # AF_UNIX sockets report a path string rather than a (host, port) tuple
+            if isinstance(socket_name, tuple) and len(socket_name) > 1:
+                socket_address = socket_name[1]
+            # The timeout armed on the socket is what a blocking read is really
+            # using, which can lag self.socket_timeout for an in-flight command.
+            active_read_timeout = self._sock.gettimeout()
         except (AttributeError, OSError):
             pass
 
-        return f"connected to ip {self.get_resolved_ip()}, local socket port: {socket_address}"
+        state = getattr(self.maintenance_state, "value", self.maintenance_state)
+        return (
+            f"connected to ip {self.get_resolved_ip()}, "
+            f"local socket port: {socket_address}, "
+            f"host: {self._host_error()} "
+            f"(orig: {getattr(self, 'orig_host_address', None)}), "
+            f"state: {state}, "
+            f"socket_timeout: {self.socket_timeout} "
+            f"(orig: {getattr(self, 'orig_socket_timeout', None)}), "
+            f"active read timeout: {active_read_timeout}, "
+            f"should_reconnect: {self.should_reconnect()}, "
+            f"notification_hash: {self.maintenance_notification_hash}"
+        )
 
 
 class Connection(AbstractConnection):
@@ -2057,7 +2140,7 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
         self._conn._connect()
 
     def _host_error(self):
-        self._conn._host_error()
+        return self._conn._host_error()
 
     def _enable_tracking_callback(self, conn: ConnectionInterface) -> None:
         conn.send_command("CLIENT", "TRACKING", "ON")
@@ -2753,6 +2836,11 @@ class MaintNotificationsAbstractConnectionPool:
                     raise ValueError(
                         "Either maint_notifications_pool_handler or oss_cluster_maint_notifications_handler must be set"
                     )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "Marking active connection for reconnect after config update "
+                        f"config update: {conn}, {conn.extract_connection_details()}"
+                    )
                 conn.mark_for_reconnect()
 
     def _should_update_connection(
@@ -2911,11 +2999,17 @@ class MaintNotificationsAbstractConnectionPool:
 
         :param moving_address_src: The address of the node that is being moved.
         """
+        debug = logger.isEnabledFor(logging.DEBUG)
         with self._get_pool_lock():
             for conn in self._get_in_use_connections():
                 if self._should_update_connection(
                     conn, "connected_address", moving_address_src
                 ):
+                    if debug:
+                        logger.debug(
+                            f"Marking active connection for reconnect: {conn}, "
+                            f"{conn.extract_connection_details()}"
+                        )
                     conn.mark_for_reconnect()
 
     def disconnect_free_connections(
@@ -2928,11 +3022,17 @@ class MaintNotificationsAbstractConnectionPool:
 
         :param moving_address_src: The address of the node that is being moved.
         """
+        debug = logger.isEnabledFor(logging.DEBUG)
         with self._get_pool_lock():
             for conn in self._get_free_connections():
                 if self._should_update_connection(
                     conn, "connected_address", moving_address_src
                 ):
+                    if debug:
+                        logger.debug(
+                            f"Disconnecting free connection: {conn}, "
+                            f"{conn.extract_connection_details()}"
+                        )
                     conn.disconnect()
 
 
@@ -3448,6 +3548,11 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
 
             if self.owns_connection(connection):
                 if connection.should_reconnect():
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(
+                            "Disconnecting released connection marked for reconnect: "
+                            f"{connection}, {connection.extract_connection_details()}"
+                        )
                     connection.disconnect()
                 self._available_connections.append(connection)
                 self._event_dispatcher.dispatch(
@@ -3888,6 +3993,11 @@ class BlockingConnectionPool(ConnectionPool):
                 )
                 return
             if connection.should_reconnect():
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "Disconnecting released connection marked for reconnect: "
+                        f"{connection}, {connection.extract_connection_details()}"
+                    )
                 connection.disconnect()
             # Put the connection back into the pool.
             pool_name = get_pool_name(self)

--- a/redis/maint_notifications.py
+++ b/redis/maint_notifications.py
@@ -603,19 +603,10 @@ def add_debug_log_for_notification(
     notification: Union[str, MaintenanceNotification],
 ):
     if logger.isEnabledFor(logging.DEBUG):
-        socket_address = None
-        try:
-            socket_address = (
-                connection._sock.getsockname() if connection._sock else None
-            )
-            socket_address = socket_address[1] if socket_address else None
-        except (AttributeError, OSError):
-            pass
-
         logger.debug(
             f"Handling maintenance notification: {notification}, "
-            f"with connection: {connection}, connected to ip {connection.get_resolved_ip()}, "
-            f"local socket port: {socket_address}",
+            f"with connection: {connection}, "
+            f"{connection.extract_connection_details() if connection else 'no connection'}",
         )
 
 
@@ -650,7 +641,8 @@ class MaintNotificationsConfig:
             proactive_reconnect (bool): Whether to proactively reconnect when a node is replaced.
                 Defaults to True.
             relaxed_timeout (Number): The relaxed timeout to use for the connection during maintenance.
-                If -1 is provided - the relaxed timeout is disabled. Defaults to 20.
+                If -1 is provided - the relaxed timeout is disabled. If None is provided - the
+                affected operations become blocking. Defaults to 10.
             endpoint_type (Optional[EndpointType]): Override for the endpoint type to use in CLIENT MAINT_NOTIFICATIONS.
                 If None, the endpoint type will be automatically determined based on the host and TLS configuration.
                 Defaults to None.

--- a/tests/maint_notifications/test_connection_diagnostic_logging.py
+++ b/tests/maint_notifications/test_connection_diagnostic_logging.py
@@ -1,0 +1,447 @@
+"""Regression tests for the connection diagnostic details helper.
+
+Deliberately narrow: the debug log *wording* is not pinned here, because that
+would make every message tweak a test failure. What is pinned is the behaviour
+the logging change relies on:
+
+- `CacheProxyConnection._host_error()` returning the wrapped host (it used to
+  drop the value, rendering "Timeout reading from None").
+- `extract_connection_details()` not mangling AF_UNIX paths and not raising from
+  a failure path - it runs inside pool locks while handling errors. That includes
+  real `UnixDomainSocketConnection`s, which carry a `path` instead of a
+  `host`/`port` pair.
+- Sync/async parity of the emitted fields, which AGENTS.md requires.
+- Nothing being formatted when DEBUG is off, since these sites are on the
+  per-command path.
+"""
+
+import logging
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import redis.asyncio as redis_async
+from redis import Redis
+from redis._parsers import _RESP3Parser
+from redis._parsers.socket import SocketBuffer
+from redis.asyncio.connection import Connection as AsyncConnection
+from redis.asyncio.connection import (
+    UnixDomainSocketConnection as AsyncUnixDomainSocketConnection,
+)
+from redis.backoff import NoBackoff
+from redis.connection import (
+    CacheProxyConnection,
+    Connection,
+    ConnectionPool,
+    UnixDomainSocketConnection,
+)
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+from redis.retry import Retry
+
+LOCAL_PORT = 54321
+PEER_IP = "10.1.2.3"
+UDS_PATH = "/tmp/redis.sock"
+
+
+class FakeSock:
+    def __init__(self, sockname=("127.0.0.1", LOCAL_PORT), peername=(PEER_IP, 6379)):
+        self._sockname = sockname
+        self._peername = peername
+
+    def getsockname(self):
+        return self._sockname
+
+    def getpeername(self):
+        return self._peername
+
+    def gettimeout(self):
+        return 0.3
+
+    def close(self):
+        pass
+
+    def shutdown(self, how):
+        pass
+
+
+class FakeWriter:
+    def __init__(self, sockname=("127.0.0.1", LOCAL_PORT), peername=(PEER_IP, 6379)):
+        self._info = {"sockname": sockname, "peername": peername}
+
+    def get_extra_info(self, name):
+        return self._info.get(name)
+
+    def close(self):
+        pass
+
+
+def _sync_conn(connected=True):
+    conn = Connection(host="myhost.example.com", port=6379)
+    if connected:
+        conn._sock = FakeSock()
+    return conn
+
+
+def _async_conn(connected=True):
+    conn = AsyncConnection(host="myhost.example.com", port=6379)
+    if connected:
+        conn._writer = FakeWriter()
+    return conn
+
+
+def _sync_uds_conn(connected=True):
+    conn = UnixDomainSocketConnection(path=UDS_PATH)
+    if connected:
+        conn._sock = FakeSock(sockname=UDS_PATH, peername=UDS_PATH)
+    return conn
+
+
+def _async_uds_conn(connected=True):
+    conn = AsyncUnixDomainSocketConnection(path=UDS_PATH)
+    if connected:
+        conn._writer = FakeWriter(sockname=UDS_PATH, peername=UDS_PATH)
+    return conn
+
+
+class TestExtractConnectionDetails:
+    @pytest.mark.parametrize(
+        "factory", [_sync_conn, _async_conn, _sync_uds_conn, _async_uds_conn]
+    )
+    def test_not_connected(self, factory):
+        assert factory(connected=False).extract_connection_details() == "not connected"
+
+    def test_field_layout_matches_across_stacks(self):
+        """Same fields, same order, same values - except the one that cannot match.
+
+        `active read timeout` legitimately differs: sync reads the deadline armed
+        on the socket, async only has one while a read is actually in flight.
+        """
+
+        def parts(details):
+            return [p for p in details.split(", ") if not p.startswith("active read")]
+
+        sync_details = _sync_conn().extract_connection_details()
+        async_details = _async_conn().extract_connection_details()
+        assert "active read timeout" in sync_details
+        assert "active read timeout" in async_details
+        assert parts(sync_details) == parts(async_details)
+
+    def test_sync_unix_socket_path_is_not_sliced_into_a_port(self):
+        """AF_UNIX reports a path string; indexing it yielded a bogus port char."""
+        conn = _sync_conn(connected=False)
+        conn._sock = FakeSock(sockname="/tmp/redis.sock", peername="/tmp/redis.sock")
+        assert "local socket port: None" in conn.extract_connection_details()
+
+    def test_async_unix_socket_path_is_not_sliced_into_a_port(self):
+        conn = _async_conn(connected=False)
+        conn._writer = FakeWriter(
+            sockname="/tmp/redis.sock", peername="/tmp/redis.sock"
+        )
+        assert "local socket port: None" in conn.extract_connection_details()
+
+    @pytest.mark.parametrize("factory", [_sync_uds_conn, _async_uds_conn])
+    def test_unix_domain_socket_details_do_not_raise(self, factory):
+        """A UDS connection has no `host`/`port`; rendering used to raise.
+
+        The helper runs on every command failure path before `disconnect()`, so
+        raising here replaced the real TimeoutError/ConnectionError with an
+        AttributeError and left the connection open.
+        """
+        details = factory().extract_connection_details()
+        assert UDS_PATH in details
+        assert "local socket port: None" in details
+        # AF_UNIX getpeername() returns the path, not a (host, port) tuple.
+        assert "connected to ip None" in details
+
+    def test_unix_domain_socket_field_layout_matches_across_stacks(self):
+        def parts(details):
+            return [p for p in details.split(", ") if not p.startswith("active read")]
+
+        assert parts(_sync_uds_conn().extract_connection_details()) == parts(
+            _async_uds_conn().extract_connection_details()
+        )
+
+    def test_sync_does_not_raise_when_getsockname_fails(self):
+        conn = _sync_conn(connected=False)
+        sock = FakeSock()
+        sock.getsockname = MagicMock(side_effect=OSError("boom"))
+        conn._sock = sock
+        assert "local socket port: None" in conn.extract_connection_details()
+
+    def test_async_does_not_raise_when_get_extra_info_fails(self):
+        conn = _async_conn(connected=False)
+        writer = FakeWriter()
+        writer.get_extra_info = MagicMock(side_effect=OSError("boom"))
+        conn._writer = writer
+        assert "local socket port: None" in conn.extract_connection_details()
+
+
+class TestDebugGating:
+    """These sites are on the per-command path; nothing may be built when off."""
+
+    def test_command_failure_logs_nothing_when_debug_disabled(self, caplog):
+        client = Redis(
+            host="myhost.example.com", port=6379, retry=Retry(NoBackoff(), 0)
+        )
+        conn = _sync_conn()
+        pool = client.connection_pool
+        error = RedisTimeoutError("Timeout reading from myhost.example.com:6379")
+        with (
+            caplog.at_level(logging.INFO, logger="redis.client"),
+            patch.object(pool, "get_connection", return_value=conn),
+            patch.object(pool, "release"),
+            patch.object(conn, "send_command", side_effect=error),
+        ):
+            with pytest.raises(RedisTimeoutError):
+                client.get("mykey")
+
+        assert caplog.records == []
+
+    def test_pool_logs_nothing_when_debug_disabled(self, caplog):
+        pool = ConnectionPool(
+            host="myhost.example.com", port=6379, connection_class=Connection
+        )
+        pool._in_use_connections.add(_sync_conn())
+        pool._available_connections.append(_sync_conn())
+        with caplog.at_level(logging.INFO, logger="redis.connection"):
+            pool.update_active_connections_for_reconnect()
+            pool.disconnect_free_connections()
+
+        assert caplog.records == []
+
+    @pytest.mark.asyncio
+    async def test_async_pool_logs_nothing_when_debug_disabled(self, caplog):
+        pool = redis_async.ConnectionPool(
+            host="myhost.example.com", port=6379, connection_class=AsyncConnection
+        )
+        pool._in_use_connections.add(_async_conn())
+        with caplog.at_level(logging.INFO, logger="redis.asyncio.connection"):
+            await pool._run_proactive_reconnect_without_locking()
+
+        assert caplog.records == []
+
+
+class TestHostErrorRegression:
+    def test_cache_proxy_connection_reports_the_wrapped_host(self):
+        """It used to drop the return value, rendering 'Timeout reading from None'."""
+        conn = _sync_conn()
+        proxy = CacheProxyConnection(conn, MagicMock(), threading.RLock())
+        assert proxy._host_error() == "myhost.example.com:6379"
+
+
+class _FailingWriteSock(FakeSock):
+    """A FakeSock whose sendall() fails the way a dropped peer would."""
+
+    def sendall(self, data):
+        raise OSError(32, "Broken pipe")
+
+
+class _RetimeableSock(FakeSock):
+    """A FakeSock whose timeout can actually be armed and read back."""
+
+    def __init__(self, timeout):
+        super().__init__()
+        self._timeout = timeout
+
+    def gettimeout(self):
+        return self._timeout
+
+    def settimeout(self, value):
+        self._timeout = value
+
+
+class TestFailureDetailsSurviveTheFailurePath:
+    """The failure path closes the socket, so the details must be rendered first.
+
+    Before this, `extract_connection_details()` ran only after `disconnect()`
+    had already cleared the socket, so every timed out or failed command was
+    reported as `details: not connected` - losing the resolved ip, local port
+    and the timeout the read actually ran under.
+    """
+
+    def test_sync_read_failure_logs_live_socket_state(self, caplog):
+        conn = _sync_conn()
+        conn._parser = MagicMock()
+        conn._parser.read_response.side_effect = RedisTimeoutError(
+            "Timeout reading from socket"
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="redis.connection"):
+            with pytest.raises(RedisTimeoutError):
+                conn.read_response()
+
+        # the failure path still tears the socket down ...
+        assert conn._sock is None
+        # ... but the details were captured while it was alive.
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(f"local socket port: {LOCAL_PORT}" in m for m in messages)
+        assert any(f"connected to ip {PEER_IP}" in m for m in messages)
+        assert not any("not connected" in m for m in messages)
+
+    def test_sync_write_failure_logs_live_socket_state(self, caplog):
+        conn = _sync_conn()
+        conn._parser = MagicMock()
+        conn._sock = _FailingWriteSock()
+
+        with caplog.at_level(logging.DEBUG, logger="redis.connection"):
+            with pytest.raises(RedisConnectionError):
+                conn.send_packed_command([b"PING\r\n"], check_health=False)
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(f"local socket port: {LOCAL_PORT}" in m for m in messages)
+        assert not any("not connected" in m for m in messages)
+
+    @pytest.mark.asyncio
+    async def test_async_read_failure_logs_live_transport_state(self, caplog):
+        conn = _async_conn()
+        # is_connected() needs both halves, otherwise disconnect() returns early
+        # and would leave the writer in place regardless of ordering.
+        conn._reader = MagicMock()
+
+        with (
+            caplog.at_level(logging.DEBUG, logger="redis.asyncio.connection"),
+            patch.object(
+                conn,
+                "_read_response_from_parser",
+                new=AsyncMock(side_effect=OSError("boom")),
+            ),
+        ):
+            with pytest.raises(RedisConnectionError):
+                await conn.read_response()
+
+        assert conn._writer is None
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(f"local socket port: {LOCAL_PORT}" in m for m in messages)
+        assert not any("not connected" in m for m in messages)
+
+    def test_read_failure_renders_nothing_when_debug_disabled(self, caplog):
+        """This is the per-command path; the details must not even be built."""
+        conn = _sync_conn()
+        conn._parser = MagicMock()
+        conn._parser.read_response.side_effect = RedisTimeoutError("boom")
+
+        with (
+            caplog.at_level(logging.INFO, logger="redis.connection"),
+            patch.object(
+                Connection,
+                "extract_connection_details",
+                side_effect=AssertionError("rendered while DEBUG was off"),
+            ),
+        ):
+            with pytest.raises(RedisTimeoutError):
+                conn.read_response()
+
+        assert caplog.records == []
+
+
+class TestParserTimeoutIsReraisedWithTheHost:
+    """The parsers raise redis TimeoutError, which is not an OSError.
+
+    It therefore missed both typed branches in `read_response` and fell through
+    to `except BaseException`, keeping the parser's undecorated
+    "Timeout reading from socket". Async already reported the host, because its
+    deadline surfaces as asyncio.TimeoutError.
+    """
+
+    def test_sync_timeout_message_carries_the_host(self):
+        conn = _sync_conn()
+        conn._parser = MagicMock()
+        conn._parser.read_response.side_effect = RedisTimeoutError(
+            "Timeout reading from socket"
+        )
+
+        with pytest.raises(RedisTimeoutError, match="myhost.example.com:6379"):
+            conn.read_response()
+
+    def test_sync_timeout_still_disconnects(self):
+        conn = _sync_conn()
+        conn._parser = MagicMock()
+        conn._parser.read_response.side_effect = RedisTimeoutError("boom")
+
+        with pytest.raises(RedisTimeoutError):
+            conn.read_response()
+        assert conn._sock is None
+
+    def test_sync_timeout_does_not_disconnect_when_opted_out(self):
+        conn = _sync_conn()
+        conn._parser = MagicMock()
+        conn._parser.read_response.side_effect = RedisTimeoutError("boom")
+
+        with pytest.raises(RedisTimeoutError):
+            conn.read_response(disconnect_on_error=False)
+        assert conn._sock is not None
+
+
+class TestRelaxedTimeoutStaysConsistent:
+    """The parser caches the timeout to restore after a per-call override.
+
+    So while a can_read() probe holds the socket at 0, that cache is the pending
+    restore value and has to be updated even though the socket must not be: it
+    is what arms the new timeout for the reads that follow the probe.
+    """
+
+    def test_parser_is_updated_while_socket_is_non_blocking(self):
+        conn = _sync_conn()
+        conn._sock = _RetimeableSock(0)
+
+        with patch.object(Connection, "update_parser_timeout") as update_parser:
+            conn.update_current_socket_timeout(30)
+
+        # a 0 timeout means a can_read() probe is in progress - leave the socket
+        # alone, but still arm the value the probe will restore.
+        assert conn._sock.gettimeout() == 0
+        update_parser.assert_called_once_with(30)
+
+    def test_relaxation_arriving_during_can_read_survives_the_probe(self):
+        """
+        Regression: a maintenance relaxation raced against a can_read() probe.
+
+        The probe arms timeout 0 on the socket and restores the parser's cached
+        value when it finishes. A relaxation that lands inside that window can
+        not touch the socket - that would turn a non-blocking read blocking -
+        so if it skips the parser too, the probe restores the pre-relaxation
+        timeout and the connection never sees the relaxed maintenance deadline.
+        """
+        conn = _sync_conn()
+        conn._sock = _RetimeableSock(1)
+        parser = _RESP3Parser(socket_read_size=8192)
+        parser._buffer = SocketBuffer(conn._sock, 8192, 1)
+        conn._parser = parser
+
+        # A can_read(0) probe: arm the non-blocking timeout the way
+        # SocketBuffer._read_from_socket does for a per-call override.
+        conn._sock.settimeout(0)
+        try:
+            # Maintenance relaxes the pool while the probe is in flight.
+            conn.update_current_socket_timeout(30)
+            assert conn._sock.gettimeout() == 0, "the probe must stay non-blocking"
+        finally:
+            # The probe's finally clause restores from the parser's cache.
+            conn._sock.settimeout(parser._buffer.socket_timeout)
+
+        assert conn._sock.gettimeout() == 30
+
+    def test_parser_follows_the_socket_when_blocking(self):
+        conn = _sync_conn()
+        conn._sock = _RetimeableSock(1)
+
+        with patch.object(Connection, "update_parser_timeout") as update_parser:
+            conn.update_current_socket_timeout(30)
+
+        assert conn._sock.gettimeout() == 30
+        update_parser.assert_called_once_with(30)
+
+    def test_resp3_parser_receives_a_none_timeout(self):
+        """None means "block indefinitely"; the RESP3 branch used to drop it."""
+        conn = _sync_conn()
+        conn._sock = _RetimeableSock(1)
+        parser = _RESP3Parser(socket_read_size=8192)
+        parser._buffer = SocketBuffer(conn._sock, 8192, 1)
+        conn._parser = parser
+
+        conn.update_current_socket_timeout(None)
+
+        assert conn._sock.gettimeout() is None
+        assert parser._buffer.socket_timeout is None

--- a/tests/test_asyncio/test_scenario/test_maint_notifications.py
+++ b/tests/test_asyncio/test_scenario/test_maint_notifications.py
@@ -5,7 +5,7 @@ import json
 import logging
 import random
 import time
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 import pytest
 import pytest_asyncio
@@ -53,18 +53,70 @@ logging.basicConfig(
 
 logging.getLogger("redis.asyncio.maint_notifications").setLevel(logging.DEBUG)
 logging.getLogger("redis.asyncio.cluster").setLevel(logging.DEBUG)
+logging.getLogger("redis.asyncio.client").setLevel(logging.DEBUG)
+logging.getLogger("redis.asyncio.connection").setLevel(logging.DEBUG)
 
 STANDALONE_MAINT_TIMEOUT = 60
-SLOT_SHUFFLE_TIMEOUT = 120
-SMIGRATING_TIMEOUT = 20
-SMIGRATED_TIMEOUT = 40
+
+SMIGRATED_TIMEOUT = 120
+SLOT_SHUFFLE_TIMEOUT = 300
+RESHARD_SMIGRATING_TIMEOUT = int(SLOT_SHUFFLE_TIMEOUT / 2)
+RESHARD_OP_TIMEOUT = 600
+DEFAULT_TRIGGER_OP_TIMEOUT = 180
+RESHARD_TEST_TIMEOUT = RESHARD_OP_TIMEOUT + SMIGRATED_TIMEOUT + 180
 
 DEFAULT_BIND_TTL = 15
 DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT = 1
 DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT = 1
 
+# The fault injector's create_database can fail on transient cluster-side infrastructure
+# problems - a DNS blip while it polls the cluster REST API, for example - that say nothing
+# about the client under test. Retrying the setup keeps such a blip from being reported as a
+# test failure.
+DB_CREATE_ATTEMPTS = 3
+
 
 class TestAsyncPushNotificationsBase:
+    def _drain_command_errors(self, errors, source: str) -> list[str]:
+        """Drain and log the collected command errors without failing yet.
+
+        Callers that also await the trigger task or assert on connection state
+        must drain *before* that: otherwise the first of those raises and the
+        command errors - usually the more informative signal - are never
+        reported.
+
+        Every error is logged individually: pytest truncates long assertion
+        messages, so a run with many failures would otherwise hide most of them
+        behind "...Full output truncated".
+        """
+        collected = []
+        while not errors.empty():
+            collected.append(errors.get_nowait())
+        if collected:
+            logging.error(f"{len(collected)} error(s) collected from {source}:")
+            for index, error in enumerate(collected, start=1):
+                logging.error(f"  [{index}/{len(collected)}] {error}")
+        return collected
+
+    def _fail_on_collected_command_errors(self, collected: list[str], source: str):
+        """Fail on errors already drained by ``_drain_command_errors``.
+
+        The failure message keeps a short preview and points at the log for the
+        rest.
+        """
+        if not collected:
+            return
+        preview = "; ".join(collected[:5])
+        if len(collected) > 5:
+            preview += f"; ... ({len(collected) - 5} more, see the log above)"
+        pytest.fail(f"{len(collected)} error(s) occurred in {source}: {preview}")
+
+    def _fail_on_command_errors(self, errors, source: str):
+        """Drain the collected command errors and fail with all of them printed."""
+        self._fail_on_collected_command_errors(
+            self._drain_command_errors(errors, source), source
+        )
+
     async def _get_all_connections_in_pool(self, client: Redis) -> List:
         connections = []
         async with client.connection_pool._get_pool_lock():
@@ -136,6 +188,7 @@ class TestAsyncPushNotificationsBase:
         configured_timeout: float = CLIENT_TIMEOUT,
     ):
         matching_conns_count = 0
+        mismatched: list[str] = []
         connections = await self._get_all_connections_in_pool(client)
         logging.info(f"Validating {len(connections)} connections")
 
@@ -148,13 +201,14 @@ class TestAsyncPushNotificationsBase:
                 ):
                     matching_conns_count += 1
                 else:
-                    logging.debug(
-                        f"Connection not matching default state: "
-                        f"maintenance_state={conn.maintenance_state}, "
-                        f"socket_timeout={conn.socket_timeout}, "
-                        f"host={conn.host}, "
-                        f"orig_host_address={getattr(conn, 'orig_host_address', None)}"
+                    detail = (
+                        f"{conn}: maintenance_state={conn.maintenance_state}, "
+                        f"socket_timeout={conn.socket_timeout}, host={conn.host}, "
+                        f"orig_host_address={getattr(conn, 'orig_host_address', None)}, "
+                        f"{conn.extract_connection_details()}"
                     )
+                    mismatched.append(detail)
+                    logging.debug(f"Connection not matching default state: {detail}")
             elif (
                 conn.socket_timeout == configured_timeout
                 and conn.maintenance_state == MaintenanceState.NONE
@@ -162,13 +216,14 @@ class TestAsyncPushNotificationsBase:
             ):
                 matching_conns_count += 1
             else:
-                logging.debug(
-                    f"Connection not matching default state: "
-                    f"maintenance_state={conn.maintenance_state}, "
-                    f"socket_timeout={conn.socket_timeout}, "
-                    f"host={conn.host}, "
-                    f"orig_host_address={getattr(conn, 'orig_host_address', None)}"
+                detail = (
+                    f"{conn}: maintenance_state={conn.maintenance_state}, "
+                    f"socket_timeout={conn.socket_timeout}, host={conn.host}, "
+                    f"orig_host_address={getattr(conn, 'orig_host_address', None)}, "
+                    f"{conn.extract_connection_details()}"
                 )
+                mismatched.append(detail)
+                logging.debug(f"Connection not matching default state: {detail}")
 
         conn_kwargs = client.connection_pool.connection_kwargs
         client_host = conn_kwargs.get("host", "unknown")
@@ -182,7 +237,8 @@ class TestAsyncPushNotificationsBase:
             f"Client: host={client_host}, port={client_port}, "
             f"configured_timeout={configured_timeout}. "
             f"Expected {expected_matching_conns_count} matching connections, "
-            f"but found {matching_conns_count} out of {len(connections)} total connections."
+            f"but found {matching_conns_count} out of {len(connections)} total connections. "
+            f"Non-matching connections: {'; '.join(mismatched) if mismatched else 'none'}"
         )
 
     async def _validate_default_notif_disabled_state(
@@ -222,7 +278,10 @@ class TestAsyncPushNotificationsBase:
                 logging.info(f"Deleted database: {db_name}")
             else:
                 logging.info(f"Database {db_name} does not exist.")
-        except Exception as e:
+        # _get_cluster_nodes_info reports failures through pytest.fail, which does not
+        # derive from Exception - catch it too, so deleting a leftover DB stays best
+        # effort and never aborts the caller.
+        except (Exception, pytest.fail.Exception) as e:
             logging.error(f"Failed to delete database {db_name}: {e}")
 
     async def create_db(
@@ -230,14 +289,28 @@ class TestAsyncPushNotificationsBase:
         fault_injector_client: AsyncFaultInjectorClient,
         bdb_config: Dict[str, Any],
     ):
-        try:
-            logging.info(f"Creating database: \n{json.dumps(bdb_config, indent=2)}")
-            cluster_endpoint_config = await fault_injector_client.create_database(
-                bdb_config
-            )
-            return cluster_endpoint_config
-        except Exception as e:
-            pytest.fail(f"Failed to create database: {e}")
+        """Create the test database, retrying transient infrastructure failures.
+
+        A create that fails midway can still leave the BDB on the cluster, so any
+        leftover is deleted by name before the next attempt - otherwise the retry
+        collides with it on the fixed port from the config.
+        """
+        logging.info(f"Creating database: \n{json.dumps(bdb_config, indent=2)}")
+        for attempt in range(1, DB_CREATE_ATTEMPTS + 1):
+            try:
+                return await fault_injector_client.create_database(bdb_config)
+            # get_operation_result reports a failed action through pytest.fail, which
+            # does not derive from Exception.
+            except (Exception, pytest.fail.Exception) as e:
+                if attempt == DB_CREATE_ATTEMPTS:
+                    pytest.fail(
+                        f"Failed to create database after {attempt} attempts: {e}"
+                    )
+                logging.warning(
+                    f"Attempt {attempt}/{DB_CREATE_ATTEMPTS} to create database "
+                    f"{bdb_config['name']} failed: {e}"
+                )
+                await self.delete_prev_db(fault_injector_client, bdb_config["name"])
 
     async def _trigger_effect(
         self,
@@ -248,7 +321,7 @@ class TestAsyncPushNotificationsBase:
         target_node: Optional[str] = None,
         empty_node: Optional[str] = None,
         skip_end_notification: bool = False,
-        timeout: int = SLOT_SHUFFLE_TIMEOUT,
+        timeout: int = DEFAULT_TRIGGER_OP_TIMEOUT,
     ):
         action_id = await fault_injector_client.trigger_effect(
             endpoint_config=endpoints_config,
@@ -277,8 +350,9 @@ class TestAsyncStandaloneClientPushNotificationsWithEffectTriggerBase(
         self._fault_injector = fault_injector_client
         await self.delete_prev_db(fault_injector_client, db_config["name"])
 
-        db_endpoint_config = await self.create_db(fault_injector_client, db_config)
+        # Recorded before the create so teardown removes a partially created DB.
         self._bdb_name = db_config["name"]
+        db_endpoint_config = await self.create_db(fault_injector_client, db_config)
 
         auth_ssl_client_certs_config_info = db_config.get(
             "authentication_ssl_client_certs", None
@@ -877,10 +951,7 @@ class TestAsyncStandaloneClientPushNotificationsHandlingWithEffectTrigger(
                     assert conn.host != conn.orig_host_address
                 assert not conn.should_reconnect()
 
-        error_items = []
-        while not errors.empty():
-            error_items.append(errors.get_nowait())
-        assert not error_items, f"Errors occurred in tasks: {error_items}"
+        self._fail_on_command_errors(errors, "command execution tasks")
 
         await trigger_task
         self.maintenance_ops_tasks.remove(trigger_task)
@@ -1020,8 +1091,9 @@ class TestAsyncStandaloneClientPushNotificationsHandlingWithEffectTrigger(
 
         self._fault_injector = fault_injector_client
         await self.delete_prev_db(fault_injector_client, db_config["name"])
-        db_endpoint_config = await self.create_db(fault_injector_client, db_config)
+        # Recorded before the create so teardown removes a partially created DB.
         self._bdb_name = db_config["name"]
+        db_endpoint_config = await self.create_db(fault_injector_client, db_config)
 
         logging.info("Creating client with disabled notifications.")
         self._client = client = get_async_standalone_client_maint_notifications(
@@ -1112,6 +1184,8 @@ class TestAsyncStandaloneClientPushNotificationsHandlingWithEffectTrigger(
 class TestAsyncStandaloneClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
     TestAsyncStandaloneClientPushNotificationsWithEffectTriggerBase
 ):
+    # TODO: re-enable TopologyChangeStandaloneEffects.DNS_RESOLUTION_CHANGE once the
+    # effect is troubleshooted and fixed.
     @pytest.mark.timeout(300)
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name, endpoint_type",
@@ -1121,7 +1195,7 @@ class TestAsyncStandaloneClientCommandsExecutionWithPushNotificationsWithEffectT
                 TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP,
                 TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP,
                 TopologyChangeStandaloneEffects.CONN_DROP,
-                TopologyChangeStandaloneEffects.DNS_RESOLUTION_CHANGE,
+                # TopologyChangeStandaloneEffects.DNS_RESOLUTION_CHANGE,
             ],
             endpoint_types=[
                 EndpointType.EXTERNAL_FQDN,
@@ -1191,19 +1265,26 @@ class TestAsyncStandaloneClientCommandsExecutionWithPushNotificationsWithEffectT
 
         await asyncio.gather(*tasks)
 
+        # Drain first so the command errors are logged even if awaiting the
+        # trigger task or the state assertion below raises.
+        collected_errors = self._drain_command_errors(errors, "command execution tasks")
+
         await trigger_task
         self.maintenance_ops_tasks.remove(trigger_task)
 
+        # "all" rather than a hard-coded 10: the pool size is emergent from the
+        # task count, so pinning the number fails on an extra connection even
+        # when every connection is in the expected state - and passes when one
+        # of eleven is not.
         await self._validate_default_state(
             client,
-            expected_matching_conns_count=10,
+            expected_matching_conns_count="all",
             configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
         )
 
-        error_items = []
-        while not errors.empty():
-            error_items.append(errors.get_nowait())
-        assert not error_items, f"Errors occurred in tasks: {error_items}"
+        self._fail_on_collected_command_errors(
+            collected_errors, "command execution tasks"
+        )
 
 
 class TestAsyncClusterClientPushNotificationsWithEffectTriggerBase(
@@ -1217,8 +1298,9 @@ class TestAsyncClusterClientPushNotificationsWithEffectTriggerBase(
         self._fault_injector = fault_injector_client
         await self.delete_prev_db(fault_injector_client, db_config["name"])
 
-        cluster_endpoint_config = await self.create_db(fault_injector_client, db_config)
+        # Recorded before the create so teardown removes a partially created DB.
         self._bdb_name = db_config["name"]
+        cluster_endpoint_config = await self.create_db(fault_injector_client, db_config)
 
         socket_timeout = DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT
         socket_connect_timeout = DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT
@@ -1274,6 +1356,57 @@ class TestAsyncClusterClientPushNotificationsWithEffectTriggerBase(
             await asyncio.gather(*tasks, return_exceptions=True)
         await asyncio.sleep(0)
 
+    async def _wait_for_node_cache_reconciliation(
+        self,
+        client: RedisCluster,
+        connections: List,
+        is_reconciled: Callable[[Dict[str, Any]], bool],
+        description: str,
+        timeout: int = SMIGRATED_TIMEOUT,
+    ):
+        """Drain pending notifications until the client node cache reconciles.
+
+        Async counterpart of the sync suite's ``_wait_for_node_cache_delta``,
+        generalized to a predicate over the node cache so it also covers the
+        net-zero node-replace case (one node removed and one added leaves the
+        cache size unchanged).
+
+        A topology change may arrive as several push notifications - in particular an
+        ASM scale add/remove is a cascade of SMIGRATING/SMIGRATED as the decision
+        engine moves slots - so the client reconciles its node cache over multiple
+        notifications after the server-side operation finishes. Reading a single
+        SMIGRATED frame off a single connection is therefore not enough; poll,
+        draining pending pushes on the given connections, until ``is_reconciled``
+        holds. Single-step triggers (migrate/failover) reach the target immediately
+        and return on the first check.
+
+        Draining pushes alone is not sufficient in the async client: SMIGRATED
+        handling is scheduled as a background task instead of completing inline while
+        reading the command response, so every round also drains those tasks.
+        """
+        deadline = time.time() + timeout
+        while True:
+            await self._drain_maint_notification_tasks(client)
+            if is_reconciled(client.nodes_manager.nodes_cache):
+                return
+            if time.time() >= deadline:
+                break
+            for conn in connections:
+                try:
+                    if conn.is_connected and await conn.can_read():
+                        await conn.read_response(push_request=True)
+                except Exception as e:
+                    # A connection to a node being removed may error; that is expected.
+                    logging.debug(f"Ignored error while draining notifications: {e}")
+            await asyncio.sleep(0.5)
+        # Fail explicitly on a drain timeout so it surfaces as a clear "node cache did
+        # not reconcile" error, rather than silently returning and letting the caller's
+        # exact assertion fail later with a misleading node-count message.
+        pytest.fail(
+            f"Node cache did not reconcile ({description}) within {timeout}s; "
+            f"current nodes={sorted(client.nodes_manager.nodes_cache)}"
+        )
+
     @pytest_asyncio.fixture(autouse=True)
     async def setup_and_cleanup(self):
         self.maintenance_ops_tasks = []
@@ -1301,7 +1434,9 @@ class TestAsyncClusterClientPushNotificationsWithEffectTriggerBase(
 class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
     TestAsyncClusterClientPushNotificationsWithEffectTriggerBase
 ):
-    @pytest.mark.timeout(300)
+    @pytest.mark.timeout(
+        RESHARD_TEST_TIMEOUT
+    )  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1336,6 +1471,7 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
                 cluster_endpoint_config,
                 effect_name,
                 trigger,
+                timeout=RESHARD_OP_TIMEOUT,
             )
         )
         self.maintenance_ops_tasks.append(trigger_task)
@@ -1344,7 +1480,7 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
         for conn in in_use_connections.values():
             await AsyncClientValidations.wait_push_notification(
                 client,
-                timeout=int(SLOT_SHUFFLE_TIMEOUT / 2),
+                timeout=RESHARD_SMIGRATING_TIMEOUT,
                 connection=conn,
             )
 
@@ -1395,7 +1531,9 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
         await trigger_task
         self.maintenance_ops_tasks.remove(trigger_task)
 
-    @pytest.mark.timeout(300)
+    @pytest.mark.timeout(
+        RESHARD_TEST_TIMEOUT
+    )  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1431,6 +1569,7 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
                 cluster_endpoint_config,
                 effect_name,
                 trigger,
+                timeout=RESHARD_OP_TIMEOUT,
             )
         )
         self.maintenance_ops_tasks.append(trigger_task)
@@ -1439,7 +1578,7 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
         for conn in in_use_connections.values():
             await AsyncClientValidations.wait_push_notification(
                 client,
-                timeout=SMIGRATING_TIMEOUT,
+                timeout=RESHARD_SMIGRATING_TIMEOUT,
                 connection=conn,
             )
 
@@ -1458,7 +1597,19 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
             timeout=SMIGRATED_TIMEOUT,
             connection=con_to_read_smigrated,
         )
-        await self._drain_maint_notification_tasks(client)
+        logging.info("Waiting for the operation to finish server-side...")
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+        logging.info("Draining notifications until one node has been replaced...")
+        initial_nodes = set(initial_cluster_nodes.values())
+        await self._wait_for_node_cache_reconciliation(
+            client,
+            list(in_use_connections.values()),
+            lambda cache: len(initial_nodes - set(cache.values())) == 1
+            and len(set(cache.values()) - initial_nodes) == 1,
+            "expected exactly one node removed and one added",
+        )
 
         logging.info("Validating connection state after SMIGRATED ...")
         updated_cluster_nodes = client.nodes_manager.nodes_cache.copy()
@@ -1485,10 +1636,9 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
         for node, conn in in_use_connections.items():
             node.release(conn)
 
-        await trigger_task
-        self.maintenance_ops_tasks.remove(trigger_task)
-
-    @pytest.mark.timeout(300)
+    @pytest.mark.timeout(
+        RESHARD_TEST_TIMEOUT
+    )  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1524,6 +1674,7 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
                 cluster_endpoint_config,
                 effect_name,
                 trigger,
+                timeout=RESHARD_OP_TIMEOUT,
             )
         )
         self.maintenance_ops_tasks.append(trigger_task)
@@ -1532,7 +1683,7 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
         for conn in in_use_connections.values():
             await AsyncClientValidations.wait_push_notification(
                 client,
-                timeout=int(SLOT_SHUFFLE_TIMEOUT / 2),
+                timeout=RESHARD_SMIGRATING_TIMEOUT,
                 connection=conn,
             )
 
@@ -1551,7 +1702,18 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
             timeout=SMIGRATED_TIMEOUT,
             connection=con_to_read_smigrated,
         )
-        await self._drain_maint_notification_tasks(client)
+        logging.info("Waiting for the operation to finish server-side...")
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+        logging.info("Draining notifications until the node cache reflects -1 node...")
+        expected_node_count = len(initial_cluster_nodes) - 1
+        await self._wait_for_node_cache_reconciliation(
+            client,
+            list(in_use_connections.values()),
+            lambda cache: len(cache) == expected_node_count,
+            f"expected {expected_node_count} nodes, one fewer than at start",
+        )
 
         logging.info("Validating connection state after SMIGRATED ...")
         updated_cluster_nodes = client.nodes_manager.nodes_cache.copy()
@@ -1583,14 +1745,13 @@ class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
         for node, conn in in_use_connections.items():
             node.release(conn)
 
-        await trigger_task
-        self.maintenance_ops_tasks.remove(trigger_task)
-
 
 class TestAsyncClusterClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
     TestAsyncClusterClientPushNotificationsWithEffectTriggerBase
 ):
-    @pytest.mark.timeout(300)
+    @pytest.mark.timeout(
+        RESHARD_TEST_TIMEOUT
+    )  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1691,6 +1852,7 @@ class TestAsyncClusterClientCommandsExecutionWithPushNotificationsWithEffectTrig
                 cluster_endpoint_config,
                 effect_name,
                 trigger,
+                timeout=RESHARD_OP_TIMEOUT,
             )
         )
         self.maintenance_ops_tasks.append(trigger_task)
@@ -1737,7 +1899,4 @@ class TestAsyncClusterClientCommandsExecutionWithPushNotificationsWithEffectTrig
             logging.info(f"Consumed all buffers for node: {node.name}")
         logging.info("All buffers consumed.")
 
-        error_items = []
-        while not errors.empty():
-            error_items.append(errors.get_nowait())
-        assert not error_items, f"Errors occurred in tasks: {error_items}"
+        self._fail_on_command_errors(errors, "command execution tasks")

--- a/tests/test_scenario/maint_notifications_helpers.py
+++ b/tests/test_scenario/maint_notifications_helpers.py
@@ -352,7 +352,18 @@ def generate_params(
                             )
                     else:
                         params.append((effect_name, trigger, dbconfig, db_name_pattern))
+    except NotImplementedError as e:
+        # Not every backend implements every effect - the mock proxy server
+        # rejects the topology-change triggers outright - so an empty
+        # parametrization is the correct outcome rather than a failure.
+        logging.info(f"No params for test, unsupported by this fault injector: {e}")
     except Exception as e:
         logging.error(f"Failed to extract params for test: {e}")
+        if not params:
+            # Partial results are still worth running, but an *empty*
+            # parametrization makes pytest report success while having executed
+            # nothing at all. A fault injector that is unreachable or rejecting
+            # requests has to surface as a collection error instead.
+            raise
 
     return params

--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -51,6 +51,8 @@ logging.basicConfig(
 # Set DEBUG level for specific redis-py loggers
 logging.getLogger("redis.maint_notifications").setLevel(logging.DEBUG)
 logging.getLogger("redis.cluster").setLevel(logging.DEBUG)
+logging.getLogger("redis.client").setLevel(logging.DEBUG)
+logging.getLogger("redis.connection").setLevel(logging.DEBUG)
 
 
 STANDALONE_MAINT_TIMEOUT = 60
@@ -87,12 +89,76 @@ DEFAULT_BIND_TTL = 15
 DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT = 1
 DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT = 1
 
+# The fault injector's create_database can fail on transient cluster-side infrastructure
+# problems - a DNS blip while it polls the cluster REST API, for example - that say nothing
+# about the client under test. Retrying the setup keeps such a blip from being reported as a
+# test failure.
+DB_CREATE_ATTEMPTS = 3
+
 
 class TestPushNotificationsBase:
     """
     Test Redis Enterprise maintenance push notifications with real cluster
     operations.
     """
+
+    @pytest.fixture(autouse=True)
+    def _reset_trigger_effect_failures(self):
+        """Per-test store for failures raised inside the FI trigger thread."""
+        self._trigger_effect_failures: list[str] = []
+        yield
+
+    def _drain_command_errors(self, errors, source: str) -> list[str]:
+        """Drain and log the collected command errors without failing yet.
+
+        Callers that also assert on connection state must drain *before* that
+        assertion: otherwise a state mismatch raises first and the command
+        errors - usually the more informative signal - are never reported.
+
+        Every error is logged individually: pytest truncates long assertion
+        messages, so a run with many failures would otherwise hide most of them
+        behind "...Full output truncated".
+        """
+        collected = []
+        while not errors.empty():
+            collected.append(errors.get_nowait())
+        if collected:
+            logging.error(f"{len(collected)} error(s) collected from {source}:")
+            for index, error in enumerate(collected, start=1):
+                logging.error(f"  [{index}/{len(collected)}] {error}")
+        return collected
+
+    def _fail_on_collected_command_errors(self, collected: list[str], source: str):
+        """Fail on errors already drained by ``_drain_command_errors``.
+
+        The failure message keeps a short preview and points at the log for the
+        rest.
+        """
+        if not collected:
+            return
+        preview = "; ".join(collected[:5])
+        if len(collected) > 5:
+            preview += f"; ... ({len(collected) - 5} more, see the log above)"
+        pytest.fail(f"{len(collected)} error(s) occurred in {source}: {preview}")
+
+    def _fail_on_command_errors(self, errors, source: str):
+        """Drain the collected command errors and fail with all of them printed."""
+        self._fail_on_collected_command_errors(
+            self._drain_command_errors(errors, source), source
+        )
+
+    def _fail_on_trigger_effect_failures(self):
+        """Surface a failure raised inside the FI trigger thread.
+
+        ``pytest.fail()`` on a spawned thread only kills that thread - it does
+        not fail the test - so the main thread has to re-report it after join().
+        """
+        failures = self._trigger_effect_failures
+        if not failures:
+            return
+        pytest.fail(
+            f"{len(failures)} failure(s) in the trigger thread: {'; '.join(failures)}"
+        )
 
     def delete_prev_db(
         self,
@@ -111,7 +177,10 @@ class TestPushNotificationsBase:
                 logging.info(f"Deleted database: {db_name}")
             else:
                 logging.info(f"Database {db_name} does not exist.")
-        except Exception as e:
+        # get_cluster_nodes_info reports failures through pytest.fail, which does not
+        # derive from Exception - catch it too, so deleting a leftover DB stays best
+        # effort and never aborts the caller.
+        except (Exception, pytest.fail.Exception) as e:
             logging.error(f"Failed to delete database {db_name}: {e}")
 
     def create_db(
@@ -119,12 +188,28 @@ class TestPushNotificationsBase:
         fault_injector_client: FaultInjectorClient,
         bdb_config: Dict[str, Any],
     ):
-        try:
-            logging.info(f"Creating database: \n{json.dumps(bdb_config, indent=2)}")
-            cluster_endpoint_config = fault_injector_client.create_database(bdb_config)
-            return cluster_endpoint_config
-        except Exception as e:
-            pytest.fail(f"Failed to create database: {e}")
+        """Create the test database, retrying transient infrastructure failures.
+
+        A create that fails midway can still leave the BDB on the cluster, so any
+        leftover is deleted by name before the next attempt - otherwise the retry
+        collides with it on the fixed port from the config.
+        """
+        logging.info(f"Creating database: \n{json.dumps(bdb_config, indent=2)}")
+        for attempt in range(1, DB_CREATE_ATTEMPTS + 1):
+            try:
+                return fault_injector_client.create_database(bdb_config)
+            # get_operation_result reports a failed action through pytest.fail, which
+            # does not derive from Exception.
+            except (Exception, pytest.fail.Exception) as e:
+                if attempt == DB_CREATE_ATTEMPTS:
+                    pytest.fail(
+                        f"Failed to create database after {attempt} attempts: {e}"
+                    )
+                logging.warning(
+                    f"Attempt {attempt}/{DB_CREATE_ATTEMPTS} to create database "
+                    f"{bdb_config['name']} failed: {e}"
+                )
+                self.delete_prev_db(fault_injector_client, bdb_config["name"])
 
     def _trigger_effect(
         self,
@@ -137,21 +222,29 @@ class TestPushNotificationsBase:
         skip_end_notification: bool = False,
         timeout: int = DEFAULT_TRIGGER_OP_TIMEOUT,
     ):
-        trigger_effect_action_id = ClusterOperations.trigger_effect(
-            fault_injector=fault_injector_client,
-            endpoint_config=endpoints_config,
-            effect_name=effect_name,
-            trigger_name=trigger_name,
-            source_node=target_node,
-            target_node=empty_node,
-            skip_end_notification=skip_end_notification,
-        )
+        try:
+            trigger_effect_action_id = ClusterOperations.trigger_effect(
+                fault_injector=fault_injector_client,
+                endpoint_config=endpoints_config,
+                effect_name=effect_name,
+                trigger_name=trigger_name,
+                source_node=target_node,
+                target_node=empty_node,
+                skip_end_notification=skip_end_notification,
+            )
 
-        trigger_effect_result = fault_injector_client.get_operation_result(
-            trigger_effect_action_id,
-            timeout=timeout,
-        )
-        logging.debug(f"Action execution result: {trigger_effect_result}")
+            trigger_effect_result = fault_injector_client.get_operation_result(
+                trigger_effect_action_id,
+                timeout=timeout,
+            )
+            logging.debug(f"Action execution result: {trigger_effect_result}")
+        except BaseException as e:
+            # This usually runs on a spawned thread, where pytest.fail() only
+            # kills the thread and leaves the test looking like it merely saw
+            # command errors. Record it for _fail_on_trigger_effect_failures().
+            logging.error(f"Trigger effect failed: {type(e).__name__}: {e}")
+            self._trigger_effect_failures.append(f"{type(e).__name__}: {e}")
+            raise
 
     def _get_all_connections_in_pool(self, client: Redis) -> List[ConnectionInterface]:
         connections = []
@@ -226,6 +319,7 @@ class TestPushNotificationsBase:
     ):
         """Validate the client connections are in the expected state after migration."""
         matching_conns_count = 0
+        mismatched: list[str] = []
         connections = self._get_all_connections_in_pool(client)
         logging.info(f"Validating {len(connections)} connections")
         logging.info(f"Expected matching conns count: {expected_matching_conns_count}")
@@ -239,13 +333,14 @@ class TestPushNotificationsBase:
                 ):
                     matching_conns_count += 1
                 else:
-                    logging.debug(
-                        f"Connection not matching default state: "
-                        f"maintenance_state={conn.maintenance_state}, "
-                        f"socket_timeout={conn.socket_timeout}, "
-                        f"host={conn.host}, "
-                        f"orig_host_address={conn.orig_host_address}"
+                    detail = (
+                        f"{conn}: maintenance_state={conn.maintenance_state}, "
+                        f"socket_timeout={conn.socket_timeout}, host={conn.host}, "
+                        f"orig_host_address={conn.orig_host_address}, "
+                        f"{conn.extract_connection_details()}"
                     )
+                    mismatched.append(detail)
+                    logging.debug(f"Connection not matching default state: {detail}")
             elif (
                 conn._sock.gettimeout() == configured_timeout
                 and conn.maintenance_state == MaintenanceState.NONE
@@ -253,13 +348,14 @@ class TestPushNotificationsBase:
             ):
                 matching_conns_count += 1
             else:
-                logging.debug(
-                    f"Connection not matching default state: "
-                    f"maintenance_state={conn.maintenance_state}, "
-                    f"socket_timeout={conn.socket_timeout}, "
-                    f"host={conn.host}, "
-                    f"orig_host_address={conn.orig_host_address}"
+                detail = (
+                    f"{conn}: maintenance_state={conn.maintenance_state}, "
+                    f"socket_timeout={conn.socket_timeout}, host={conn.host}, "
+                    f"orig_host_address={conn.orig_host_address}, "
+                    f"{conn.extract_connection_details()}"
                 )
+                mismatched.append(detail)
+                logging.debug(f"Connection not matching default state: {detail}")
 
         # Get client configuration details for error message
         conn_kwargs = client.connection_pool.connection_kwargs
@@ -274,7 +370,8 @@ class TestPushNotificationsBase:
             f"Client: host={client_host}, port={client_port}, "
             f"configured_timeout={configured_timeout}. "
             f"Expected {expected_matching_conns_count} matching connections, "
-            f"but found {matching_conns_count} out of {len(connections)} total connections."
+            f"but found {matching_conns_count} out of {len(connections)} total connections. "
+            f"Non-matching connections: {'; '.join(mismatched) if mismatched else 'none'}"
         )
 
     def _validate_default_notif_disabled_state(
@@ -312,9 +409,10 @@ class TestStanaloneClientPushNotificationsWithEffectTriggerBase(
     ):
         self.delete_prev_db(fault_injector_client, db_config["name"])
 
+        # Recorded before the create so teardown removes a partially created DB.
+        self._bdb_name = db_config["name"]
         db_endpoint_config = self.create_db(fault_injector_client, db_config)
 
-        self._bdb_name = db_config["name"]
         socket_timeout = DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
 
         auth_ssl_client_certs_config_info = db_config.get(
@@ -971,7 +1069,8 @@ class TestStandaloneClientPushNotificationsHandlingWithEffectTrigger(
                     client.get("key")
                 except Exception as e:
                     errors.put(
-                        f"Command failed in thread {threading.current_thread().name}: {e}"
+                        f"[mono={time.monotonic():.6f}] Command failed in thread "
+                        f"{threading.current_thread().name}: {e}"
                     )
 
         # get the connection here because in case of proxy server
@@ -1039,7 +1138,7 @@ class TestStandaloneClientPushNotificationsHandlingWithEffectTrigger(
                 assert not conn.should_reconnect()
 
         # validate no errors were raised in the command execution threads
-        assert errors.empty(), f"Errors occurred in threads: {errors.queue}"
+        self._fail_on_command_errors(errors, "command execution threads")
 
         trigger_effect_thread.join()
         self.maintenance_ops_threads.remove(trigger_effect_thread)
@@ -1187,8 +1286,9 @@ class TestStandaloneClientPushNotificationsHandlingWithEffectTrigger(
         logging.info(f"DB name: {db_name}")
 
         self.delete_prev_db(fault_injector_client, db_config["name"])
-        db_endpoint_config = self.create_db(fault_injector_client, db_config)
+        # Recorded before the create so teardown removes a partially created DB.
         self._bdb_name = db_config["name"]
+        db_endpoint_config = self.create_db(fault_injector_client, db_config)
 
         logging.info("Creating client with disabled notifications.")
         # self._client for teardown cleanup; local `client` used in the rest of this method.
@@ -1293,6 +1393,8 @@ class TestStandaloneClientPushNotificationsHandlingWithEffectTrigger(
 class TestStandaloneClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
     TestStanaloneClientPushNotificationsWithEffectTriggerBase
 ):
+    # TODO: re-enable TopologyChangeStandaloneEffects.DNS_RESOLUTION_CHANGE once the
+    # effect is troubleshooted and fixed.
     @pytest.mark.timeout(300)  # 5 minutes timeout for this test
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name, endpoint_type",
@@ -1302,7 +1404,7 @@ class TestStandaloneClientCommandsExecutionWithPushNotificationsWithEffectTrigge
                 TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP,
                 TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP,
                 TopologyChangeStandaloneEffects.CONN_DROP,
-                TopologyChangeStandaloneEffects.DNS_RESOLUTION_CHANGE,
+                # TopologyChangeStandaloneEffects.DNS_RESOLUTION_CHANGE,
             ],
             endpoint_types=[
                 EndpointType.EXTERNAL_FQDN,
@@ -1351,7 +1453,8 @@ class TestStandaloneClientCommandsExecutionWithPushNotificationsWithEffectTrigge
                         f"Error in thread {threading.current_thread().name}: {e}"
                     )
                     errors.put(
-                        f"Command failed in thread {threading.current_thread().name}: {e}"
+                        f"[mono={time.monotonic():.6f}] Command failed in thread "
+                        f"{threading.current_thread().name}: {e}"
                     )
             logging.debug(f"{threading.current_thread().name}: Thread ended")
 
@@ -1391,14 +1494,29 @@ class TestStandaloneClientCommandsExecutionWithPushNotificationsWithEffectTrigge
         trigger_effect_thread.join()
         self.maintenance_ops_threads.remove(trigger_effect_thread)
 
-        # validate connections settings
+        # Drain first so the command errors are logged even if one of the
+        # assertions below raises.
+        collected_errors = self._drain_command_errors(
+            errors, "command execution threads"
+        )
+
+        # A failed trigger voids the premise of the test, so report it before
+        # judging the connection state it was supposed to produce.
+        self._fail_on_trigger_effect_failures()
+
+        # validate connections settings. "all" rather than a hard-coded 10: the
+        # pool size is emergent from the worker count, so pinning the number
+        # fails on an extra connection even when every connection is in the
+        # expected state - and passes when one of eleven is not.
         self._validate_default_state(
             client_maint_notifications,
-            expected_matching_conns_count=10,
+            expected_matching_conns_count="all",
             configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
         )
 
-        assert errors.empty(), f"Errors occurred in threads: {errors.queue}"
+        self._fail_on_collected_command_errors(
+            collected_errors, "command execution threads"
+        )
 
 
 class TestClusterClientPushNotificationsWithEffectTriggerBase(
@@ -1411,11 +1529,12 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
     ):
         self.delete_prev_db(fault_injector_client_oss_api, db_config["name"])
 
+        # Recorded before the create so teardown removes a partially created DB.
+        self._bdb_name = db_config["name"]
         cluster_endpoint_config = self.create_db(
             fault_injector_client_oss_api, db_config
         )
 
-        self._bdb_name = db_config["name"]
         socket_timeout = DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT
         socket_connect_timeout = DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT
 
@@ -2222,7 +2341,8 @@ class TestClusterClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
                             f"Error in thread {threading.current_thread().name}: {e}"
                         )
                         errors.put(
-                            f"Command failed in thread {threading.current_thread().name}: {e}"
+                            f"[mono={time.monotonic():.6f}] Command failed in thread "
+                            f"{threading.current_thread().name}: {e}"
                         )
                 if executed_commands_count % 500 == 0:
                     logging.debug(
@@ -2284,6 +2404,16 @@ class TestClusterClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
             logging.info(f"Consumed all buffers for node: {node.name}")
         logging.info("All buffers consumed.")
 
+        # Drain first so the command errors are logged even if one of the
+        # assertions below raises.
+        collected_errors = self._drain_command_errors(
+            errors, "command execution threads"
+        )
+
+        # A failed trigger voids the premise of the test, so report it before
+        # judging the connection state it was supposed to produce.
+        self._fail_on_trigger_effect_failures()
+
         for (
             node
         ) in cluster_client_maint_notifications.nodes_manager.nodes_cache.values():
@@ -2299,4 +2429,6 @@ class TestClusterClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
             )
 
         # validate no errors were raised in the command execution threads
-        assert errors.empty(), f"Errors occurred in threads: {errors.queue}"
+        self._fail_on_collected_command_errors(
+            collected_errors, "command execution threads"
+        )


### PR DESCRIPTION
## Change summary

This pull request fixes a maintenance-notification timing bug and makes maintenance failures diagnosable. The bug: when a maintenance relaxation arrived while a `can_read()` probe held the socket non-blocking, the parser's cached timeout was not updated, so the probe restored the pre-relaxation timeout and the relaxed deadline was lost for the life of the connection. `MaintNotificationsAbstractConnection.update_current_socket_timeout` now always arms the parser's cached value, while still leaving the socket untouched during the probe.

The rest of the change is diagnostics and test stabilization:

- debug logging for maint notification handling, connection failures, and cluster topology refresh (sync and async), with connection details formatted via a new `Connection.extract_connection_details()` helper instead of ad-hoc socket address probing
- maint notifications scenario tests: retry database creation before each test, log failed command executions with monotonic timestamps, and make `generate_params` skip effects the fault injector does not support while still failing collection when it produces no params at all
- docstring correction: `MaintNotificationsConfig.relaxed_timeout` already defaults to 10, not 20

There are no public API or behavior changes beyond the timeout fix; the logging is gated on debug level. The `can_read` timeout fix currently exists only in the sync stack (the async connection path arms timeouts differently), which is worth a look before merging.

## Test coverage

A new suite, `tests/maint_notifications/test_connection_diagnostic_logging.py`, covers the diagnostic logging and the parser-timeout behavior, including a regression test for a relaxation arriving during a `can_read` probe. The full `tests/maint_notifications/` directory passes (264 tests). The updated scenario tests require Redis Enterprise infrastructure and were not run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection read/write, timeout, and maintenance-notification paths in sync and async clients; the parser-cache timeout change affects long-lived connections during cluster maintenance, though logging is DEBUG-only and scenario tests were not run locally.
> 
> **Overview**
> Adds **DEBUG-gated** connection and cluster diagnostics across sync/async clients: richer `extract_connection_details()` (maintenance state, hosts, socket vs active read timeouts), failure logs **before** `disconnect()` so live socket state is captured, retry-path logging with **command name only** (no secret-bearing args), and topology-refresh / MOVING-pool tracing. Maintenance notification debug lines now reuse `extract_connection_details()` instead of hand-rolled socket fields.
> 
> **Behavior fixes** bundled with the logging work: sync `CacheProxyConnection._host_error()` returns the wrapped host; AF_UNIX peers/paths no longer mis-parse as TCP ports; sync `read_response` re-raises parser `TimeoutError` with the host and logs/disconnects consistently; **`update_current_socket_timeout` / `update_parser_timeout`** keep the parser’s cached timeout in sync with maintenance relaxations even when a `can_read()` probe leaves the socket at timeout `0` (and RESP3 gets `None` when blocking indefinitely). Cluster error debug paths drop `_extracts_socket_address` in favor of the shared helper.
> 
> **Tests**: new `test_connection_diagnostic_logging.py` for the above; maint-notification scenario suites get DB-create retries, longer reshard timeouts, async node-cache reconciliation waits, clearer error draining, and temporarily disabled DNS_RESOLUTION_CHANGE parametrization. `MaintNotificationsConfig` doc now states `relaxed_timeout` defaults to **10**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ba6bdb8f4ca6eb2f66af2e031858e2840ed89d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->