### PR TITLE
Disconnect connections after invalid responses

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -82,6 +82,7 @@ from redis.exceptions import (
     AuthenticationWrongNumberOfArgsError,
     ConnectionError,
     DataError,
+    InvalidResponse,
     MaxConnectionsError,
     RedisError,
     ResponseError,
@@ -1422,7 +1423,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             # Also by default close in case of BaseException.  A lot of code
             # relies on this behaviour when doing Command/Response pairs.
             # See #1128.
-            if disconnect_on_error:
+            if disconnect_on_error or isinstance(e, InvalidResponse):
                 add_debug_log_for_connection_failure(self, e, "reading response")
                 await self.disconnect(nowait=True)
             raise

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -55,6 +55,7 @@ from .exceptions import (
     ChildDeadlockedError,
     ConnectionError,
     DataError,
+    InvalidResponse,
     MaxConnectionsError,
     RedisError,
     ResponseError,
@@ -1553,7 +1554,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
             # Also by default close in case of BaseException.  A lot of code
             # relies on this behaviour when doing Command/Response pairs.
             # See #1128.
-            if disconnect_on_error:
+            if disconnect_on_error or isinstance(e, InvalidResponse):
                 add_debug_log_for_connection_failure(self, e, "reading response")
                 self.disconnect()
             raise

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -581,6 +581,22 @@ async def test_connect_timeout_error_without_retry():
     assert conn._connect.call_count == 1
 
 
+async def test_connection_invalid_response_disconnects_when_disconnect_disabled():
+    conn = Connection()
+    with (
+        mock.patch.object(
+            conn._parser,
+            "read_response",
+            new=mock.AsyncMock(side_effect=InvalidResponse("invalid response")),
+        ),
+        mock.patch.object(conn, "disconnect", new=mock.AsyncMock()) as disconnect,
+    ):
+        with pytest.raises(InvalidResponse):
+            await conn.read_response(disconnect_on_error=False)
+
+    disconnect.assert_awaited_once_with(nowait=True)
+
+
 @pytest.mark.onlynoncluster
 async def test_connection_parse_response_resume(r: redis.Redis):
     """

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -104,6 +104,22 @@ def test_invalid_response(r):
             parser.read_response()
 
 
+def test_connection_invalid_response_disconnects_when_disconnect_disabled():
+    conn = Connection()
+    with (
+        mock.patch.object(
+            conn._parser,
+            "read_response",
+            side_effect=InvalidResponse("invalid response"),
+        ),
+        mock.patch.object(conn, "disconnect") as disconnect,
+    ):
+        with pytest.raises(InvalidResponse):
+            conn.read_response(disconnect_on_error=False)
+
+    disconnect.assert_called_once_with()
+
+
 def test_hiredis_can_read_detects_reader_data():
     parser = make_hiredis_parser(response=b"OK", has_data=True)
 


### PR DESCRIPTION
### Description of change

Fixes #4291. When RESP parsing raises `InvalidResponse`, the parser cannot safely resume because the offending bytes remain in the buffer. Some PubSub and maintenance-notification paths intentionally pass `disconnect_on_error=False`, which previously allowed the same invalid response to be retried forever.

This change forces sync and asyncio connections to disconnect for `InvalidResponse` while preserving resumable behavior for other exceptions. Regression tests cover both implementations without requiring a live Redis server.

### Validation

- `uv run --frozen pytest -q tests/test_connection.py::test_connection_invalid_response_disconnects_when_disconnect_disabled tests/test_asyncio/test_connection.py::test_connection_invalid_response_disconnects_when_disconnect_disabled`
- `uv run --frozen ruff check redis/connection.py redis/asyncio/connection.py tests/test_connection.py tests/test_asyncio/test_connection.py`
- `uv run --frozen ruff format --check redis/connection.py redis/asyncio/connection.py tests/test_connection.py tests/test_asyncio/test_connection.py`

All focused tests and lint/format checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow connection-lifecycle fix with matching tests; only changes behavior on unrecoverable protocol errors where keeping the connection open was incorrect.
> 
> **Overview**
> **Fixes infinite retry when RESP parsing fails** (#4291). Malformed protocol data leaves the parser buffer in an unrecoverable state, but `read_response(disconnect_on_error=False)` (used in PubSub and maintenance-notification flows) previously kept the socket open and could retry the same bad bytes forever.
> 
> Sync and asyncio `read_response` now **always disconnect** when `InvalidResponse` is raised, while other `BaseException` paths still honor `disconnect_on_error`. Regression tests assert disconnect happens with `disconnect_on_error=False` for both connection implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff7d3e67239f4e8c3791454d00d0963a8c88deab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->