### PR TITLE
Clear the in-progress cache entry when a read fails

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2028,12 +2028,25 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
                     result=CSCResult.MISS,
                 )
 
-        response = self._conn.read_response(
-            disable_decoding=disable_decoding,
-            timeout=timeout,
-            disconnect_on_error=disconnect_on_error,
-            push_request=push_request,
-        )
+        try:
+            response = self._conn.read_response(
+                disable_decoding=disable_decoding,
+                timeout=timeout,
+                disconnect_on_error=disconnect_on_error,
+                push_request=push_request,
+            )
+        except BaseException:
+            # The placeholder send_command staked out is only ever resolved by the read
+            # that just failed, so it has to go with it. Left behind, it stays in the
+            # pool-wide cache until an invalidation or a disconnect clears it, and every
+            # later call of the same command and key finds an entry, skips the network,
+            # then reads a reply nobody asked for - a WRONGTYPE or a NOPERM on one call
+            # desynchronizes the connection for the rest of its life.
+            with self._cache_lock:
+                if self._current_command_cache_key is not None:
+                    self._cache.delete_by_cache_keys([self._current_command_cache_key])
+                    self._current_command_cache_key = None
+            raise
 
         with self._cache_lock:
             # Prevent not-allowed command from caching.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -47,7 +47,13 @@ from redis.credentials import UsernamePasswordCredentialProvider
 from redis.event import (
     EventDispatcher,
 )
-from redis.exceptions import ConnectionError, InvalidResponse, RedisError, TimeoutError
+from redis.exceptions import (
+    ConnectionError,
+    InvalidResponse,
+    RedisError,
+    ResponseError,
+    TimeoutError,
+)
 from redis.observability.attributes import (
     DB_CLIENT_CONNECTION_POOL_NAME,
     DB_CLIENT_CONNECTION_STATE,
@@ -1275,6 +1281,50 @@ class TestUnitCacheProxyConnection:
         # ...and nothing new was stored, because there is no key to store it under.
         assert cache.size == 1
         assert cache.get(stale_key).cache_value == b"bar"
+
+    def test_failed_read_clears_the_in_progress_cache_entry(self, mock_connection):
+        """
+        A cacheable command whose read fails must not leave its placeholder behind.
+
+        ``send_command`` stakes out an IN_PROGRESS entry that only a successful
+        ``read_response`` resolves. When the read raised - a WRONGTYPE reply for a key of
+        another type, a NOPERM under a restricted ACL - that entry stayed in the pool-wide
+        cache, and every later call of the same command and key found an entry, skipped the
+        network, then read a reply that was never requested.
+        """
+        mock_connection.retry = "mock"
+        mock_connection.host = "mock"
+        mock_connection.port = "mock"
+        mock_connection.db = 0
+        mock_connection.credential_provider = UsernamePasswordCredentialProvider()
+        mock_connection._event_dispatcher = EventDispatcher()
+        mock_connection.can_read.return_value = False
+
+        cache = DefaultCache(CacheConfig(max_size=10))
+        proxy_connection = CacheProxyConnection(
+            mock_connection, cache, threading.RLock()
+        )
+
+        mock_connection.read_response.side_effect = ResponseError(
+            "WRONGTYPE Operation against a key holding the wrong kind of value"
+        )
+        proxy_connection.send_command("GET", "foo", keys=["foo"])
+        with pytest.raises(ResponseError):
+            proxy_connection.read_response()
+
+        # The error reaches the caller unchanged, and nothing is left behind to serve a
+        # later command or to store a reply under.
+        assert cache.size == 0
+        assert proxy_connection._current_command_cache_key is None
+
+        # So the same command still reaches the server, and gets the server's reply.
+        mock_connection.read_response.side_effect = None
+        mock_connection.read_response.return_value = b"bar"
+        mock_connection.send_command.reset_mock()
+
+        proxy_connection.send_command("GET", "foo", keys=["foo"])
+        mock_connection.send_command.assert_called_once_with("GET", "foo", keys=["foo"])
+        assert proxy_connection.read_response() == b"bar"
 
     def test_himport_prepared_is_reassignable_through_proxy(self):
         # Regression: `_himport_prepared` must have a setter that delegates to the


### PR DESCRIPTION
### Description of change

With client-side caching on, `CacheProxyConnection.send_command` stakes out an `IN_PROGRESS` placeholder in the pool-wide cache before sending, and only a successful `read_response` ever resolves it. If that read raises, the placeholder is left behind, and nothing else removes it: invalidations only arrive for keys the server is actually tracking, and this command never completed, so none is coming.

From then on the entry poisons that key for the whole pool. `send_command` finds an entry and returns without touching the network, then `read_response` sees the status is `IN_PROGRESS`, does not count it as a hit, and reads from a socket nothing was written to. So the client either blocks until the socket timeout or picks up a reply that belongs to some other command.

Getting there does not take anything exotic. One `WRONGTYPE` (a `GET` against a hash, an `LRANGE` against a string) or one `NOPERM` under a restricted ACL is enough, and `MGET` reaches it without the caller ever seeing an exception, since `parse_response` swallows the `ResponseError` when `EMPTY_RESPONSE` is set.

The fix is to drop the placeholder if the read that would have resolved it fails, and re-raise unchanged. Error type, message and traceback are untouched, and a `ConnectionError` still disconnects and flushes as before.

Without the fix, the new test fails on the leftover entry:

```
>       assert cache.size == 0
E       assert 1 == 0
```

and the follow-up assertion shows the second `GET` was never sent.

There is no async counterpart to change, since the async stack has no client-side cache.

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RESP3 client-side caching on the hot read path; behavior change is narrowly scoped to failed reads but incorrect cleanup previously could desync connections pool-wide.
> 
> **Overview**
> **Fixes client-side caching leaving stale `IN_PROGRESS` placeholders** when `CacheProxyConnection.read_response` fails after a cacheable command was sent (e.g. `WRONGTYPE`, `NOPERM`).
> 
> `send_command` inserts a pool-wide placeholder that only a successful read resolves. On read failure, the change **deletes that cache key and clears `_current_command_cache_key`**, then re-raises the original exception so later calls for the same command/key still hit the network instead of skipping the send and reading the wrong socket reply.
> 
> Adds **`test_failed_read_clears_the_in_progress_cache_entry`** to assert the cache is empty after a failed read and a retry sends `GET` again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81cde525d80ac9b8960066da23f37247bce27d39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->