### PR TITLE
fix(shutdown): don't retry through backoff before reporting the expected disconnect

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -58,6 +58,7 @@ from redis.backoff import ExponentialWithJitterBackoff
 from redis.client import (
     EMPTY_RESPONSE,
     NEVER_DECODE,
+    SKIP_RETRY,
     AbstractRedis,
     CaseInsensitiveDict,
 )
@@ -956,6 +957,7 @@ class Redis(
         pool = self.connection_pool
         command_name = args[0]
         conn = self.connection or await pool.get_connection()
+        skip_retry = options.pop(SKIP_RETRY, False)
 
         # Start timing for observability
         start_time = time.monotonic()
@@ -979,6 +981,7 @@ class Redis(
                     conn, command_name, *args, **options
                 ),
                 failure_callback,
+                is_retryable=(lambda error: False) if skip_retry else None,
                 with_failure_count=True,
             )
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -109,6 +109,11 @@ EMPTY_RESPONSE = "EMPTY_RESPONSE"
 # some responses (ie. dump) are binary, and just meant to never be decoded
 NEVER_DECODE = "NEVER_DECODE"
 
+# a handful of commands (ie. shutdown) expect the connection to drop and
+# treat that as a normal outcome, so retrying through backoff first only
+# delays reporting the expected result
+SKIP_RETRY = "SKIP_RETRY"
+
 
 logger = logging.getLogger(__name__)
 
@@ -907,6 +912,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         pool = self.connection_pool
         command_name = args[0]
         conn = self.connection or pool.get_connection()
+        skip_retry = options.pop(SKIP_RETRY, False)
 
         # Start timing for observability
         start_time = time.monotonic()
@@ -927,6 +933,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                     conn, command_name, *args, **options
                 ),
                 failure_callback,
+                is_retryable=(lambda error: False) if skip_retry else None,
                 with_failure_count=True,
             )
 

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -2121,6 +2121,13 @@ class ManagementCommands(CommandsProtocol):
             args.append("FORCE")
         if abort:
             args.append("ABORT")
+        if not abort:
+            # the server closing the connection is the expected outcome of a
+            # non-aborted shutdown, so there's nothing to gain from retrying
+            # through the backoff schedule first
+            from redis.client import SKIP_RETRY
+
+            kwargs[SKIP_RETRY] = True
         try:
             self.execute_command(*args, **kwargs)
         except ConnectionError:
@@ -2476,6 +2483,13 @@ class AsyncManagementCommands(ManagementCommands):
             args.append("FORCE")
         if abort:
             args.append("ABORT")
+        if not abort:
+            # the server closing the connection is the expected outcome of a
+            # non-aborted shutdown, so there's nothing to gain from retrying
+            # through the backoff schedule first
+            from redis.client import SKIP_RETRY
+
+            kwargs[SKIP_RETRY] = True
         try:
             await self.execute_command(*args, **kwargs)
         except ConnectionError:

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -20,7 +20,7 @@ from redis._parsers.helpers import (
     get_response_callbacks,
     parse_info,
 )
-from redis.client import EMPTY_RESPONSE, NEVER_DECODE
+from redis.client import EMPTY_RESPONSE, NEVER_DECODE, SKIP_RETRY
 from redis.commands.core import (
     ArrayAggregateOperations,
     ArrayPredicateCombinator,
@@ -1541,6 +1541,25 @@ class TestRedisCommands:
         await r.restore("a", ttl, dumped, absttl=True)
         assert await r.get("a") == b"foo"
         assert 0 < await r.ttl("a") <= 61
+
+    async def test_shutdown_skips_retry_backoff(self, r: redis.Redis):
+        """A client-initiated SHUTDOWN expects the server to drop the
+        connection, so it shouldn't sit through the retry backoff schedule
+        before reporting that expected ConnectionError."""
+        r.execute_command = AsyncMock(side_effect=exceptions.ConnectionError())
+        await r.shutdown()
+        args, kwargs = r.execute_command.call_args
+        assert args[0] == "SHUTDOWN"
+        assert kwargs.get(SKIP_RETRY) is True
+
+    async def test_shutdown_abort_does_not_skip_retry(self, r: redis.Redis):
+        """ABORT cancels an in-progress shutdown, so the connection isn't
+        expected to drop and normal retry behavior should still apply."""
+        r.execute_command = AsyncMock(side_effect=exceptions.ConnectionError())
+        await r.shutdown(abort=True)
+        args, kwargs = r.execute_command.call_args
+        assert args == ("SHUTDOWN", "ABORT")
+        assert SKIP_RETRY not in kwargs
 
     async def test_exists(self, r: redis.Redis):
         assert await r.exists("a") == 0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8466,6 +8466,29 @@ class TestRedisCommands:
         r.execute_command("SHUTDOWN", "ABORT")
         r.execute_command.assert_called_with("SHUTDOWN", "ABORT")
 
+    def test_shutdown_skips_retry_backoff(self, r: redis.Redis):
+        """A client-initiated SHUTDOWN expects the server to drop the
+        connection, so it shouldn't sit through the retry backoff schedule
+        before reporting that expected ConnectionError."""
+        from redis.client import SKIP_RETRY
+
+        r.execute_command = mock.MagicMock(side_effect=redis.ConnectionError())
+        r.shutdown()
+        args, kwargs = r.execute_command.call_args
+        assert args[0] == "SHUTDOWN"
+        assert kwargs.get(SKIP_RETRY) is True
+
+    def test_shutdown_abort_does_not_skip_retry(self, r: redis.Redis):
+        """ABORT cancels an in-progress shutdown, so the connection isn't
+        expected to drop and normal retry behavior should still apply."""
+        from redis.client import SKIP_RETRY
+
+        r.execute_command = mock.MagicMock(side_effect=redis.ConnectionError())
+        r.shutdown(abort=True)
+        args, kwargs = r.execute_command.call_args
+        assert args == ("SHUTDOWN", "ABORT")
+        assert SKIP_RETRY not in kwargs
+
     @pytest.mark.replica
     @pytest.mark.xfail(strict=False)
     @skip_if_server_version_lt("2.8.0")


### PR DESCRIPTION
### Description of change

Fixes #3704.

`shutdown()` (without `abort=True`) makes the server close the connection, and the resulting `ConnectionError` is already treated as the expected, successful outcome by the method's own `try/except`. The problem is that error has to survive the client's full retry backoff first, since `execute_command` doesn't know this particular `ConnectionError` is expected. With the default retry config that adds a multi-second delay to a call that should return almost instantly, since the server is already gone.

This adds an internal `SKIP_RETRY` option, consumed inside `execute_command` before anything reaches the wire, which tells the connection's retry object not to retry (`is_retryable=False`) so the error surfaces on the first attempt. `shutdown()` sets it whenever `abort` isn't set, since `ABORT` cancels an in-progress shutdown and the connection isn't expected to drop in that case.

Kept to the standalone sync/async clients since that's what the linked issue is about; didn't touch `RedisCluster`.

### Pull Request check-list

- [x] Do tests and lints pass with this change? (ran `ruff check`/`ruff format --check`/`vulture` and the two new unit tests locally against a mocked connection; couldn't spin up the docker test env in my sandbox to run the full integration suite)
- [ ] Do the CI tests pass with this change?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to command retry plumbing and shutdown only; no public API surface beyond faster shutdown completion.
> 
> **Overview**
> Fixes slow `shutdown()` when the default retry policy would backoff on the **expected** `ConnectionError` after the server closes the connection.
> 
> Adds an internal `SKIP_RETRY` execute option (like `NEVER_DECODE`) that sync and async `execute_command` strips from kwargs and uses to pass `is_retryable=lambda _: False` into `call_with_retry`, so the error surfaces on the first attempt instead of after multi-second backoff.
> 
> **`shutdown()`** (sync and async in `core.py`) sets `SKIP_RETRY=True` for normal shutdowns (`abort` not set), because a dropped connection is success. **`shutdown(abort=True)`** leaves retry behavior unchanged since the connection should stay up.
> 
> Unit tests assert the flag is passed correctly for both paths. RedisCluster is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 373773a76a18ce405496e740f7a13a2d7fcfbffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->