### PR TITLE
Fix cluster client reuse and default-node selection after close

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -692,10 +692,21 @@ class RedisCluster(
             async with self._lock:
                 if self._initialize:
                     try:
+                        default_node = self.nodes_manager.default_node
                         await self.nodes_manager.initialize(
                             additional_startup_nodes_info=additional_startup_nodes_info,
                             last_failed_node_name=last_failed_node_name,
                         )
+                        # Reopening releases connections, not the caller's node
+                        # selection. Use the refreshed instance if it still exists.
+                        if (
+                            default_node is not None
+                            and default_node.name != last_failed_node_name
+                        ):
+                            self.nodes_manager.default_node = (
+                                self.nodes_manager.nodes_cache.get(default_node.name)
+                                or self.nodes_manager.default_node
+                            )
                         await self.commands_parser.initialize(
                             self.nodes_manager.default_node
                         )
@@ -707,7 +718,7 @@ class RedisCluster(
         return self
 
     async def aclose(self) -> None:
-        """Close all connections & client if initialized."""
+        """Release connections; later commands reconnect using the selected node if available."""
         if not self._initialize:
             if not self._lock:
                 self._lock = asyncio.Lock()
@@ -2475,7 +2486,7 @@ class NodesManager:
             )
 
     async def aclose(self, attr: str = "nodes_cache") -> None:
-        self.default_node = None
+        # Retain routing state, just as the synchronous close() does.
         await asyncio.gather(
             *(
                 asyncio.create_task(node.disconnect())

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1511,7 +1511,7 @@ class RedisCluster(
         Raises:
             RedisClusterException: If the cluster has no default node to resolve
                 the keys against, which is the case before the slots cache is
-                first populated and after the client is closed.
+                first populated.
         """
         default_node = self.get_default_node()
         if default_node is None:
@@ -2185,6 +2185,7 @@ class RedisCluster(
         )
 
     def close(self) -> None:
+        """Release connections, allowing subsequent commands to reconnect."""
         try:
             with self._lock:
                 if self.nodes_manager:
@@ -2974,7 +2975,7 @@ class NodesManager:
 
     def close(self) -> None:
         with self._lock:
-            self.default_node = None
+            # Preserve routing information so the disconnected pools can be reused.
             nodes = tuple(self.nodes_cache.values())
         for node in nodes:
             if node.redis_connection:

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -1029,6 +1029,71 @@ class TestRedisClusterObj:
         r.set_default_node(new_def_node)
         assert r.get_default_node() == new_def_node
 
+    @pytest.mark.onlycluster
+    async def test_default_node_commands_after_close(self, r: RedisCluster) -> None:
+        default_node = r.get_primaries()[1]
+        r.set_default_node(default_node)
+        for _ in range(2):
+            await r.aclose()
+            await r.aclose()
+            await r.initialize()
+            assert r.get_default_node().name == default_node.name
+            execute_command = ClusterNode.execute_command
+            selected_nodes = []
+
+            async def execute(node, *args, **kwargs):
+                if args == ("TIME",):
+                    selected_nodes.append(node.name)
+                return await execute_command(node, *args, **kwargs)
+
+            with mock.patch.object(ClusterNode, "execute_command", new=execute):
+                assert len(await r.time()) == 2
+            assert selected_nodes == [default_node.name]
+
+    @pytest.mark.fixed_client
+    @pytest.mark.parametrize("failed_default", [False, True])
+    async def test_reopen_reselects_default_from_refreshed_nodes(
+        self, failed_default: bool
+    ) -> None:
+        cluster = await get_mocked_redis_client(host=default_host, port=default_port)
+        selected = cluster.get_primaries()[1]
+        cluster.set_default_node(selected)
+        replacement = ClusterNode(selected.host, selected.port, server_type=PRIMARY)
+        fallback = cluster.get_primaries()[0]
+
+        async def refresh(**kwargs):
+            cluster.nodes_manager.nodes_cache[selected.name] = replacement
+            cluster.nodes_manager.default_node = fallback
+
+        await cluster.aclose()
+        with mock.patch.object(NodesManager, "initialize", side_effect=refresh):
+            with mock.patch.object(AsyncCommandsParser, "initialize"):
+                await cluster.initialize(
+                    last_failed_node_name=selected.name if failed_default else None
+                )
+        assert cluster.get_default_node() is (
+            fallback if failed_default else replacement
+        )
+        await cluster.aclose()
+
+    @pytest.mark.fixed_client
+    async def test_reopen_falls_back_when_selected_node_is_removed(self) -> None:
+        cluster = await get_mocked_redis_client(host=default_host, port=default_port)
+        selected = cluster.get_primaries()[1]
+        fallback = cluster.get_primaries()[0]
+        cluster.set_default_node(selected)
+
+        async def refresh(**kwargs):
+            cluster.nodes_manager.nodes_cache.pop(selected.name)
+            cluster.nodes_manager.default_node = fallback
+
+        await cluster.aclose()
+        with mock.patch.object(NodesManager, "initialize", side_effect=refresh):
+            with mock.patch.object(AsyncCommandsParser, "initialize"):
+                await cluster.initialize()
+        assert cluster.get_default_node() is fallback
+        await cluster.aclose()
+
     async def test_set_default_node_failure(self, r: RedisCluster) -> None:
         """
         test failed replacement of the default cluster node

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -366,6 +366,35 @@ class TestRedisClusterObj:
     Tests for the RedisCluster class
     """
 
+    @pytest.mark.parametrize("use_pipeline", [False, True])
+    def test_reuse_after_close(self, r, use_pipeline):
+        node = r.get_default_node()
+        kwargs = r.get_connection_kwargs().copy()
+        kwargs.pop("db", None)
+        kwargs.pop("redis_connect_func", None)
+        with RedisCluster(host=node.host, port=node.port, **kwargs) as client:
+            client.set("foo", b"value")
+            assert client.get("foo") == b"value"
+
+            for _ in range(2):
+                connections = [
+                    connection
+                    for node in client.get_nodes()
+                    for connection in node.redis_connection.connection_pool._available_connections
+                ]
+                assert any(connection._sock is not None for connection in connections)
+
+                client.close()
+                client.close()
+                assert all(connection._sock is None for connection in connections)
+
+                if use_pipeline:
+                    with client.pipeline(transaction=False) as pipe:
+                        assert pipe.get("foo").execute() == [b"value"]
+                else:
+                    assert client.get("foo") == b"value"
+                assert len(client.time()) == 2
+
     def test_host_port_startup_node(self):
         """
         Test that it is possible to use host & port arguments as startup node
@@ -3128,7 +3157,7 @@ class TestSlotResolutionWithoutADefaultNode:
     ``_get_command_keys`` resolves keys through the default node, and the static metadata table
     answers most keyed reads directly, so ``_internal_execute_command`` no longer passes through
     the fallback that used to substitute keyless routing when the default node was missing.
-    ``NodesManager.close`` clears the default node, so this is reachable on a closed client.
+    This can happen before the slots cache is first populated.
 
     The keys are unknown rather than absent, so the error has to say so: reporting a missing key
     for ``GET foo`` sends the caller looking for a key they did supply.
@@ -3140,7 +3169,7 @@ class TestSlotResolutionWithoutADefaultNode:
     @staticmethod
     def _cluster_without_a_default_node():
         rc = get_mocked_redis_client(host=default_host, port=7000)
-        # What ``NodesManager.close`` leaves behind, without closing the connections.
+        # Simulate an incomplete topology without closing the connections.
         rc.nodes_manager.default_node = None
         return rc
 
@@ -3163,6 +3192,53 @@ class TestSlotResolutionWithoutADefaultNode:
         # determine_slot rather than through the fallback that guards the default node.
         with pytest.raises(RedisClusterException, match="no default node"):
             rc.execute_command("GET", "foo")
+
+
+class TestClusterClose:
+    @pytest.mark.fixed_client
+    @pytest.mark.parametrize("use_pipeline", [False, True])
+    def test_keyed_commands_after_close(self, use_pipeline):
+        rc = get_mocked_redis_client(host=default_host, port=default_port)
+
+        for _ in range(2):
+            rc.close()
+            mock_all_nodes_resp(rc, b"value")
+            if use_pipeline:
+                with rc.pipeline(transaction=False) as pipe:
+                    assert pipe.get("foo").execute() == [b"value"]
+            else:
+                assert rc.get("foo") == b"value"
+
+    @pytest.mark.fixed_client
+    def test_default_node_commands_after_close(self):
+        rc = get_mocked_redis_client(host=default_host, port=default_port)
+        default_node = rc.get_primaries()[1]
+        rc.set_default_node(default_node)
+
+        rc.close()
+        mock_all_nodes_resp(rc, [b"1", b"2"])
+
+        assert rc.time() == (1, 2)
+        default_node.redis_connection.connection.send_command.assert_called_once_with(
+            "TIME"
+        )
+
+    @pytest.mark.fixed_client
+    def test_close_disconnects_all_node_pools(self):
+        rc = get_mocked_redis_client(host=default_host, port=default_port)
+        connections = []
+        for node in rc.get_nodes():
+            connection = Mock(spec=Connection)
+            node.redis_connection.connection_pool._available_connections.append(
+                connection
+            )
+            connections.append(connection)
+
+        rc.close()
+        rc.close()
+
+        for connection in connections:
+            assert connection.disconnect.call_count == 2
 
 
 class TestNodesManager:


### PR DESCRIPTION
### Description of change

Fixes #3846. Keep default-node routing usable after releasing cluster connections, so subsequent commands can reconnect on the same client, as clarified in https://github.com/redis/redis-py/issues/3846#issuecomment-5217603406.

The sync implementation retains its cached default node during close. The async mirror now retains that selection through aclose and reselects the current node instance after topology initialization. If the node has disappeared or is the node that just failed, initialization keeps its newly selected default. This preserves connection-failure recovery while matching close/reuse behavior between stacks.

Tests cover sync GET, pipeline GET, selected-node TIME, repeated close, and pool disconnect; the async follow-up adds actual six-node Redis 8.0.2 TIME routing after repeated close, refreshed node identity, and removed/failed-node fallback. Existing missing-default-node and failure-recovery assertions remain intact. Public signatures are unchanged. from_url pool ownership and concurrent close with in-flight commands remain outside the patch.

### Validation

The original six sync regression cases failed 5/6 before the sync fix, then passed; the full sync module previously passed 307 tests with 9 skips. For the async follow-up, the original runtime failed both selection-preservation regressions, while the removal-fallback test passed. The final focused run including existing connection-failure recovery passes 5 cases with 2 fixture skips.

On the final head: the complete non-TLS async cluster module passes **280 tests, 209 skipped, 11 TLS cases deselected** (15 warnings, including a PubSub destructor warning outside this change). The synchronous TestClusterClose regression group passes **4 tests**. Commands: `pytest tests/test_asyncio/test_cluster.py -k "not TestSSL" --redis-url redis://127.0.0.1:16379/0 -q`; `pytest tests/test_cluster.py -k TestClusterClose --redis-url redis://127.0.0.1:16379/0 -q`.

`invoke linters` passes (Ruff check/format and Vulture; 271 files), and `git diff --check` passes. A full `invoke tests` attempt on the final code cannot collect multiprocessing tests on Windows (`ValueError: cannot find context for 'fork'`). TLS cases require certificates unavailable in the local environment. Full Linux/TLS/protocol/version CI is not claimed as verified.

### Pull Request check-list

- [ ] Do tests and lints pass with this change? (Validated scope above; full-suite environment limitations stated.)
- [ ] Do the CI tests pass with this change? (Pending upstream CI.)
- [x] Is the new or changed code fully tested? (Regression tests exercise the changed lifecycle.)
- [x] Is a documentation update included? (close/aclose docstrings and stale closed-client comments updated.)
- [ ] Is there an example added to the examples folder? (Not applicable.)

AI assistance: Codex prepared the implementation, reviewed the final diff, and executed the reported checks.

