### PR TITLE
docs: fix fused/duplicated words in core and cluster docstrings

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1500,7 +1500,7 @@ class RedisCluster(
 
     def _get_command_keys(self, *args):
         """
-        Get the keys in the command. If the command has no keys in in, None is
+        Get the keys in the command. If the command has no keys in it, None is
         returned.
 
         NOTE: Due to a bug in redis<7.0, this function does not work properly

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -2515,7 +2515,7 @@ class BitFieldOperation:
         """
         Update the overflow algorithm of successive INCRBY operations
         :param overflow: Overflow algorithm, one of WRAP, SAT, FAIL. See the
-            Redis docs for descriptions of these algorithmsself.
+            Redis docs for descriptions of these algorithms.
         :returns: a :py:class:`BitFieldOperation` instance.
         """
         overflow = overflow.upper()


### PR DESCRIPTION
- `redis/commands/core.py` (`BitFieldOperation.overflow`): "descriptions of these **algorithmsself.**" — a find/replace artifact fused `algorithms` with `self.`
- `redis/cluster.py` (`_get_command_keys`): "no keys **in in**" → "in it"

Docstrings only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only docstring edits; no code or API behavior changes.
> 
> **Overview**
> Corrects two docstring typos with no runtime behavior changes.
> 
> In `redis/cluster.py`, `_get_command_keys` now reads “no keys in **it**” instead of duplicated “in in”. In `redis/commands/core.py`, `BitFieldOperation.overflow` fixes a fused word (“**algorithmsself.**” → “**algorithms.**”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e573b2ac2636e2d4eb27d3df61d6ea40f0cc84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->