### PR TITLE
Fix KeyError invalidating a multi-key cached entry by several of its keys

### DIFF
--- a/redis/cache.py
+++ b/redis/cache.py
@@ -217,6 +217,7 @@ class DefaultCache(CacheInterface):
     ) -> List[bool]:
         response = []
         keys_to_delete = []
+        seen = set()
 
         for redis_key in redis_keys:
             # Prepare both versions for lookup
@@ -230,7 +231,13 @@ class DefaultCache(CacheInterface):
                     pass  # Non-UTF-8 bytes, skip str version
 
             for cache_key in self._cache:
+                # A multi-key command (e.g. MGET foo bar) can be matched by more
+                # than one of the invalidated keys; collect each entry only once
+                # so it is not popped twice below, which raised KeyError.
+                if cache_key in seen:
+                    continue
                 if any(candidate in cache_key.redis_keys for candidate in candidates):
+                    seen.add(cache_key)
                     keys_to_delete.append(cache_key)
                     response.append(True)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1496,6 +1496,34 @@ class TestUnitDefaultCache:
         assert len(cache.collection) == 1
         assert cache.get(cache_key4).cache_value == b"bar3"
 
+    def test_delete_by_redis_keys_multikey_entry_matched_twice(self, mock_connection):
+        """A multi-key entry hit by several invalidated keys is removed once.
+
+        An invalidation push can list more than one key of the same cached
+        multi-key command (e.g. MGET foo bar). The entry must be collected and
+        deleted a single time; previously it was popped twice and raised
+        KeyError, crashing the invalidation callback.
+        """
+        cache = DefaultCache(CacheConfig(max_size=5))
+
+        cache_key = CacheKey(
+            command="MGET",
+            redis_keys=("foo", "bar"),
+            redis_args=("MGET", "foo", "bar"),
+        )
+        assert cache.set(
+            CacheEntry(
+                cache_key=cache_key,
+                cache_value=b"baz",
+                status=CacheEntryStatus.VALID,
+                connection_ref=mock_connection,
+            )
+        )
+
+        # Both keys of the single entry are invalidated in one call.
+        assert cache.delete_by_redis_keys([b"foo", b"bar"]) == [True]
+        assert len(cache.collection) == 0
+
     def test_delete_by_redis_keys_with_non_utf8_bytes_key(self, mock_connection):
         """cache fails to invalidate entries when redis_keys contain non-UTF-8 bytes."""
         cache = DefaultCache(CacheConfig(max_size=5))


### PR DESCRIPTION
### Description of change

`DefaultCache.delete_by_redis_keys` (the client-side-cache invalidation path) crashes with `KeyError` when a single invalidation push invalidates more than one of the keys belonging to the same cached multi-key command.

The method walks the cache once per invalidated key and appends every matching entry to `keys_to_delete`, then pops them all at the end. A multi-key command like `MGET foo bar` has `redis_keys=("foo", "bar")`, so if that push lists both `foo` and `bar` the same entry is collected twice and popped twice — the second `self._cache.pop(key)` raises `KeyError`.

The server does batch several keys into one invalidation message (e.g. when a transaction/`MSET` touches multiple tracked keys), so this fires in normal use. It raises inside `Connection._on_invalidation_callback`, under the cache lock, while handling a push message.

Repro against `DefaultCache`:

```python
from redis.cache import (
    DefaultCache, CacheConfig, CacheKey, CacheEntry, CacheEntryStatus,
)

cache = DefaultCache(CacheConfig(max_size=128))
ck = CacheKey(command="MGET", redis_keys=(b"k1", b"k2"))
cache.set(CacheEntry(ck, b"val", CacheEntryStatus.VALID, None))

cache.delete_by_redis_keys([b"k1", b"k2"])   # KeyError: CacheKey(...)
```

The fix tracks the entries already collected (a small `seen` set) so each cached entry is added — and popped — exactly once, regardless of how many invalidated keys match it. Single-key entries and the existing return semantics are unchanged; the only behavioural difference is that an entry matched by several keys is returned/removed once instead of raising. This is sync-only — the async stack has no client-side cache.

### Pull Request check-list

- [x] Do tests and lints pass with this change? (`pytest tests/test_cache.py -k Unit` — 60 passed; `ruff check` / `ruff format` clean)
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested? (added `test_delete_by_redis_keys_multikey_entry_matched_twice`)
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (no API change)
- [ ] Is there an example added to the examples folder (if applicable)? (not applicable — internal bug fix)
