### PR TITLE
fix(lock): raise on reacquire() with timeout=0 instead of deleting the lock

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -348,6 +348,14 @@ class Lock:
         return self.do_reacquire()
 
     def do_reacquire(self) -> Literal[True]:
+        if self.timeout <= 0:
+            # PEXPIRE with 0 deletes the key entirely (Redis >= 7.0), so
+            # "reacquiring" would silently destroy the lock while reporting
+            # success to the caller.
+            raise LockError(
+                "Cannot reacquire a lock with a timeout of 0",
+                lock_name=self.name,
+            )
         timeout = int(self.timeout * 1000)
         if not bool(
             self.lua_reacquire(


### PR DESCRIPTION
Fixes #4279

## The bug

`Lock(timeout=0).reacquire()` rejected `timeout is None` but let `timeout=0` through. `timeout=0` → `PEXPIRE key 0`, which **deletes the key** (Redis ≥ 7.0), and the Lua script returned 1 — so `reacquire()` returned `True` while the lock was gone: mutual exclusion silently destroyed, the caller told everything was fine, and any other client could immediately acquire the same lock.

## Fix

`do_reacquire()` now raises the same `LockError` that `reacquire()` already raises for `timeout=None` when the timeout is ≤ 0.

## Repro (executed with fakeredis + Lua)

```python
lock = Lock(r, 'mylock', timeout=0)
lock.acquire()         # True
lock.reacquire()       # True   <-- reported success
r.exists('mylock')     # False  <-- key deleted
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed lock renewal behavior for the edge case `timeout=0`, but the new failure mode is safer than silently deleting the lock key.
> 
> **Overview**
> Fixes a **silent mutual-exclusion break** when `Lock(..., timeout=0).reacquire()` ran after a successful `acquire()`.
> 
> `reacquire()` already rejected `timeout is None`, but **`timeout=0` was allowed**. That path converted the timeout to **`PEXPIRE key 0`**, which on **Redis ≥ 7.0 removes the lock key** while the Lua reacquire script still returned success—so callers got **`True`** even though the lock no longer existed.
> 
> **`do_reacquire()`** now raises **`LockError`** (same pattern as the no-timeout case) when **`timeout <= 0`**, before touching Redis, so reacquire cannot report success after wiping the lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba7657d00c8ef607cf7b3b637216c0e29e0e3410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->