### PR TITLE
test: run the assertions that sit inside pytest.raises blocks

### DIFF
--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -1003,12 +1003,16 @@ class TestRedisClusterObj:
                 raise error("mocked error")
 
             execute_command.side_effect = raise_error
+            # Without this the attribute is a MagicMock, so the comparison below
+            # is never an integer comparison.
+            execute_command.failed_calls = 0
 
             rc = await get_mocked_redis_client(host=default_host, port=default_port)
 
             with pytest.raises(error):
                 await rc.get("bar")
-                assert execute_command.failed_calls == rc.cluster_error_retry_attempts
+            # retry counts retries, so the first attempt is one more.
+            assert execute_command.failed_calls == rc.retry.get_retries() + 1
 
             await rc.aclose()
 

--- a/tests/test_asyncio/test_multidb/test_failover.py
+++ b/tests/test_asyncio/test_multidb/test_failover.py
@@ -132,7 +132,7 @@ class TestDefaultStrategyExecutor:
                     await asyncio.sleep(0.11)
                     pass
 
-            assert mock_fs.database.call_count == 4
+        assert mock_fs.database.call_count == 4
 
     @pytest.mark.asyncio
     async def test_execute_throws_exception_on_attempts_does_not_exceed_delay(
@@ -167,4 +167,4 @@ class TestDefaultStrategyExecutor:
                     if i == failover_attempts:
                         raise e
 
-            assert mock_fs.database.call_count == 4
+        assert mock_fs.database.call_count == 4

--- a/tests/test_asyncio/test_multidb/test_healthcheck.py
+++ b/tests/test_asyncio/test_multidb/test_healthcheck.py
@@ -555,7 +555,7 @@ class TestLagAwareHealthCheck:
 
         with pytest.raises(HttpError, match="busy") as e:
             await hc.check_health(db, mock_hc_client)
-            assert e.status == 503
+        assert e.value.status == 503
 
         # Ensure both calls were attempted
         assert mock_http.get.call_count == 2

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -900,12 +900,16 @@ class TestRedisClusterObj:
                 raise error("mocked error")
 
             execute_command.side_effect = raise_error
+            # Without this the attribute is a MagicMock, so the comparison below
+            # is never an integer comparison.
+            execute_command.failed_calls = 0
 
             rc = get_mocked_redis_client(host=default_host, port=default_port)
 
             with pytest.raises(error):
                 rc.get("bar")
-                assert execute_command.failed_calls == rc.cluster_error_retry_attempts
+            # retry counts retries, so the first attempt is one more.
+            assert execute_command.failed_calls == rc.retry.get_retries() + 1
 
     def test_user_on_connect_function(self, request):
         """
@@ -3387,7 +3391,7 @@ class TestNodesManager:
                 port=default_port,
                 cluster_enabled=False,
             )
-            assert "Cluster mode is not enabled on this node" in str(e.value)
+        assert "Cluster mode is not enabled on this node" in str(e.value)
 
     @pytest.mark.fixed_client
     def test_empty_startup_nodes(self):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8369,11 +8369,11 @@ class TestRedisCommands:
     def test_module(self, stack_r):
         with pytest.raises(redis.exceptions.ModuleError) as excinfo:
             stack_r.module_load("/some/fake/path")
-            assert "Error loading the extension." in str(excinfo.value)
+        assert "Error loading the extension." in str(excinfo.value)
 
         with pytest.raises(redis.exceptions.ModuleError) as excinfo:
             stack_r.module_load("/some/fake/path", "arg1", "arg2", "arg3", "arg4")
-            assert "Error loading the extension." in str(excinfo.value)
+        assert "Error loading the extension." in str(excinfo.value)
 
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
@@ -8382,13 +8382,13 @@ class TestRedisCommands:
     def test_module_loadex(self, stack_r: redis.Redis):
         with pytest.raises(redis.exceptions.ModuleError) as excinfo:
             stack_r.module_loadex("/some/fake/path")
-            assert "Error loading the extension." in str(excinfo.value)
+        assert "Error loading the extension." in str(excinfo.value)
 
         with pytest.raises(redis.exceptions.ModuleError) as excinfo:
             stack_r.module_loadex(
                 "/some/fake/path", ["name", "value"], ["arg1", "arg2"]
             )
-            assert "Error loading the extension." in str(excinfo.value)
+        assert "Error loading the extension." in str(excinfo.value)
 
     @skip_if_server_version_lt("2.6.0")
     def test_restore(self, r):

--- a/tests/test_multidb/test_failover.py
+++ b/tests/test_multidb/test_failover.py
@@ -126,7 +126,7 @@ class TestDefaultStrategyExecutor:
                     sleep(0.11)
                     pass
 
-            assert mock_fs.database.call_count == 4
+        assert mock_fs.database.call_count == 4
 
     def test_execute_throws_exception_on_attempts_does_not_exceed_delay(self, mock_fs):
         failover_attempts = 3
@@ -158,4 +158,4 @@ class TestDefaultStrategyExecutor:
                     if i == failover_attempts:
                         raise e
 
-            assert mock_fs.database.call_count == 4
+        assert mock_fs.database.call_count == 4


### PR DESCRIPTION
### Description of change

Twelve assertions across six test files sit inside a `with pytest.raises(...)` block, after the statement that raises, so they never execute. Same pattern you spotted in `test_lock_error_gives_correct_lock_name` on #4317; these are the rest.

Ten only needed the assertion moved out. Two were hiding more:

`test_healthcheck.py` asserted `e.status` on the `ExceptionInfo` rather than `e.value.status`.

`test_cluster_down_overreaches_retry_attempts`, sync and async, had three problems at once. `execute_command.failed_calls` is never initialised, so `+= 1` leaves it a `MagicMock` rather than an int. And `rc.cluster_error_retry_attempts` does not exist: it is a constructor parameter folded into `self.retry` as `retries=`, so the assertion raises `AttributeError` the moment it runs. A test named for retry behaviour was verifying none of it. It now counts from zero and compares against `rc.retry.get_retries() + 1`. Measured: 11 calls against `get_retries()` of 10.

Each changed assertion was checked to fail when the expected value is wrong, so none passes vacuously a second time (`+ 2` gives `assert 11 == (10 + 2)`; `999` gives `assert 503 == 999`).

Run against Redis 8.6.2, with a second instance on 6479 using `--enable-module-command yes` for `stack_r`. `tests/test_multidb` and `tests/test_asyncio/test_multidb` give 4 failed / 158 passed on both `master` and this branch; those four want several live databases and are untouched by this change.

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M5uTyCU4WcNTsPvGrErDo
