### PR TITLE
Fix OverflowError in exponential backoff during a long outage

### DIFF
--- a/redis/backoff.py
+++ b/redis/backoff.py
@@ -6,6 +6,16 @@ DEFAULT_CAP = 0.512
 # Minimum backoff between each retry in seconds
 DEFAULT_BASE = 0.008
 
+# ``2**failures`` is an arbitrary precision int, and converting one beyond the
+# float range to a float raises OverflowError. Every strategy below caps the
+# result, so doubling past this point cannot change the outcome.
+_MAX_DOUBLINGS = 1023
+
+
+def _exponential(base: float, failures: int) -> float:
+    """Return ``base * 2**failures`` without overflowing for large ``failures``."""
+    return base * 2 ** min(failures, _MAX_DOUBLINGS)
+
 
 class AbstractBackoff(ABC):
     """Backoff interface"""
@@ -72,7 +82,7 @@ class ExponentialBackoff(AbstractBackoff):
         return self._base == other._base and self._cap == other._cap
 
     def compute(self, failures: int) -> float:
-        return min(self._cap, self._base * 2**failures)
+        return min(self._cap, _exponential(self._base, failures))
 
 
 class FullJitterBackoff(AbstractBackoff):
@@ -96,7 +106,7 @@ class FullJitterBackoff(AbstractBackoff):
         return self._base == other._base and self._cap == other._cap
 
     def compute(self, failures: int) -> float:
-        return random.uniform(0, min(self._cap, self._base * 2**failures))
+        return random.uniform(0, min(self._cap, _exponential(self._base, failures)))
 
 
 class EqualJitterBackoff(AbstractBackoff):
@@ -120,7 +130,7 @@ class EqualJitterBackoff(AbstractBackoff):
         return self._base == other._base and self._cap == other._cap
 
     def compute(self, failures: int) -> float:
-        temp = min(self._cap, self._base * 2**failures) / 2
+        temp = min(self._cap, _exponential(self._base, failures)) / 2
         return temp + random.uniform(0, temp)
 
 
@@ -176,7 +186,7 @@ class ExponentialWithJitterBackoff(AbstractBackoff):
         return self._base == other._base and self._cap == other._cap
 
     def compute(self, failures: int) -> float:
-        return min(self._cap, random.random() * self._base * 2**failures)
+        return min(self._cap, random.random() * _exponential(self._base, failures))
 
 
 def default_backoff():

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -2,7 +2,12 @@ from unittest.mock import Mock
 
 import pytest
 
-from redis.backoff import ExponentialWithJitterBackoff
+from redis.backoff import (
+    EqualJitterBackoff,
+    ExponentialBackoff,
+    ExponentialWithJitterBackoff,
+    FullJitterBackoff,
+)
 
 
 @pytest.mark.fixed_client
@@ -17,3 +22,34 @@ def test_exponential_with_jitter_backoff(monkeypatch: pytest.MonkeyPatch) -> Non
     assert bo.compute(2) == 3.0  # min(5, 0.75*2^2)
     assert bo.compute(3) == 5.0  # min(5, 1*2^3)
     assert bo.compute(4) == 5.0  # min(5, 0.9*2^4)
+
+
+@pytest.mark.fixed_client
+@pytest.mark.parametrize(
+    "backoff_class",
+    [
+        ExponentialBackoff,
+        FullJitterBackoff,
+        EqualJitterBackoff,
+        ExponentialWithJitterBackoff,
+    ],
+)
+def test_backoff_survives_a_long_outage(backoff_class) -> None:
+    """A `Retry` built with a negative retry count retries forever, so the
+    failure count is unbounded. `2**failures` stops fitting in a float at 1024,
+    which used to raise OverflowError instead of returning the capped delay.
+    """
+    bo = backoff_class(cap=3.0, base=0.1)
+
+    for failures in (1023, 1024, 5000, 10**6):
+        delay = bo.compute(failures)
+        assert 0 <= delay <= 3.0
+
+
+@pytest.mark.fixed_client
+def test_exponential_backoff_is_unchanged_below_the_clamp() -> None:
+    """Clamping the exponent must not alter any reachable delay."""
+    bo = ExponentialBackoff(cap=1e9, base=0.008)
+
+    for failures in range(0, 60):
+        assert bo.compute(failures) == min(1e9, 0.008 * 2**failures)


### PR DESCRIPTION
## The problem

`Retry` is documented to retry forever when given a negative retry count:

```python
# redis/retry.py
`retries` can be negative to retry forever.
```

and the loop honors that by skipping the bound entirely:

```python
if self._retries >= 0 and failures > self._retries:
    raise error
backoff = self._backoff.compute(failures)
```

So `failures` is unbounded, and `compute` is eventually asked for a delay after a very large number of consecutive failures. Every exponential strategy computes the delay as

```python
min(self._cap, self._base * 2**failures)
```

`2**failures` is an arbitrary precision int, and multiplying one by a float converts it first, which raises `OverflowError: int too large to convert to float` once the value leaves the float range. The cap is applied to the product, so it never gets the chance to prevent this.

```python
>>> from redis.backoff import ExponentialBackoff
>>> ExponentialBackoff(cap=3.0, base=0.1).compute(1024)
OverflowError: int too large to convert to float
```

The threshold is exactly 1024 failures, and it affects `ExponentialBackoff`, `FullJitterBackoff`, `EqualJitterBackoff` and `ExponentialWithJitterBackoff`.

## Why it matters

A client set up to retry forever is the configuration most likely to reach it, and the delay is capped long before then, so the failure count grows at a steady rate. With the default cap of 0.512s that is roughly nine minutes of a server being unreachable; a restart, a failover, or a network partition of that length is ordinary.

At that point the client does not keep retrying and it does not surface a Redis error either. `OverflowError` is not a `RedisError`, so it passes straight through `except redis.RedisError` handlers and reaches the caller as something that looks unrelated to Redis.

## The change

The exponent is clamped before it is used. A separate `_exponential` helper makes the reason explicit and keeps each strategy reading the way it did before.

Clamping cannot change any delay a caller can observe. The smallest base that survives construction still produces a value far above any cap once it has been doubled a thousand times, so past the clamp every strategy was already returning the cap.

## Testing

`test_backoff_survives_a_long_outage` runs all four strategies at 1023, 1024, 5000 and 10**6 failures and asserts the delay stays finite and within the cap. It fails on the current code with `OverflowError: int too large to convert to float`.

`test_exponential_backoff_is_unchanged_below_the_clamp` pins the existing arithmetic for every failure count below the clamp, so the fix cannot quietly alter a real delay.

Running `tests/test_backoff.py`, `tests/test_retry.py`, `tests/test_utils.py` and `tests/test_connection.py` before and after gives the same set of failures apart from the four this fixes; the rest need a live server. `ruff check` and `ruff format --check` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized retry-timing math with tests preserving observable delays below the overflow threshold; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **exponential backoff** blowing up with `OverflowError` once `failures` reaches **1024**, which breaks **infinite retry** (`retries < 0`) after a long outage even though delays were already capped.
> 
> Adds a shared **`_exponential`** helper that computes `base * 2**failures` via **`math.ldexp`**, returning **`math.inf`** on overflow so **`min(cap, …)`** still yields the cap. **`ExponentialBackoff`**, **`FullJitterBackoff`**, **`EqualJitterBackoff`**, and **`ExponentialWithJitterBackoff`** now call it instead of **`base * 2**failures`**.
> 
> Tests cover all four strategies at very large failure counts, parity with the old formula for normal counts, and continued growth toward the cap past the old float overflow cliff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e012e7287716b83e1fdc71062ec83b716413b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->