### PR TITLE
[fix(asyncio)] Refresh cluster topology before retrying MOVED redirects

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1593,6 +1593,9 @@ class RedisCluster(
                     and self.reinitialize_counter % self.reinitialize_steps == 0
                 ):
                     await self.aclose()
+                    await self.initialize(
+                        additional_startup_nodes_info=[(e.host, e.port)]
+                    )
                     # Reset the counter
                     self.reinitialize_counter = 0
                 else:

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -333,6 +333,65 @@ async def moved_redirection_helper(
             assert fetched_node.server_type == PRIMARY
 
 
+class TestMovedReinitialization:
+    @pytest.mark.fixed_client
+    @pytest.mark.parametrize("reinitialize_steps", [0, 1, 3])
+    async def test_moved_refreshes_topology_before_retry(self, reinitialize_steps):
+        r = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            reinitialize_steps=reinitialize_steps,
+        )
+        key = "foo"
+        slot = r.keyslot(key)
+        refreshes = []
+        command_nodes = []
+
+        async def execute_command(node, command, *args, **kwargs):
+            if command == "CLUSTER SLOTS":
+                refreshes.append(node.name)
+                return cluster_slots
+            assert command == "GET"
+            command_nodes.append(node.port)
+            if node.port != owner_port:
+                raise MovedError(f"{slot} {default_host}:{owner_port}")
+            return b"value"
+
+        async with aclosing(r):
+            with (
+                mock.patch.object(
+                    ClusterNode,
+                    "execute_command",
+                    autospec=True,
+                    side_effect=execute_command,
+                ),
+                mock.patch.object(AsyncCommandsParser, "initialize", autospec=True),
+            ):
+                # Move the key back and forth, crossing the refresh threshold twice.
+                for moved_count in range(1, 7):
+                    owner_port = 7000 if moved_count % 2 else 7001
+                    other_port = 7001 if owner_port == 7000 else 7000
+                    cluster_slots = [
+                        [0, 8191, [default_host, other_port, "other"]],
+                        [8192, 16383, [default_host, owner_port, "owner"]],
+                    ]
+
+                    assert await r.get(key) == b"value"
+                    assert command_nodes[-2:] == [other_port, owner_port]
+                    assert len(command_nodes) == moved_count * 2
+                    assert r.get_node_from_key(key).port == owner_port
+                    assert r._initialize is False
+                    expected_refreshes = (
+                        moved_count // reinitialize_steps if reinitialize_steps else 0
+                    )
+                    assert len(refreshes) == expected_refreshes
+                    assert r.reinitialize_counter == (
+                        moved_count % reinitialize_steps
+                        if reinitialize_steps
+                        else moved_count
+                    )
+
+
 @pytest.mark.onlycluster
 class TestRedisClusterObj:
     """


### PR DESCRIPTION
### Change summary

This PR fixes topology reinitialization in the async RedisCluster MOVED retry path. When the reinitialize_steps threshold was reached, the client called aclose() but retried the command without initializing again, leaving the retry to use stale slot information. With reinitialize_steps=1, repeated MOVED responses could exhaust the retry TTL.

The client now awaits initialize() after aclose(), passing the MOVED destination as an additional startup node candidate. This refreshes the topology before retrying the command and restores the documented reinitialize_steps behavior.

Public signatures and defaults remain unchanged. The synchronous implementation already refreshes the topology before retrying and requires no change. The existing docstring describes the intended behavior, so no documentation or example changes are needed.

### Test coverage

Added server-independent, parametrized regression tests for reinitialize_steps values 0, 1, and 3. The tests simulate repeated slot ownership changes and verify successful command retries, routing to the redirected node, topology refresh frequency, and counter behavior. Removing the fix in memory causes the 1 and 3 cases to fail; the 0 case continues to pass.

All three new cases and two existing related tests pass. invoke linters also passes. A full invoke tests run was attempted but stopped when an existing integration test could not connect to Redis Cluster at 127.0.0.1:15379 because socket access was restricted in the local environment. Full integration coverage and CI results remain unverified.

### Pull Request check-list

- [ ] Do tests and lints pass with this change? (Focused tests and all linters pass; full-suite validation remains pending.)
- [ ] Do the CI tests pass with this change?
- [ ] Is the new or changed code fully tested? (Regression UT coverage added; live-cluster validation remains pending.)
- [ ] Is a documentation update included? (Not applicable: this restores documented behavior.)
- [ ] Is there an example added to the examples folder? (Not applicable.)

*NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster command retry and topology refresh on MOVED in the async client; behavior is localized to that path and aligns with the documented sync semantics, but incorrect initialization ordering could still affect routing under slot migration.
> 
> **Overview**
> Fixes **async `RedisCluster`** MOVED handling when **`reinitialize_steps`** is hit: after **`aclose()`**, the client now **`await initialize(...)`** with the MOVED destination as an extra startup node so slot topology is refreshed **before** the command retries. Previously it closed connections but retried with stale routing, which could burn through the redirect TTL (notably with **`reinitialize_steps=1`**).
> 
> Adds **parametrized regression tests** (`reinitialize_steps` 0, 1, 3) that simulate alternating slot owners and assert successful retries, redirect routing, **`CLUSTER SLOTS`** refresh cadence, and counter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b47866d9565588d0ffdd67f95ea8c563da7277af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->