### PR TITLE
Add latency-based Redis Cluster read load balancing

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,6 +3,34 @@
 This directory contains local benchmark scripts for redis-py. They are not part
 of the normal CI test matrix.
 
+## Cluster latency-based load balancing
+
+`cluster_latency_load_balancing.py` compares round-robin and latency-based
+reads against the same Redis Cluster during healthy, degraded, and recovery
+phases. It reports attempted and successful request counts, errors,
+p50/p95/p99 latency, per-node attempt share, and when the restored replica is
+first selected by latency-based routing.
+
+The delay must be introduced outside redis-py. For example, the following uses
+Redis `CLIENT PAUSE` against replica `127.0.0.1:7001`; use a pause longer
+than the degraded phase:
+
+```shell
+python -m benchmarks.cluster_latency_load_balancing \
+  --url redis://localhost:7000/0 \
+  --degraded-node 127.0.0.1:7001 \
+  --degrade-command "redis-cli -h 127.0.0.1 -p 7001 CLIENT PAUSE 20000 ALL" \
+  --recover-command "redis-cli -h 127.0.0.1 -p 7001 CLIENT UNPAUSE"
+```
+
+You can instead use `tc netem`, a proxy, or another server-side fault tool.
+Omit either command to have the script pause while you apply or remove that
+change manually. The default recovery phase is 35 seconds, covering the three
+10-second decay periods plus time to observe the restored node. Keep
+`--socket-timeout` longer than the injected delay when you want the slow
+requests to succeed and train the latency estimator; shorter timeouts exercise
+failure handling instead.
+
 ## OpenTelemetry Benchmarks
 
 `otel_benchmark.py` measures redis-py operation throughput and latency with

--- a/benchmarks/cluster_latency_load_balancing.py
+++ b/benchmarks/cluster_latency_load_balancing.py
@@ -1,0 +1,254 @@
+"""Compare round-robin and latency-based Redis Cluster read routing.
+
+The benchmark never adds delay inside the client. Use ``--degrade-command`` to
+pause a Redis replica or add network latency, and ``--recover-command`` to undo
+that external change.
+"""
+
+import argparse
+import json
+import shlex
+import subprocess
+import threading
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+
+from redis.cluster import (
+    REPLICA,
+    ClusterNode,
+    LoadBalancingStrategy,
+    RedisCluster,
+)
+from redis.commands import READ_COMMANDS
+from redis.exceptions import RedisError
+from redis.typing import EncodableT
+
+
+class TrackingRedisCluster(RedisCluster):
+    """Record the initially routed node for each read attempt."""
+
+    def __init__(self, *args, **kwargs):
+        self._selection_lock = threading.Lock()
+        self._selections: list[tuple[float, str]] = []
+        super().__init__(*args, **kwargs)
+
+    def _execute_command(self, target_node: ClusterNode, *args: EncodableT, **kwargs):
+        if args[0] in READ_COMMANDS:
+            with self._selection_lock:
+                self._selections.append((time.monotonic(), target_node.name))
+        return super()._execute_command(target_node, *args, **kwargs)
+
+    def drain_selections(self) -> list[tuple[float, str]]:
+        with self._selection_lock:
+            selections = self._selections
+            self._selections = []
+        return selections
+
+
+def _percentile(sorted_samples: list[float], quantile: float) -> float:
+    if not sorted_samples:
+        return 0.0
+    position = (len(sorted_samples) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(sorted_samples) - 1)
+    fraction = position - lower
+    return (
+        sorted_samples[lower]
+        + (sorted_samples[upper] - sorted_samples[lower]) * fraction
+    )
+
+
+def summarize(
+    latencies: list[float], selected_nodes: list[str], errors: int
+) -> dict[str, object]:
+    """Return deterministic latency and routing statistics."""
+    sorted_latencies = sorted(latencies)
+    node_counts = Counter(selected_nodes)
+    selection_count = len(selected_nodes)
+    return {
+        "attempts": selection_count,
+        "successful_requests": len(latencies),
+        "errors": errors,
+        "p50_ms": round(_percentile(sorted_latencies, 0.50) * 1000, 3),
+        "p95_ms": round(_percentile(sorted_latencies, 0.95) * 1000, 3),
+        "p99_ms": round(_percentile(sorted_latencies, 0.99) * 1000, 3),
+        "node_share": {
+            node: round(count / selection_count, 4)
+            for node, count in sorted(node_counts.items())
+        }
+        if selection_count
+        else {},
+    }
+
+
+def run_phase(
+    clients: dict[str, TrackingRedisCluster],
+    key: str,
+    duration: float,
+    workers_per_strategy: int,
+) -> tuple[dict[str, dict[str, object]], dict[str, list[tuple[float, str]]]]:
+    for client in clients.values():
+        client.drain_selections()
+
+    deadline = time.monotonic() + duration
+
+    def worker(client: TrackingRedisCluster) -> tuple[list[float], int]:
+        latencies = []
+        errors = 0
+        while time.monotonic() < deadline:
+            started_at = time.monotonic()
+            try:
+                client.get(key)
+            except RedisError:
+                errors += 1
+            else:
+                latencies.append(time.monotonic() - started_at)
+        return latencies, errors
+
+    outcomes: dict[str, list] = {name: [] for name in clients}
+    with ThreadPoolExecutor(max_workers=workers_per_strategy * len(clients)) as pool:
+        futures = [
+            (name, pool.submit(worker, client))
+            for name, client in clients.items()
+            for _ in range(workers_per_strategy)
+        ]
+        for name, future in futures:
+            outcomes[name].append(future.result())
+
+    selections = {name: client.drain_selections() for name, client in clients.items()}
+    summaries = {}
+    for name, worker_outcomes in outcomes.items():
+        latencies = [
+            latency
+            for worker_latencies, _ in worker_outcomes
+            for latency in worker_latencies
+        ]
+        errors = sum(worker_errors for _, worker_errors in worker_outcomes)
+        summaries[name] = summarize(
+            latencies,
+            [node for _, node in selections[name]],
+            errors,
+        )
+    return summaries, selections
+
+
+def apply_external_change(command: str | None, prompt: str) -> None:
+    if command:
+        subprocess.run(shlex.split(command), check=True)
+    else:
+        input(f"{prompt}\nPress Enter when complete: ")
+
+
+def wait_for_replication(
+    client: TrackingRedisCluster,
+    nodes: list[ClusterNode],
+    key: str,
+    value: str,
+    timeout: float = 10.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if all(node.redis_connection.get(key) == value.encode() for node in nodes):
+                return
+        except RedisError:
+            pass
+        time.sleep(0.05)
+    raise RuntimeError("test key did not replicate to every eligible node")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default="redis://localhost:16379/0")
+    parser.add_argument("--key", default="{latency-benchmark}:key")
+    parser.add_argument("--degraded-node", required=True, help="Replica as host:port")
+    parser.add_argument("--degrade-command")
+    parser.add_argument("--recover-command")
+    parser.add_argument("--warmup-seconds", type=float, default=5.0)
+    parser.add_argument("--phase-seconds", type=float, default=15.0)
+    parser.add_argument("--recovery-seconds", type=float, default=35.0)
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--socket-timeout", type=float, default=30.0)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    clients = {
+        "round_robin": TrackingRedisCluster.from_url(
+            args.url,
+            load_balancing_strategy=LoadBalancingStrategy.ROUND_ROBIN,
+            socket_timeout=args.socket_timeout,
+        ),
+        "latency_based": TrackingRedisCluster.from_url(
+            args.url,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+            socket_timeout=args.socket_timeout,
+        ),
+    }
+
+    try:
+        latency_client = clients["latency_based"]
+        slot = latency_client.determine_slot("GET", args.key)
+        nodes = latency_client.nodes_manager.slots_cache[slot]
+        degraded_node = next(
+            (node for node in nodes if node.name == args.degraded_node), None
+        )
+        if degraded_node is None or degraded_node.server_type != REPLICA:
+            eligible = ", ".join(f"{node.name} ({node.server_type})" for node in nodes)
+            raise ValueError(
+                f"--degraded-node must be a replica for {args.key}; eligible: {eligible}"
+            )
+
+        value = "redis-py-latency-benchmark"
+        latency_client.set(args.key, value)
+        wait_for_replication(latency_client, nodes, args.key, value)
+
+        run_phase(clients, args.key, args.warmup_seconds, args.workers)
+        healthy, _ = run_phase(clients, args.key, args.phase_seconds, args.workers)
+
+        apply_external_change(
+            args.degrade_command,
+            f"Externally degrade replica {args.degraded_node}",
+        )
+        try:
+            degraded, _ = run_phase(clients, args.key, args.phase_seconds, args.workers)
+        finally:
+            apply_external_change(
+                args.recover_command,
+                f"Restore replica {args.degraded_node}",
+            )
+
+        recovery_started_at = time.monotonic()
+        recovered, recovery_selections = run_phase(
+            clients, args.key, args.recovery_seconds, args.workers
+        )
+        reentry_times = [
+            selected_at - recovery_started_at
+            for selected_at, node_name in recovery_selections["latency_based"]
+            if node_name == args.degraded_node
+        ]
+        recovered["latency_based"]["degraded_node_reentry_seconds"] = (
+            round(min(reentry_times), 3) if reentry_times else None
+        )
+
+        print(
+            json.dumps(
+                {
+                    "degraded_node": args.degraded_node,
+                    "healthy": healthy,
+                    "degraded": degraded,
+                    "recovered": recovered,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    finally:
+        for client in clients.values():
+            client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/clustering.rst
+++ b/docs/clustering.rst
@@ -228,13 +228,23 @@ the primary and its replications in a Round-Robin manner.
 With load_balancing_strategy you can define a custom strategy for
 assigning read commands to the replicas and primary nodes.
 
+``LoadBalancingStrategy.LATENCY_BASED`` is an opt-in strategy that samples two
+of the primary and replica nodes eligible for a read and chooses the lower
+client-observed latency-and-load score. It learns only from successful reads;
+failed attempts, redirects, writes, and pipeline batches do not update latency.
+All commands still contribute to the number of in-flight requests while the
+strategy is active, so primary write load affects read selection. Measurements
+are local to each client instance and old measurements decay, allowing a
+recovered node to receive traffic again. As with every replica-reading mode,
+reads from replicas can return stale data.
+
 READONLY mode can be set at runtime by calling the readonly() method
 with target_nodes=‘replicas’, and read-write access can be restored by
 calling the readwrite() method.
 
 .. code:: python
 
-   >>> from cluster import RedisCluster as Redis
+   >>> from redis.cluster import LoadBalancingStrategy, RedisCluster as Redis
    # Use 'debug' log level to print the node that the command is executed on
    >>> rc_readonly = Redis(startup_nodes=startup_nodes,
    ...                     read_from_replicas=True)
@@ -248,3 +258,9 @@ calling the readwrite() method.
    >>> rc_readonly.readwrite(target_nodes='replicas')
    # now the get command would be directed only to the slot's primary node
    >>> rc_readonly.get('{foo}1')
+
+   >>> rc_latency = Redis(
+   ...     startup_nodes=startup_nodes,
+   ...     load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+   ... )
+   >>> rc_latency.get('{foo}1')

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1472,10 +1472,19 @@ class RedisCluster(
         ttl = self.RedisClusterRequestTTL
         command = args[0]
         start_time = time.monotonic()
+        latency_balancing = (
+            getattr(self, "load_balancing_strategy", None)
+            == LoadBalancingStrategy.LATENCY_BASED
+        )
+        latency_sampling = latency_balancing and await self._is_replica_safe(command)
 
         while ttl > 0:
             ttl -= 1
             ask_himport = False
+            latency_attempt = None
+            latency_started_at = None
+            latency_sample = None
+            asking_attempt = asking
             try:
                 if asking:
                     target_node = self.get_node(node_name=redirect_addr)
@@ -1503,9 +1512,20 @@ class RedisCluster(
                     )
                     moved = False
 
+                if latency_balancing:
+                    latency_attempt = (
+                        self.nodes_manager.read_load_balancer.start_request(
+                            target_node.name
+                        )
+                    )
+                    if latency_sampling and not asking_attempt:
+                        latency_started_at = time.monotonic()
+
                 response = await target_node.execute_command(
                     *args, asking=ask_himport, **kwargs
                 )
+                if latency_started_at is not None:
+                    latency_sample = time.monotonic() - latency_started_at
                 await self._record_command_metric(
                     command_name=command,
                     duration_seconds=time.monotonic() - start_time,
@@ -1652,6 +1672,11 @@ class RedisCluster(
                     error=e,
                 )
                 raise
+            finally:
+                if latency_attempt is not None:
+                    self.nodes_manager.read_load_balancer.finish_request(
+                        latency_attempt, latency_sample
+                    )
 
         e = ClusterError("TTL exhausted.")
         e.connection = target_node
@@ -2439,7 +2464,10 @@ class NodesManager:
                 # get the server index using the strategy defined in load_balancing_strategy
                 primary_name = self.slots_cache[slot][0].name
                 node_idx = self.read_load_balancer.get_server_index(
-                    primary_name, len(self.slots_cache[slot]), load_balancing_strategy
+                    primary_name,
+                    len(self.slots_cache[slot]),
+                    load_balancing_strategy,
+                    nodes=self.slots_cache[slot],
                 )
                 return self.slots_cache[slot][node_idx]
             return self.slots_cache[slot][0]
@@ -2683,6 +2711,7 @@ class NodesManager:
 
             # Set the default node
             self.default_node = self.get_nodes_by_server_type(PRIMARY)[0]
+            self.read_load_balancer.reconcile(self.nodes_cache)
             self._epoch += 1
         # Dispatch so listeners (e.g. ClusterPubSub) can reconcile per-node
         # state after slot ownership may have changed. A listener must not
@@ -3203,12 +3232,29 @@ class PipelineStrategy(AbstractStrategy):
         # Start timing for observability
         start_time = time.monotonic()
 
-        errors = await asyncio.gather(
-            *(
-                asyncio.create_task(node[0].execute_pipeline(node[1]))
-                for node in nodes.values()
+        if client.load_balancing_strategy == LoadBalancingStrategy.LATENCY_BASED:
+            load_balancer = client.nodes_manager.read_load_balancer
+
+            async def execute_node(node_name, node, commands):
+                attempt = load_balancer.start_request(node_name)
+                try:
+                    return await node.execute_pipeline(commands)
+                finally:
+                    load_balancer.finish_request(attempt)
+
+            errors = await asyncio.gather(
+                *(
+                    asyncio.create_task(execute_node(node_name, node, commands))
+                    for node_name, (node, commands) in nodes.items()
+                )
             )
-        )
+        else:
+            errors = await asyncio.gather(
+                *(
+                    asyncio.create_task(node[0].execute_pipeline(node[1]))
+                    for node in nodes.values()
+                )
+            )
 
         # Record operation duration for each node
         for node_name, (node, commands) in nodes.items():
@@ -3447,10 +3493,31 @@ class TransactionStrategy(AbstractStrategy):
         )
 
     async def _get_connection_and_send_command(self, *args, **options):
-        redis_node, connection = self._get_client_and_connection_for_transaction()
-        # Only disconnect if not watching - disconnecting would lose WATCH state
-        if not self._watching:
-            await redis_node.disconnect_if_needed(connection)
+        latency_attempt = None
+        if (
+            self._pipe.cluster_client.load_balancing_strategy
+            == LoadBalancingStrategy.LATENCY_BASED
+            and self._pipeline_slots
+        ):
+            nodes_manager = self._pipe.cluster_client.nodes_manager
+            node = nodes_manager.get_node_from_slot(
+                next(iter(self._pipeline_slots)), False
+            )
+            latency_attempt = nodes_manager.read_load_balancer.start_request(node.name)
+            try:
+                redis_node, connection = (
+                    self._get_client_and_connection_for_transaction()
+                )
+                # Only disconnect if not watching - disconnecting would lose WATCH state
+                if not self._watching:
+                    await redis_node.disconnect_if_needed(connection)
+            except BaseException:
+                nodes_manager.read_load_balancer.finish_request(latency_attempt)
+                raise
+        else:
+            redis_node, connection = self._get_client_and_connection_for_transaction()
+            if not self._watching:
+                await redis_node.disconnect_if_needed(connection)
 
         # Start timing for observability
         start_time = time.monotonic()
@@ -3480,6 +3547,9 @@ class TransactionStrategy(AbstractStrategy):
                 error=e,
             )
             raise
+        finally:
+            if latency_attempt is not None:
+                nodes_manager.read_load_balancer.finish_request(latency_attempt)
 
     async def _send_command_parse_response(
         self,
@@ -3597,8 +3667,28 @@ class TransactionStrategy(AbstractStrategy):
     async def _execute_transaction_with_retries(
         self, stack: List["PipelineCommand"], raise_on_error: bool
     ):
+        async def execute_transaction():
+            latency_attempt = None
+            if (
+                self._pipe.cluster_client.load_balancing_strategy
+                == LoadBalancingStrategy.LATENCY_BASED
+                and len(self._pipeline_slots) == 1
+            ):
+                nodes_manager = self._pipe.cluster_client.nodes_manager
+                node = nodes_manager.get_node_from_slot(
+                    next(iter(self._pipeline_slots)), False
+                )
+                latency_attempt = nodes_manager.read_load_balancer.start_request(
+                    node.name
+                )
+            try:
+                return await self._execute_transaction(stack, raise_on_error)
+            finally:
+                if latency_attempt is not None:
+                    nodes_manager.read_load_balancer.finish_request(latency_attempt)
+
         return await self._retry.call_with_retry(
-            lambda: self._execute_transaction(stack, raise_on_error),
+            execute_transaction,
             lambda error, failure_count: self._reinitialize_on_error(
                 error, failure_count
             ),

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -968,10 +968,9 @@ class RedisCluster(
         otherwise.
 
         A replicas-only ``load_balancing_strategy`` is honored by picking from the replicas
-        alone, so a strategy that asks for replicas cannot land on a primary here. The
-        strategy is not applied any further than that: the rest of it is an index into one
-        shard's node list and a round-robin counter kept per primary name, and a keyless
-        command has no shard to index - so the pick is uniform over the eligible nodes.
+        alone, so a strategy that asks for replicas cannot land on a primary here.
+        ``LATENCY_BASED`` scores all eligible nodes because it does not require a shard.
+        Other strategies pick uniformly because their state is scoped to a shard.
 
         Falls back to the whole node set when the cluster has no replicas to pick from,
         which is every primary. That is also the answer for the two strategies that
@@ -986,6 +985,16 @@ class RedisCluster(
                 replicas = self.get_replicas()
                 if replicas:
                     return random.choice(replicas)
+
+            if self.load_balancing_strategy == LoadBalancingStrategy.LATENCY_BASED:
+                eligible_nodes = self.get_nodes()
+                index = self.nodes_manager.read_load_balancer.get_server_index(
+                    "",
+                    len(eligible_nodes),
+                    self.load_balancing_strategy,
+                    nodes=eligible_nodes,
+                )
+                return eligible_nodes[index]
 
             return self.get_random_node()
 

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -10,19 +10,24 @@ from collections import OrderedDict, defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager, nullcontext
 from copy import copy
+from dataclasses import dataclass
 from enum import Enum
 from functools import partial
 from itertools import chain
+from math import exp
+from random import sample as random_sample
 from types import MethodType
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     Dict,
     Iterable,
     List,
     Literal,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -1930,9 +1935,18 @@ class RedisCluster(
 
         # Start timing for observability
         start_time = time.monotonic()
+        latency_balancing = (
+            getattr(self, "load_balancing_strategy", None)
+            == LoadBalancingStrategy.LATENCY_BASED
+        )
+        latency_sampling = latency_balancing and self._is_replica_safe(command)
 
         while ttl > 0:
             ttl -= 1
+            latency_attempt = None
+            latency_started_at = None
+            latency_sample = None
+            asking_attempt = asking
             try:
                 if asking:
                     target_node = self.get_node(node_name=redirect_addr)
@@ -1950,6 +1964,15 @@ class RedisCluster(
                         self.load_balancing_strategy if replica_safe else None,
                     )
                     moved = False
+
+                if latency_balancing:
+                    latency_attempt = (
+                        self.nodes_manager.read_load_balancer.start_request(
+                            target_node.name
+                        )
+                    )
+                    if latency_sampling and not asking_attempt:
+                        latency_started_at = time.monotonic()
 
                 redis_node = self.get_redis_connection(target_node)
                 connection = get_connection(redis_node)
@@ -2002,6 +2025,9 @@ class RedisCluster(
                         response = self.cluster_response_callbacks[command](
                             response, **kwargs
                         )
+
+                if latency_started_at is not None:
+                    latency_sample = time.monotonic() - latency_started_at
 
                 self._record_command_metric(
                     command_name=command,
@@ -2233,6 +2259,10 @@ class RedisCluster(
                 )
                 raise e
             finally:
+                if latency_attempt is not None:
+                    self.nodes_manager.read_load_balancer.finish_request(
+                        latency_attempt, latency_sample
+                    )
                 if connection is not None:
                     redis_node.connection_pool.release(connection)
 
@@ -2387,6 +2417,29 @@ class LoadBalancingStrategy(Enum):
     ROUND_ROBIN_REPLICAS = "round_robin_replicas"
     RANDOM = "random"
     RANDOM_REPLICA = "random_replica"
+    LATENCY_BASED = "latency_based"
+
+
+_LATENCY_EWMA_ALPHA = 0.2
+_LATENCY_BASELINE_ALPHA = 0.05
+_LATENCY_DECAY_SECONDS = 10.0
+_LATENCY_EVIDENCE_TTL_SECONDS = 3 * _LATENCY_DECAY_SECONDS
+_INITIAL_LATENCY_SECONDS = 0.001
+
+
+@dataclass(frozen=True, slots=True)
+class _LatencyAttempt:
+    node_name: str
+    generation: int
+
+
+@dataclass(slots=True)
+class _NodeLatencyState:
+    generation: int
+    in_flight: int = 0
+    ewma: float | None = None
+    peak: float | None = None
+    observed_at: float | None = None
 
 
 # The strategies that exclude the primary. ``LoadBalancer`` derives the same thing per
@@ -2404,21 +2457,38 @@ _REPLICAS_ONLY_STRATEGIES = frozenset(
 
 class LoadBalancer:
     """
-    Round-Robin Load Balancing
+    Select nodes according to a configured load-balancing strategy.
     """
 
     def __init__(self, start_index: int = 0) -> None:
         self.primary_to_idx: dict[str, int] = {}
         self.start_index: int = start_index
         self._lock: threading.Lock = threading.Lock()
+        self._latency_state: dict[str, _NodeLatencyState] = {}
+        self._next_generation = 0
+        self._baseline = _INITIAL_LATENCY_SECONDS
+        self._clock = time.monotonic
 
     def get_server_index(
         self,
         primary: str,
         list_size: int,
         load_balancing_strategy: LoadBalancingStrategy = LoadBalancingStrategy.ROUND_ROBIN,
+        nodes: Sequence["ClusterNode"] | None = None,
     ) -> int:
-        if load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA:
+        if load_balancing_strategy == LoadBalancingStrategy.LATENCY_BASED:
+            if nodes is None or len(nodes) != list_size:
+                raise ValueError("nodes are required for latency-based load balancing")
+            candidate_indices = random_sample(range(list_size), min(2, list_size))
+            now = self._clock()
+            with self._lock:
+                return min(
+                    candidate_indices,
+                    key=lambda index: self._latency_score_unlocked(
+                        nodes[index].name, now
+                    ),
+                )
+        elif load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA:
             return self._get_random_server_index(
                 list_size,
                 replicas_only=True,
@@ -2434,6 +2504,79 @@ class LoadBalancer:
                 list_size,
                 load_balancing_strategy == LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
             )
+
+    def start_request(self, node_name: str) -> _LatencyAttempt:
+        with self._lock:
+            state = self._latency_state.get(node_name)
+            if state is None:
+                self._next_generation += 1
+                state = _NodeLatencyState(generation=self._next_generation)
+                self._latency_state[node_name] = state
+            state.in_flight += 1
+            return _LatencyAttempt(node_name, state.generation)
+
+    def finish_request(
+        self,
+        attempt: _LatencyAttempt,
+        latency_seconds: float | None = None,
+    ) -> None:
+        now = self._clock()
+        with self._lock:
+            state = self._latency_state.get(attempt.node_name)
+            if state is None or state.generation != attempt.generation:
+                return
+            state.in_flight = max(0, state.in_flight - 1)
+            if latency_seconds is not None:
+                self._observe_unlocked(state, max(0.0, latency_seconds), now)
+
+    def reconcile(self, active_node_names: Collection[str]) -> None:
+        active = set(active_node_names)
+        with self._lock:
+            for node_name in tuple(self._latency_state):
+                if node_name not in active:
+                    del self._latency_state[node_name]
+
+    def _observe_unlocked(
+        self, state: _NodeLatencyState, latency_seconds: float, now: float
+    ) -> None:
+        aged_ewma, aged_peak = self._aged_estimates_unlocked(state, now)
+        state.ewma = (
+            _LATENCY_EWMA_ALPHA * latency_seconds
+            + (1 - _LATENCY_EWMA_ALPHA) * aged_ewma
+        )
+        state.peak = max(latency_seconds, state.ewma, aged_peak)
+        state.observed_at = now
+
+        self._baseline = (
+            _LATENCY_BASELINE_ALPHA * state.ewma
+            + (1 - _LATENCY_BASELINE_ALPHA) * self._baseline
+        )
+
+    def _aged_estimates_unlocked(
+        self, state: _NodeLatencyState, now: float
+    ) -> tuple[float, float]:
+        baseline = self._baseline
+        if state.ewma is None or state.peak is None or state.observed_at is None:
+            return baseline, baseline
+        age = max(0.0, now - state.observed_at)
+        if age >= _LATENCY_EVIDENCE_TTL_SECONDS:
+            return baseline, baseline
+        weight = exp(-age / _LATENCY_DECAY_SECONDS)
+        aged_ewma = baseline + (state.ewma - baseline) * weight
+        aged_peak = aged_ewma + max(0.0, state.peak - state.ewma) * weight
+        return aged_ewma, aged_peak
+
+    def _latency_score(self, node_name: str) -> float:
+        now = self._clock()
+        with self._lock:
+            return self._latency_score_unlocked(node_name, now)
+
+    def _latency_score_unlocked(self, node_name: str, now: float) -> float:
+        state = self._latency_state.get(node_name)
+        if state is None:
+            return self._baseline
+        _, peak = self._aged_estimates_unlocked(state, now)
+        return peak * (state.in_flight + 1)
 
     def reset(self) -> None:
         with self._lock:
@@ -2670,7 +2813,10 @@ class NodesManager:
                 # get the server index using the strategy defined in load_balancing_strategy
                 primary_name = self.slots_cache[slot][0].name
                 node_idx = self.read_load_balancer.get_server_index(
-                    primary_name, len(self.slots_cache[slot]), load_balancing_strategy
+                    primary_name,
+                    len(self.slots_cache[slot]),
+                    load_balancing_strategy,
+                    nodes=self.slots_cache[slot],
                 )
             elif (
                 server_type is None
@@ -3128,6 +3274,7 @@ class NodesManager:
                 if self._dynamic_startup_nodes:
                     # Populate the startup nodes with all discovered nodes
                     self.startup_nodes = tmp_nodes_cache
+                self.read_load_balancer.reconcile(self.nodes_cache)
                 # Increment the epoch to signal that initialization has completed
                 self._epoch += 1
             # Dispatch so listeners (e.g. ClusterPubSub) can reconcile per-node
@@ -5192,6 +5339,7 @@ class PipelineStrategy(AbstractStrategy):
         node_objs: dict = {}
         nodes_written = 0
         nodes_read = 0
+        latency_attempts = None
 
         try:
             # as we move through each command that still needs to be processed,
@@ -5315,6 +5463,15 @@ class PipelineStrategy(AbstractStrategy):
             # Start timing for observability
             start_time = time.monotonic()
 
+            if (
+                self._pipe.load_balancing_strategy
+                == LoadBalancingStrategy.LATENCY_BASED
+            ):
+                latency_attempts = [
+                    self._nodes_manager.read_load_balancer.start_request(node_name)
+                    for node_name in nodes
+                ]
+
             node_commands = nodes.values()
             for n in node_commands:
                 nodes_written += 1
@@ -5340,6 +5497,11 @@ class PipelineStrategy(AbstractStrategy):
                 )
                 nodes_read += 1
         finally:
+            if latency_attempts is not None:
+                for latency_attempt in latency_attempts:
+                    self._nodes_manager.read_load_balancer.finish_request(
+                        latency_attempt
+                    )
             # release all the redis connections we allocated earlier
             # back into the connection pool.
             # if the connection is dirty (that is: we've written
@@ -5660,7 +5822,26 @@ class TransactionStrategy(AbstractStrategy):
         )
 
     def _get_connection_and_send_command(self, *args, **options):
-        redis_node, connection = self._get_client_and_connection_for_transaction()
+        latency_attempt = None
+        if (
+            self._pipe.load_balancing_strategy == LoadBalancingStrategy.LATENCY_BASED
+            and self._pipeline_slots
+        ):
+            node = self._nodes_manager.get_node_from_slot(
+                next(iter(self._pipeline_slots)), False
+            )
+            latency_attempt = self._nodes_manager.read_load_balancer.start_request(
+                node.name
+            )
+            try:
+                redis_node, connection = (
+                    self._get_client_and_connection_for_transaction()
+                )
+            except BaseException:
+                self._nodes_manager.read_load_balancer.finish_request(latency_attempt)
+                raise
+        else:
+            redis_node, connection = self._get_client_and_connection_for_transaction()
 
         # Start timing for observability
         start_time = time.monotonic()
@@ -5692,6 +5873,9 @@ class TransactionStrategy(AbstractStrategy):
                 error=e,
             )
             raise
+        finally:
+            if latency_attempt is not None:
+                self._nodes_manager.read_load_balancer.finish_request(latency_attempt)
 
     def _send_command_parse_response(
         self, conn, redis_node: Redis, command_name, *args, **options
@@ -5799,8 +5983,29 @@ class TransactionStrategy(AbstractStrategy):
     def _execute_transaction_with_retries(
         self, stack: List["PipelineCommand"], raise_on_error: bool
     ):
+        def execute_transaction():
+            latency_attempt = None
+            if (
+                self._pipe.load_balancing_strategy
+                == LoadBalancingStrategy.LATENCY_BASED
+                and len(self._pipeline_slots) == 1
+            ):
+                node = self._nodes_manager.get_node_from_slot(
+                    next(iter(self._pipeline_slots)), False
+                )
+                latency_attempt = self._nodes_manager.read_load_balancer.start_request(
+                    node.name
+                )
+            try:
+                return self._execute_transaction(stack, raise_on_error)
+            finally:
+                if latency_attempt is not None:
+                    self._nodes_manager.read_load_balancer.finish_request(
+                        latency_attempt
+                    )
+
         return self._retry.call_with_retry(
-            lambda: self._execute_transaction(stack, raise_on_error),
+            execute_transaction,
             lambda error, failure_count: self._reinitialize_on_error(
                 error, failure_count
             ),

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1146,10 +1146,9 @@ class RedisCluster(
         otherwise.
 
         A replicas-only ``load_balancing_strategy`` is honored by picking from the replicas
-        alone, so a strategy that asks for replicas cannot land on a primary here. The
-        strategy is not applied any further than that: the rest of it is an index into one
-        shard's node list and a round-robin counter kept per primary name, and a keyless
-        command has no shard to index - so the pick is uniform over the eligible nodes.
+        alone, so a strategy that asks for replicas cannot land on a primary here.
+        ``LATENCY_BASED`` scores all eligible nodes because it does not require a shard.
+        Other strategies pick uniformly because their state is scoped to a shard.
 
         Falls back to the whole node set when the cluster has no replicas to pick from,
         which is every primary. That is also the answer for the two strategies that
@@ -1164,6 +1163,16 @@ class RedisCluster(
                 replicas = self.get_replicas()
                 if replicas:
                     return random.choice(replicas)
+
+            if self.load_balancing_strategy == LoadBalancingStrategy.LATENCY_BASED:
+                eligible_nodes = self.get_nodes()
+                index = self.nodes_manager.read_load_balancer.get_server_index(
+                    "",
+                    len(eligible_nodes),
+                    self.load_balancing_strategy,
+                    nodes=eligible_nodes,
+                )
+                return eligible_nodes[index]
 
             return self.get_random_node()
 
@@ -5467,18 +5476,24 @@ class PipelineStrategy(AbstractStrategy):
                 self._pipe.load_balancing_strategy
                 == LoadBalancingStrategy.LATENCY_BASED
             ):
-                latency_attempts = [
-                    self._nodes_manager.read_load_balancer.start_request(node_name)
+                latency_attempts = {
+                    node_name: self._nodes_manager.read_load_balancer.start_request(
+                        node_name
+                    )
                     for node_name in nodes
-                ]
+                }
 
             node_commands = nodes.values()
             for n in node_commands:
                 nodes_written += 1
                 n.write()
 
-            for n in node_commands:
+            for node_name, n in nodes.items():
                 n.read()
+                if latency_attempts is not None:
+                    self._nodes_manager.read_load_balancer.finish_request(
+                        latency_attempts.pop(node_name)
+                    )
 
                 # Find the first error in this node's commands, if any
                 node_error = None
@@ -5498,7 +5513,7 @@ class PipelineStrategy(AbstractStrategy):
                 nodes_read += 1
         finally:
             if latency_attempts is not None:
-                for latency_attempt in latency_attempts:
+                for latency_attempt in latency_attempts.values():
                     self._nodes_manager.read_load_balancer.finish_request(
                         latency_attempt
                     )

--- a/specs/latency_based_load_balancing.md
+++ b/specs/latency_based_load_balancing.md
@@ -1,0 +1,94 @@
+# Latency-Based Cluster Read Balancing
+
+## Objective
+
+Add an opt-in `LoadBalancingStrategy.LATENCY_BASED` for Redis Cluster reads.
+The strategy samples two eligible nodes and selects the lower score:
+
+```text
+aged peak EWMA * (in-flight requests + 1)
+```
+
+The unsuffixed strategy includes the primary and replicas, matching `RANDOM`
+and `ROUND_ROBIN`. Existing strategies remain unchanged.
+
+## State and observations
+
+Each node stores a generation, in-flight count, ordinary EWMA, peak EWMA, and
+last-observation time. The load balancer also stores a slow cluster baseline.
+
+Only successful reads update latency. All commands update in-flight load while
+the strategy is active, so writes make a busy primary less attractive without
+mixing write latency into the read estimator. Failures, redirects, timeouts,
+cancellation, and pipeline batches release in-flight state without recording a
+latency sample.
+
+For successful latency `r`, node EWMA alpha `0.2`, baseline alpha `0.05`, elapsed
+time `dt`, and decay period `10s`:
+
+```text
+d = 0 if dt >= 30 else exp(-dt / 10)
+aged_ewma = baseline + (ewma - baseline) * d
+aged_peak = aged_ewma + max(0, peak - ewma) * d
+new_ewma = 0.2 * r + 0.8 * aged_ewma
+new_peak = max(r, new_ewma, aged_peak)
+new_baseline = 0.05 * new_ewma + 0.95 * baseline
+```
+
+Cold nodes use the baseline, initialized to `1ms`. The first successful node
+EWMA updates that value through the same baseline equation; it does not replace
+the baseline. Measurements expire after three decay periods (`30s`) and then
+score at the baseline. This finite evidence lifetime is necessary because pure
+exponential decay only approaches the baseline: with one primary and one
+replica, strict minimum selection could otherwise starve a recovered node
+forever.
+
+## Lifecycle
+
+`start_request(node_name)` increments load and returns a token containing the
+node generation. `finish_request(token, latency=None)` always releases the
+matching generation and observes latency only when provided. Stale tokens are
+ignored after a node is removed and later recreated.
+
+Topology refresh reconciles active names only after successful discovery. It
+preserves surviving state and prunes departed nodes. Ordinary round-robin reset
+does not erase latency history.
+
+## Timing boundary
+
+A sample begins immediately before connection acquisition and ends after a
+successful parsed response. It includes pool wait, successful reconnect,
+network, server, parsing, and callbacks. It excludes routing, retry backoff,
+failed attempts, and ASK migration attempts. Sync and async use this same
+client-observed boundary.
+
+## Pipelines
+
+Each grouped node batch counts as one in-flight operation while executing but
+does not update latency. A transactional pipeline likewise counts as one
+in-flight operation on its owning node, and immediate watched commands use one
+attempt apiece. Batch duration is not comparable across different command
+counts or sync pipeline ordering. Commands retried individually use the normal
+lifecycle and may record a successful read sample.
+
+## Tradeoffs
+
+- Errors do not penalize latency; existing retry and topology logic owns hard
+  failures.
+- End-to-end attempt timing intentionally includes client pool pressure.
+- The fixed decay constants avoid new public configuration and require benchmark
+  validation.
+- Expiring evidence at `30s` creates a small score discontinuity in exchange for
+  bounded recovery exploration.
+- The traffic-weighted baseline favors nodes serving real traffic; a per-node
+  median is deferred unless evidence shows it is needed.
+- In-flight accounting begins immediately after selection rather than reserving
+  atomically inside routing, avoiding a broad routing return-type change.
+- Pipeline-only workloads receive concurrency balancing but do not learn
+  historical latency.
+
+## Merge evidence
+
+The implementation requires deterministic unit tests for state, failures,
+topology generations, sync/async parity, and pipelines, plus a real local-cluster
+benchmark with externally induced replica degradation and recovery.

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3529,6 +3529,33 @@ class TestStaticMetadataRouting:
         await rc.aclose()
 
     @pytest.mark.fixed_client
+    async def test_keyless_latency_routing_scores_all_eligible_nodes(self) -> None:
+        rc = await get_mocked_redis_client(
+            host=default_host,
+            port=7000,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+        nodes = rc.get_nodes()
+        selected_index = len(nodes) - 1
+
+        with mock.patch.object(
+            rc.nodes_manager.read_load_balancer,
+            "get_server_index",
+            return_value=selected_index,
+        ) as select_index:
+            assert (
+                await rc.get_keyless_target_node("FT.SEARCH") is nodes[selected_index]
+            )
+
+        select_index.assert_called_once_with(
+            "",
+            len(nodes),
+            LoadBalancingStrategy.LATENCY_BASED,
+            nodes=nodes,
+        )
+        await rc.aclose()
+
+    @pytest.mark.fixed_client
     async def test_slot_id_commands_route_by_slot_for_any_spelling(self) -> None:
         """
         The SLOT_ID flag lookup is normalized, so a raw lowercase spelling names the same

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -30,6 +30,7 @@ from redis.cluster import (
     PIPELINE_BLOCKED_COMMANDS,
     PRIMARY,
     REPLICA,
+    LoadBalancer,
     LoadBalancingStrategy,
     get_node_name,
 )
@@ -63,6 +64,8 @@ from redis.exceptions import (
     RedisError,
     ResponseError,
     SlotNotCoveredError,
+    TimeoutError,
+    TryAgainError,
 )
 from redis.himport import HIMPORT_SET
 from redis.utils import str_if_bytes
@@ -90,6 +93,377 @@ default_cluster_slots = [
     [0, 8191, ["127.0.0.1", 7000, "node_0"], ["127.0.0.1", 7003, "node_3"]],
     [8192, 16383, ["127.0.0.1", 7001, "node_1"], ["127.0.0.1", 7002, "node_2"]],
 ]
+
+
+class TestLatencyBasedCommandTracking:
+    @staticmethod
+    def client(load_balancer):
+        client = object.__new__(RedisCluster)
+        client.RedisClusterRequestTTL = 1
+        client.load_balancing_strategy = LoadBalancingStrategy.LATENCY_BASED
+        client.nodes_manager = mock.Mock(read_load_balancer=load_balancer)
+        client._metadata_resolver = AsyncDynamicMetadataResolver(
+            {"core": {"get": CACHEABLE_KEYED}, "custom": {"read": CACHEABLE_KEYED}}
+        )
+        client._record_command_metric = mock.AsyncMock()
+        client._record_error_metric = mock.AsyncMock()
+        return client
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "command,response,records_latency",
+        [
+            ("GET", b"value", True),
+            ("CUSTOM.READ", b"value", True),
+            ("SET", b"OK", False),
+        ],
+    )
+    async def test_success_releases_request_and_only_reads_record_latency(
+        self, command, response, records_latency
+    ):
+        node = ClusterNode("127.0.0.1", 7000)
+        load_balancer = LoadBalancer()
+        client = self.client(load_balancer)
+
+        with mock.patch.object(
+            ClusterNode, "execute_command", mock.AsyncMock(return_value=response)
+        ):
+            assert await client._execute_command(node, command, "key") == response
+
+        state = load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert (state.ewma is not None) is records_latency
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error", [ResponseError("failure"), asyncio.CancelledError()]
+    )
+    async def test_failure_releases_request_without_recording_latency(self, error):
+        node = ClusterNode("127.0.0.1", 7000)
+        load_balancer = LoadBalancer()
+        client = self.client(load_balancer)
+
+        with mock.patch.object(
+            ClusterNode, "execute_command", mock.AsyncMock(side_effect=error)
+        ):
+            with pytest.raises(type(error)):
+                await client._execute_command(node, "GET", "key")
+
+        state = load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error",
+        [
+            AuthenticationError("failure"),
+            MaxConnectionsError("failure"),
+            ConnectionError("failure"),
+            TimeoutError("failure"),
+            ClusterDownError("failure"),
+            SlotNotCoveredError("failure"),
+        ],
+    )
+    async def test_other_failures_release_without_recording_latency(self, error):
+        node = ClusterNode("127.0.0.1", 7000)
+        load_balancer = LoadBalancer()
+        client = self.client(load_balancer)
+        client.aclose = mock.AsyncMock()
+
+        with (
+            mock.patch.object(
+                ClusterNode, "execute_command", mock.AsyncMock(side_effect=error)
+            ),
+            mock.patch("redis.asyncio.cluster.asyncio.sleep", mock.AsyncMock()),
+        ):
+            with pytest.raises(type(error)):
+                await client._execute_command(node, "GET", "key")
+
+        state = load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is None
+
+    @pytest.mark.asyncio
+    async def test_moved_retry_records_only_the_final_target(self):
+        source = ClusterNode("127.0.0.1", 7000)
+        target = ClusterNode("127.0.0.1", 7001)
+        load_balancer = LoadBalancer()
+        client = self.client(load_balancer)
+        client.RedisClusterRequestTTL = 2
+        client.reinitialize_counter = 0
+        client.reinitialize_steps = 0
+        client.read_from_replicas = True
+        client._determine_slot = mock.AsyncMock(return_value=0)
+        client.nodes_manager.move_slot = mock.AsyncMock()
+        client.nodes_manager.get_node_from_slot.return_value = target
+
+        with mock.patch.object(
+            ClusterNode,
+            "execute_command",
+            mock.AsyncMock(side_effect=[MovedError("0 127.0.0.1:7001"), b"value"]),
+        ):
+            assert await client._execute_command(source, "GET", "key") == b"value"
+
+        assert load_balancer._latency_state[source.name].ewma is None
+        assert load_balancer._latency_state[target.name].ewma is not None
+        assert all(
+            state.in_flight == 0 for state in load_balancer._latency_state.values()
+        )
+
+    @pytest.mark.asyncio
+    async def test_ask_retry_does_not_record_migration_latency(self):
+        source = ClusterNode("127.0.0.1", 7000)
+        target = ClusterNode("127.0.0.1", 7001)
+        load_balancer = LoadBalancer()
+        client = self.client(load_balancer)
+        client.RedisClusterRequestTTL = 2
+        client.get_node = mock.Mock(return_value=target)
+
+        with mock.patch.object(
+            ClusterNode,
+            "execute_command",
+            mock.AsyncMock(side_effect=[AskError("0 127.0.0.1:7001"), b"OK", b"value"]),
+        ):
+            assert await client._execute_command(source, "GET", "key") == b"value"
+
+        assert all(
+            state.in_flight == 0 and state.ewma is None
+            for state in load_balancer._latency_state.values()
+        )
+
+    @pytest.mark.asyncio
+    async def test_tryagain_retry_records_only_the_successful_attempt(self):
+        node = ClusterNode("127.0.0.1", 7000)
+        load_balancer = LoadBalancer()
+        client = self.client(load_balancer)
+        client.RedisClusterRequestTTL = 2
+
+        with mock.patch.object(
+            ClusterNode,
+            "execute_command",
+            mock.AsyncMock(side_effect=[TryAgainError("retry"), b"value"]),
+        ):
+            assert await client._execute_command(node, "GET", "key") == b"value"
+
+        state = load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is not None
+
+    @pytest.mark.asyncio
+    async def test_pipeline_tracks_in_flight_without_recording_batch_latency(self):
+        client = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+
+        async def execute_pipeline(node, commands):
+            for command in commands:
+                command.result = b"value"
+            return False
+
+        pipeline = client.pipeline()
+        pipeline.get("foo")
+        with mock.patch.object(ClusterNode, "execute_pipeline", execute_pipeline):
+            assert await pipeline.execute() == [b"value"]
+
+        states = client.nodes_manager.read_load_balancer._latency_state.values()
+        assert states
+        assert all(state.in_flight == 0 for state in states)
+        assert all(state.ewma is None for state in states)
+
+    @pytest.mark.asyncio
+    async def test_pipeline_releases_each_node_when_its_task_finishes(self):
+        client = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+        waiting_started = asyncio.Event()
+        release_waiting = asyncio.Event()
+        waiting_finished = asyncio.Event()
+        waiting_node = client.get_node(default_host, 7000)
+        failing_node = client.get_node(default_host, 7001)
+
+        async def execute_pipeline(node, commands):
+            if node is waiting_node:
+                waiting_started.set()
+                await release_waiting.wait()
+                waiting_finished.set()
+                return False
+            await waiting_started.wait()
+            raise RuntimeError("failed node")
+
+        pipeline = client.pipeline()
+        pipeline.execute_command("GET", "bar", target_nodes=waiting_node)
+        pipeline.execute_command("GET", "foo", target_nodes=failing_node)
+        with mock.patch.object(ClusterNode, "execute_pipeline", execute_pipeline):
+            with pytest.raises(RuntimeError, match="failed node"):
+                await pipeline.execute()
+
+            state = client.nodes_manager.read_load_balancer._latency_state[
+                waiting_node.name
+            ]
+            assert state.in_flight == 1
+
+            release_waiting.set()
+            await waiting_finished.wait()
+            assert state.in_flight == 0
+            assert state.ewma is None
+
+    @pytest.mark.asyncio
+    async def test_transaction_tracks_one_in_flight_batch_without_latency(self):
+        client = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+        pipeline = client.pipeline(transaction=True)
+        strategy = pipeline._execution_strategy
+        strategy._pipeline_slots = {0}
+        node = client.nodes_manager.get_node_from_slot(0, False)
+
+        async def execute_transaction(*_args):
+            state = client.nodes_manager.read_load_balancer._latency_state[node.name]
+            assert state.in_flight == 1
+            return []
+
+        with mock.patch.object(
+            strategy, "_execute_transaction", side_effect=execute_transaction
+        ):
+            assert await strategy._execute_transaction_with_retries([], True) == []
+
+        state = client.nodes_manager.read_load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is None
+
+    @pytest.mark.asyncio
+    async def test_immediate_transaction_command_tracks_in_flight_without_latency(self):
+        client = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+        strategy = client.pipeline(transaction=True)._execution_strategy
+
+        with pytest.raises(
+            RedisClusterException,
+            match="At least a command with a key is needed to identify a node",
+        ):
+            await strategy._get_connection_and_send_command("UNWATCH")
+        assert not client.nodes_manager.read_load_balancer._latency_state
+
+        strategy._pipeline_slots = {0}
+        node = client.nodes_manager.get_node_from_slot(0, False)
+        connection = mock.AsyncMock(host=node.host, port=node.port, db=0)
+
+        async def send_command(*_args, **_kwargs):
+            state = client.nodes_manager.read_load_balancer._latency_state[node.name]
+            assert state.in_flight == 1
+            return b"OK"
+
+        with (
+            mock.patch.object(
+                strategy,
+                "_get_client_and_connection_for_transaction",
+                return_value=(node, connection),
+            ),
+            mock.patch.object(
+                strategy, "_send_command_parse_response", side_effect=send_command
+            ),
+            mock.patch.object(ClusterNode, "disconnect_if_needed", mock.AsyncMock()),
+            mock.patch(
+                "redis.asyncio.cluster.record_operation_duration", mock.AsyncMock()
+            ),
+        ):
+            assert (
+                await strategy._get_connection_and_send_command("WATCH", "key") == b"OK"
+            )
+
+        state = client.nodes_manager.read_load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is None
+
+        client.nodes_manager.read_load_balancer.reconcile(set())
+        with mock.patch.object(
+            strategy,
+            "_get_client_and_connection_for_transaction",
+            side_effect=asyncio.CancelledError(),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await strategy._get_connection_and_send_command("WATCH", "key")
+
+        state = client.nodes_manager.read_load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is None
+
+    @pytest.mark.asyncio
+    async def test_topology_refresh_preserves_survivors_and_failed_refresh_preserves_all(
+        self,
+    ):
+        client = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+        manager = client.nodes_manager
+        survivor = next(iter(manager.nodes_cache))
+        departed = "127.0.0.1:7999"
+        for node_name in (survivor, departed):
+            attempt = manager.read_load_balancer.start_request(node_name)
+            manager.read_load_balancer.finish_request(attempt, 0.005)
+        generation = manager.read_load_balancer._latency_state[survivor].generation
+
+        with mock.patch.object(
+            ClusterNode,
+            "execute_command",
+            mock.AsyncMock(side_effect=ConnectionError("offline")),
+        ):
+            with pytest.raises(RedisClusterUnreachableError):
+                await manager.initialize()
+
+        assert set(manager.read_load_balancer._latency_state) == {survivor, departed}
+        assert (
+            manager.read_load_balancer._latency_state[survivor].generation == generation
+        )
+
+        with mock.patch.object(
+            ClusterNode,
+            "execute_command",
+            mock.AsyncMock(return_value=default_cluster_slots),
+        ):
+            await manager.initialize()
+
+        assert (
+            manager.read_load_balancer._latency_state[survivor].generation == generation
+        )
+        assert departed not in manager.read_load_balancer._latency_state
+
+
+def test_async_nodes_manager_passes_slot_nodes_to_latency_selection():
+    nodes = [
+        ClusterNode("127.0.0.1", 7000, PRIMARY),
+        ClusterNode("127.0.0.1", 7001, REPLICA),
+        ClusterNode("127.0.0.1", 7002, REPLICA),
+    ]
+    manager = object.__new__(NodesManager)
+    manager.slots_cache = {0: nodes}
+    manager.read_load_balancer = LoadBalancer()
+
+    for node, latency in zip(nodes, (0.020, 0.010, 0.005)):
+        attempt = manager.read_load_balancer.start_request(node.name)
+        manager.read_load_balancer.finish_request(attempt, latency)
+
+    with mock.patch("redis.cluster.random_sample", return_value=[0, 2]):
+        assert (
+            manager.get_node_from_slot(
+                0,
+                read_from_replicas=True,
+                load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+            )
+            is nodes[2]
+        )
 
 
 class NodeProxy:
@@ -1214,6 +1588,7 @@ class TestClusterRedisCommands:
             LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
             LoadBalancingStrategy.RANDOM,
             LoadBalancingStrategy.RANDOM_REPLICA,
+            LoadBalancingStrategy.LATENCY_BASED,
         ],
     )
     async def test_get_and_set_with_load_balanced_client(

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -492,6 +492,41 @@ class TestLatencyBasedCommandTracking:
         assert all(state.in_flight == 0 for state in states)
         assert all(state.ewma is None for state in states)
 
+    def test_pipeline_releases_each_node_after_its_read_finishes(self):
+        client = get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+        first_node = client.get_node(default_host, 7000)
+        second_node = client.get_node(default_host, 7001)
+        connections = {
+            first_node.redis_connection: Mock(host=first_node.host, port=7000, db=0),
+            second_node.redis_connection: Mock(host=second_node.host, port=7001, db=0),
+        }
+
+        def write_without_network(self):
+            for command in self.commands:
+                command.result = None
+
+        def read_response(node_commands):
+            states = client.nodes_manager.read_load_balancer._latency_state
+            if node_commands.connection.port == second_node.port:
+                assert states[first_node.name].in_flight == 0
+                assert states[second_node.name].in_flight == 1
+            for command in node_commands.commands:
+                command.result = b"value"
+
+        pipeline = client.pipeline()
+        pipeline.execute_command("GET", "first", target_nodes=first_node)
+        pipeline.execute_command("GET", "second", target_nodes=second_node)
+        with (
+            patch.object(NodeCommands, "write", write_without_network),
+            patch.object(NodeCommands, "read", read_response),
+            patch("redis.cluster.get_connection", side_effect=connections.__getitem__),
+        ):
+            assert pipeline.execute() == [b"value", b"value"]
+
     def test_transaction_tracks_one_in_flight_batch_without_latency(self):
         client = get_mocked_redis_client(
             host=default_host,
@@ -3722,6 +3757,30 @@ class TestStaticMetadataRouting:
             assert rc.get_keyless_target_node("get") is node
 
         any_node.assert_called_once()
+
+    @pytest.mark.fixed_client
+    def test_keyless_latency_routing_scores_all_eligible_nodes(self):
+        rc = get_mocked_redis_client(
+            host=default_host,
+            port=7000,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+        nodes = rc.get_nodes()
+        selected_index = len(nodes) - 1
+
+        with patch.object(
+            rc.nodes_manager.read_load_balancer,
+            "get_server_index",
+            return_value=selected_index,
+        ) as select_index:
+            assert rc.get_keyless_target_node("FT.SEARCH") is nodes[selected_index]
+
+        select_index.assert_called_once_with(
+            "",
+            len(nodes),
+            LoadBalancingStrategy.LATENCY_BASED,
+            nodes=nodes,
+        )
 
     @pytest.mark.fixed_client
     def test_every_load_balancing_strategy_is_classified(self):

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -27,7 +27,9 @@ from redis.cluster import (
     REPLICA,
     ClusterNode,
     ClusterPipeline,
+    LoadBalancer,
     LoadBalancingStrategy,
+    NodeCommands,
     NodesManager,
     RedisCluster,
     get_node_name,
@@ -57,13 +59,16 @@ from redis.exceptions import (
     ConnectionError,
     CrossSlotTransactionError,
     DataError,
+    MaxConnectionsError,
     MovedError,
     NoPermissionError,
     RedisClusterException,
     RedisClusterUnreachableError,
     RedisError,
     ResponseError,
+    SlotNotCoveredError,
     TimeoutError,
+    TryAgainError,
 )
 from redis.himport import HIMPORT_SET
 from redis.observability import recorder
@@ -91,6 +96,483 @@ default_cluster_slots = [
     [0, 8191, ["127.0.0.1", 7000, "node_0"], ["127.0.0.1", 7003, "node_3"]],
     [8192, 16383, ["127.0.0.1", 7001, "node_1"], ["127.0.0.1", 7002, "node_2"]],
 ]
+
+
+class TestLatencyBasedLoadBalancer:
+    @staticmethod
+    def nodes():
+        return [
+            ClusterNode("127.0.0.1", 7000, PRIMARY),
+            ClusterNode("127.0.0.1", 7001, REPLICA),
+            ClusterNode("127.0.0.1", 7002, REPLICA),
+        ]
+
+    def test_selects_lower_score_from_two_sampled_nodes(self):
+        nodes = self.nodes()
+        load_balancer = LoadBalancer()
+
+        for node, latency in zip(nodes, (0.001, 0.020, 0.010)):
+            attempt = load_balancer.start_request(node.name)
+            load_balancer.finish_request(attempt, latency)
+
+        with patch("redis.cluster.random_sample", return_value=[1, 2]):
+            assert (
+                load_balancer.get_server_index(
+                    nodes[0].name,
+                    len(nodes),
+                    LoadBalancingStrategy.LATENCY_BASED,
+                    nodes=nodes,
+                )
+                == 2
+            )
+
+    def test_equal_scores_follow_randomized_sample_order(self):
+        nodes = self.nodes()
+        load_balancer = LoadBalancer()
+
+        with patch("redis.cluster.random_sample", return_value=[2, 1]):
+            assert (
+                load_balancer.get_server_index(
+                    nodes[0].name,
+                    len(nodes),
+                    LoadBalancingStrategy.LATENCY_BASED,
+                    nodes=nodes,
+                )
+                == 2
+            )
+
+    @pytest.mark.parametrize(
+        "strategy",
+        [
+            LoadBalancingStrategy.ROUND_ROBIN,
+            LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
+            LoadBalancingStrategy.RANDOM,
+            LoadBalancingStrategy.RANDOM_REPLICA,
+        ],
+    )
+    def test_existing_strategies_do_not_touch_latency_state(self, strategy):
+        load_balancer = LoadBalancer()
+        load_balancer._clock = Mock(
+            side_effect=AssertionError("existing strategy read the latency clock")
+        )
+
+        index = load_balancer.get_server_index("primary", 3, strategy)
+
+        assert 0 <= index < 3
+        assert load_balancer._latency_state == {}
+
+    def test_in_flight_work_increases_score(self):
+        nodes = self.nodes()[:2]
+        load_balancer = LoadBalancer()
+
+        for node in nodes:
+            attempt = load_balancer.start_request(node.name)
+            load_balancer.finish_request(attempt, 0.010)
+
+        active = load_balancer.start_request(nodes[0].name)
+        with patch("redis.cluster.random_sample", return_value=[0, 1]):
+            assert (
+                load_balancer.get_server_index(
+                    nodes[0].name,
+                    len(nodes),
+                    LoadBalancingStrategy.LATENCY_BASED,
+                    nodes=nodes,
+                )
+                == 1
+            )
+
+        load_balancer.finish_request(active)
+
+    def test_cold_node_uses_baseline_instead_of_zero(self):
+        nodes = self.nodes()[:2]
+        load_balancer = LoadBalancer()
+        attempt = load_balancer.start_request(nodes[0].name)
+        load_balancer.finish_request(attempt, 0.010)
+
+        assert load_balancer._latency_score(nodes[1].name) == pytest.approx(
+            load_balancer._baseline
+        )
+
+    def test_peak_and_ewma_decay_toward_baseline_without_traffic(self):
+        nodes = self.nodes()[:2]
+        load_balancer = LoadBalancer()
+        now = 0.0
+        load_balancer._clock = lambda: now
+
+        healthy = load_balancer.start_request(nodes[0].name)
+        load_balancer.finish_request(healthy, 0.005)
+        slow = load_balancer.start_request(nodes[1].name)
+        load_balancer.finish_request(slow, 0.100)
+        initial_score = load_balancer._latency_score(nodes[1].name)
+
+        now = 40.0
+        aged_score = load_balancer._latency_score(nodes[1].name)
+
+        assert aged_score < initial_score
+        assert aged_score == load_balancer._baseline
+
+    def test_baseline_moves_slowly_from_node_ewma(self):
+        node = self.nodes()[0]
+        load_balancer = LoadBalancer()
+
+        first = load_balancer.start_request(node.name)
+        load_balancer.finish_request(first, 0.005)
+        assert load_balancer._latency_state[node.name].ewma == pytest.approx(0.0018)
+        assert load_balancer._baseline == pytest.approx(0.00104)
+
+        spike = load_balancer.start_request(node.name)
+        load_balancer.finish_request(spike, 0.100)
+
+        assert load_balancer._latency_state[node.name].ewma == pytest.approx(0.02144)
+        assert load_balancer._latency_state[node.name].peak == pytest.approx(0.100)
+        assert load_balancer._baseline == pytest.approx(0.00206)
+
+    def test_stale_attempt_cannot_mutate_recreated_node_state(self):
+        node = self.nodes()[0]
+        load_balancer = LoadBalancer()
+        stale = load_balancer.start_request(node.name)
+
+        load_balancer.reconcile(set())
+        current = load_balancer.start_request(node.name)
+        load_balancer.finish_request(stale, 0.100)
+
+        state = load_balancer._latency_state[node.name]
+        assert state.generation == current.generation
+        assert state.in_flight == 1
+        assert state.ewma is None
+
+        load_balancer.finish_request(current, 0.005)
+
+    def test_reconcile_preserves_active_nodes_and_prunes_removed_nodes(self):
+        nodes = self.nodes()[:2]
+        load_balancer = LoadBalancer()
+        for node in nodes:
+            attempt = load_balancer.start_request(node.name)
+            load_balancer.finish_request(attempt, 0.005)
+
+        generation = load_balancer._latency_state[nodes[0].name].generation
+        load_balancer.reconcile({nodes[0].name})
+
+        assert load_balancer._latency_state[nodes[0].name].generation == generation
+        assert nodes[1].name not in load_balancer._latency_state
+
+    def test_nodes_manager_passes_slot_nodes_to_latency_selection(self):
+        nodes = self.nodes()
+        manager = object.__new__(NodesManager)
+        manager._lock = threading.RLock()
+        manager._require_full_coverage = True
+        manager.slots_cache = {0: nodes}
+        manager.read_load_balancer = LoadBalancer()
+
+        for node, latency in zip(nodes, (0.020, 0.010, 0.005)):
+            attempt = manager.read_load_balancer.start_request(node.name)
+            manager.read_load_balancer.finish_request(attempt, latency)
+
+        with patch("redis.cluster.random_sample", return_value=[0, 2]):
+            assert (
+                manager.get_node_from_slot(
+                    0,
+                    read_from_replicas=True,
+                    load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+                )
+                is nodes[2]
+            )
+
+
+class TestLatencyBasedCommandTracking:
+    @staticmethod
+    def client(load_balancer):
+        redis_node = Mock()
+        redis_node.connection_pool.release = Mock()
+        connection = Mock()
+        client = object.__new__(RedisCluster)
+        client.RedisClusterRequestTTL = 1
+        client.load_balancing_strategy = LoadBalancingStrategy.LATENCY_BASED
+        client.nodes_manager = Mock(read_load_balancer=load_balancer)
+        client.cluster_response_callbacks = {}
+        client.get_redis_connection = Mock(return_value=redis_node)
+        client._record_command_metric = Mock()
+        client._record_error_metric = Mock()
+        client.reinitialize_counter = 0
+        client.reinitialize_steps = 0
+        client.read_from_replicas = True
+        client._metadata_resolver = DynamicMetadataResolver(
+            {"core": {"get": CACHEABLE_KEYED}, "custom": {"read": CACHEABLE_KEYED}}
+        )
+        return client, redis_node, connection
+
+    @pytest.mark.parametrize(
+        "command,response,records_latency",
+        [
+            ("GET", b"value", True),
+            ("CUSTOM.READ", b"value", True),
+            ("SET", b"OK", False),
+        ],
+    )
+    def test_success_releases_request_and_only_reads_record_latency(
+        self, command, response, records_latency
+    ):
+        node = ClusterNode("127.0.0.1", 7000)
+        load_balancer = LoadBalancer()
+        client, redis_node, connection = self.client(load_balancer)
+        redis_node.parse_response.return_value = response
+
+        with patch("redis.cluster.get_connection", return_value=connection):
+            assert client._execute_command(node, command, "key") == response
+
+        state = load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert (state.ewma is not None) is records_latency
+
+    def test_response_error_releases_request_without_recording_latency(self):
+        node = ClusterNode("127.0.0.1", 7000)
+        load_balancer = LoadBalancer()
+        client, redis_node, connection = self.client(load_balancer)
+        redis_node.parse_response.side_effect = ResponseError("failure")
+
+        with (
+            patch("redis.cluster.get_connection", return_value=connection),
+            pytest.raises(ResponseError, match="failure"),
+        ):
+            client._execute_command(node, "GET", "key")
+
+        state = load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is None
+
+    def test_topology_refresh_preserves_survivors_and_failed_refresh_preserves_all(
+        self,
+    ):
+        client = get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+        manager = client.nodes_manager
+        survivor = next(iter(manager.nodes_cache))
+        departed = "127.0.0.1:7999"
+        for node_name in (survivor, departed):
+            attempt = manager.read_load_balancer.start_request(node_name)
+            manager.read_load_balancer.finish_request(attempt, 0.005)
+        generation = manager.read_load_balancer._latency_state[survivor].generation
+
+        with (
+            patch.object(
+                Redis, "execute_command", side_effect=ConnectionError("offline")
+            ),
+            pytest.raises(RedisClusterUnreachableError),
+        ):
+            manager.initialize(disconnect_startup_nodes_pools=False)
+
+        assert set(manager.read_load_balancer._latency_state) == {survivor, departed}
+        assert (
+            manager.read_load_balancer._latency_state[survivor].generation == generation
+        )
+
+        with patch.object(Redis, "execute_command", return_value=default_cluster_slots):
+            manager.initialize(disconnect_startup_nodes_pools=False)
+
+        assert (
+            manager.read_load_balancer._latency_state[survivor].generation == generation
+        )
+        assert departed not in manager.read_load_balancer._latency_state
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            AuthenticationError("failure"),
+            MaxConnectionsError("failure"),
+            ConnectionError("failure"),
+            TimeoutError("failure"),
+            ClusterDownError("failure"),
+            SlotNotCoveredError("failure"),
+        ],
+    )
+    def test_other_failures_release_without_recording_latency(self, error):
+        node = ClusterNode("127.0.0.1", 7000)
+        load_balancer = LoadBalancer()
+        client, redis_node, connection = self.client(load_balancer)
+        redis_node.parse_response.side_effect = error
+
+        with (
+            patch("redis.cluster.get_connection", return_value=connection),
+            patch("redis.cluster.time.sleep"),
+            pytest.raises(type(error)),
+        ):
+            client._execute_command(node, "GET", "key")
+
+        state = load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is None
+
+    def test_moved_retry_records_only_the_final_target(self):
+        source = ClusterNode("127.0.0.1", 7000)
+        target = ClusterNode("127.0.0.1", 7001)
+        load_balancer = LoadBalancer()
+        client, redis_node, connection = self.client(load_balancer)
+        client.RedisClusterRequestTTL = 2
+        client.determine_slot = Mock(return_value=0)
+        client.nodes_manager.get_node_from_slot.return_value = target
+        redis_node.parse_response.side_effect = [
+            MovedError("0 127.0.0.1:7001"),
+            b"value",
+        ]
+
+        with patch("redis.cluster.get_connection", return_value=connection):
+            assert client._execute_command(source, "GET", "key") == b"value"
+
+        assert load_balancer._latency_state[source.name].ewma is None
+        assert load_balancer._latency_state[target.name].ewma is not None
+        assert all(
+            state.in_flight == 0 for state in load_balancer._latency_state.values()
+        )
+
+    def test_ask_retry_does_not_record_migration_latency(self):
+        source = ClusterNode("127.0.0.1", 7000)
+        target = ClusterNode("127.0.0.1", 7001)
+        load_balancer = LoadBalancer()
+        client, redis_node, connection = self.client(load_balancer)
+        client.RedisClusterRequestTTL = 2
+        client.get_node = Mock(return_value=target)
+        redis_node.parse_response.side_effect = [
+            AskError("0 127.0.0.1:7001"),
+            b"OK",
+            b"value",
+        ]
+
+        with patch("redis.cluster.get_connection", return_value=connection):
+            assert client._execute_command(source, "GET", "key") == b"value"
+
+        assert all(
+            state.in_flight == 0 and state.ewma is None
+            for state in load_balancer._latency_state.values()
+        )
+
+    def test_tryagain_retry_records_only_the_successful_attempt(self):
+        node = ClusterNode("127.0.0.1", 7000)
+        load_balancer = LoadBalancer()
+        client, redis_node, connection = self.client(load_balancer)
+        client.RedisClusterRequestTTL = 2
+        redis_node.parse_response.side_effect = [TryAgainError("retry"), b"value"]
+
+        with patch("redis.cluster.get_connection", return_value=connection):
+            assert client._execute_command(node, "GET", "key") == b"value"
+
+        state = load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is not None
+
+    def test_pipeline_tracks_in_flight_without_recording_batch_latency(self):
+        client = get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+
+        def write_without_network(self):
+            for command in self.commands:
+                command.result = None
+
+        def read_response(self):
+            for command in self.commands:
+                command.result = b"value"
+
+        pipeline = client.pipeline()
+        pipeline.get("foo")
+        connection = Mock(host=default_host, port=default_port, db=0)
+        with (
+            patch.object(NodeCommands, "write", write_without_network),
+            patch.object(NodeCommands, "read", read_response),
+            patch("redis.cluster.get_connection", return_value=connection),
+        ):
+            assert pipeline.execute() == [b"value"]
+
+        states = client.nodes_manager.read_load_balancer._latency_state.values()
+        assert states
+        assert all(state.in_flight == 0 for state in states)
+        assert all(state.ewma is None for state in states)
+
+    def test_transaction_tracks_one_in_flight_batch_without_latency(self):
+        client = get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+        pipeline = client.pipeline(transaction=True)
+        strategy = pipeline._execution_strategy
+        strategy._pipeline_slots = {0}
+        node = client.nodes_manager.get_node_from_slot(0, False)
+
+        def execute_transaction(*_args):
+            state = client.nodes_manager.read_load_balancer._latency_state[node.name]
+            assert state.in_flight == 1
+            return []
+
+        with patch.object(
+            strategy, "_execute_transaction", side_effect=execute_transaction
+        ):
+            assert strategy._execute_transaction_with_retries([], True) == []
+
+        state = client.nodes_manager.read_load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is None
+
+    def test_immediate_transaction_command_tracks_in_flight_without_latency(self):
+        client = get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            load_balancing_strategy=LoadBalancingStrategy.LATENCY_BASED,
+        )
+        strategy = client.pipeline(transaction=True)._execution_strategy
+
+        with pytest.raises(
+            RedisClusterException,
+            match="At least a command with a key is needed to identify a node",
+        ):
+            strategy._get_connection_and_send_command("UNWATCH")
+        assert not client.nodes_manager.read_load_balancer._latency_state
+
+        strategy._pipeline_slots = {0}
+        node = client.nodes_manager.get_node_from_slot(0, False)
+        redis_node = Mock()
+        connection = Mock(host=node.host, port=node.port, db=0)
+
+        def send_command(*_args, **_kwargs):
+            state = client.nodes_manager.read_load_balancer._latency_state[node.name]
+            assert state.in_flight == 1
+            return b"OK"
+
+        with (
+            patch.object(
+                strategy,
+                "_get_client_and_connection_for_transaction",
+                return_value=(redis_node, connection),
+            ),
+            patch.object(
+                strategy, "_send_command_parse_response", side_effect=send_command
+            ),
+            patch("redis.cluster.record_operation_duration"),
+        ):
+            assert strategy._get_connection_and_send_command("WATCH", "key") == b"OK"
+
+        state = client.nodes_manager.read_load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is None
+
+        client.nodes_manager.read_load_balancer.reconcile(set())
+        with (
+            patch.object(
+                strategy,
+                "_get_client_and_connection_for_transaction",
+                side_effect=ConnectionError("offline"),
+            ),
+            pytest.raises(ConnectionError, match="offline"),
+        ):
+            strategy._get_connection_and_send_command("WATCH", "key")
+
+        state = client.nodes_manager.read_load_balancer._latency_state[node.name]
+        assert state.in_flight == 0
+        assert state.ewma is None
 
 
 class ProxyRequestHandler(socketserver.BaseRequestHandler):
@@ -1206,6 +1688,7 @@ class TestClusterRedisCommands:
             LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
             LoadBalancingStrategy.RANDOM,
             LoadBalancingStrategy.RANDOM_REPLICA,
+            LoadBalancingStrategy.LATENCY_BASED,
         ],
     )
     def test_get_and_set_with_load_balanced_client(
@@ -3253,6 +3736,7 @@ class TestStaticMetadataRouting:
             LoadBalancingStrategy.RANDOM_REPLICA,
         }
         assert set(LoadBalancingStrategy) - _REPLICAS_ONLY_STRATEGIES == {
+            LoadBalancingStrategy.LATENCY_BASED,
             LoadBalancingStrategy.ROUND_ROBIN,
             LoadBalancingStrategy.RANDOM,
         }

--- a/tests/test_cluster_latency_benchmark.py
+++ b/tests/test_cluster_latency_benchmark.py
@@ -1,0 +1,30 @@
+from benchmarks.cluster_latency_load_balancing import summarize
+
+
+def test_summarize_reports_latency_percentiles_and_node_share():
+    summary = summarize(
+        latencies=[0.001, 0.002, 0.003, 0.004],
+        selected_nodes=[
+            "replica-a",
+            "replica-a",
+            "replica-a",
+            "primary",
+            "replica-b",
+            "replica-b",
+        ],
+        errors=2,
+    )
+
+    assert summary == {
+        "attempts": 6,
+        "successful_requests": 4,
+        "errors": 2,
+        "p50_ms": 2.5,
+        "p95_ms": 3.85,
+        "p99_ms": 3.97,
+        "node_share": {
+            "primary": 0.1667,
+            "replica-a": 0.5,
+            "replica-b": 0.3333,
+        },
+    }


### PR DESCRIPTION
### Description of change

This pull request resolves #4185 by adding an opt-in `LoadBalancingStrategy.LATENCY_BASED` for Redis Cluster reads, with matching synchronous and asynchronous behavior. For each read, it samples two eligible nodes from the slot's primary and replicas and chooses the lower client-observed latency-and-load score:

```text
aged_peak_ewma * (in_flight_requests + 1)
```

The implementation keeps per-client node state, records latency only after successful replica-safe reads, and always releases in-flight accounting on success, errors, redirects, timeouts, or cancellation. Writes contribute only to in-flight load, so a busy primary becomes less attractive without mixing write latency into the read estimator. Pipelines and transactions contribute in-flight load but do not train latency because batch durations are not comparable. Topology refresh preserves surviving node history, prunes departed nodes, and uses generation-tagged attempt tokens so stale completions cannot corrupt replacement-node state. Latency eligibility reuses the command metadata resolver, including registered custom reads, rather than maintaining a second static read-command list.

#### Assumptions and tradeoffs

- The strategy is opt-in and includes the primary plus replicas, matching the scope of `RANDOM` and `ROUND_ROBIN`; replica staleness semantics are unchanged.
- Measurements are local to each client. No cross-process coordination or server-side signal is assumed.
- Only successful reads train latency. Existing retry and topology handling own hard failures instead of translating them into synthetic latency penalties.
- Timing intentionally includes pool wait, successful reconnect, network, server work, parsing, and response callbacks because these are the delays observed by this client.
- EWMA alpha is `0.2`, baseline alpha is `0.05`, the decay period is `10s`, evidence expires after `30s`, and cold nodes start at a `1ms` baseline. These remain internal constants to avoid expanding the public API before operational evidence justifies tuning knobs.
- The baseline is traffic-weighted. Expiring old evidence creates a small score discontinuity, but guarantees recovered-node exploration instead of possible permanent starvation.
- In-flight accounting begins immediately after routing rather than making node selection and reservation one atomic API, avoiding a broad routing return-type change.

The change includes the implementation specification, sync/async unit and integration coverage, user documentation, and a reusable benchmark that externally degrades a Redis replica with `CLIENT PAUSE` rather than injecting delay inside redis-py.

#### Benchmark results

Two eligible nodes (one primary and one replica):

- Degraded-node traffic: `0.01%`
- Degraded-phase p99: latency-based `0.626 ms`; round-robin `6,056.736 ms`
- Recovered-node re-entry: `29.862s`
- Errors: `0`

Three eligible nodes (one primary and two replicas):

- Healthy traffic share: `32.29% / 36.57% / 31.14%`
- Degraded-replica traffic: `0.01%`
- Traffic redistributed across healthy nodes: `51.24% / 48.75%`
- Degraded-phase p99: latency-based `0.794 ms`; round-robin `20,043.952 ms`
- Recovered-node re-entry: `29.838s`
- Errors: `0`

#### Test coverage

- Focused latency tracking and metadata regression tests: `125 passed`
- Fixed-client suite: `1,635 passed, 2 skipped`
- Standalone suite: `3,584 passed, 674 skipped, 26 xpassed`
- Cluster suite: `2,216 passed, 1,089 skipped, 2 xpassed`
- `invoke all-tests`: passed, including Ruff lint/format and Vulture
- `invoke build-docs`: passed (existing documentation warnings remain)
- `git diff --check`: passed

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (CI will run on this PR)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included?
- [x] Is there an example added where applicable? The cluster documentation includes opt-in usage.

Resolves #4185.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster read routing and load-balancer state in sync/async execution paths, but the strategy is opt-in and existing strategies keep prior behavior.
> 
> **Overview**
> Adds opt-in **`LoadBalancingStrategy.LATENCY_BASED`** for Redis Cluster reads in sync and async clients. For each eligible read, the **`LoadBalancer`** samples two nodes (primary or replicas), scores them with decaying EWMA peak latency times in-flight load, and picks the lower score. Successful replica-safe reads update latency; failures, ASK redirects, writes, and pipeline/transaction batches only affect in-flight counts. Topology refresh **`reconcile`** prunes departed nodes while preserving survivor history via generation-tagged attempts.
> 
> Routing changes include slot-based selection with a **`nodes`** argument, keyless commands that score all cluster nodes, and pipeline/transaction hooks so load accounting is released on errors. Docs describe the strategy and staleness caveats; **`benchmarks/cluster_latency_load_balancing.py`** compares round-robin vs latency-based routing under externally degraded replicas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce8964cd3d14fc9862cac33d2d670069a718d221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->