### PR TITLE
Align empty cluster target handling

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1775,7 +1775,7 @@ class RedisCluster(
         is_default_node = False
         target_nodes = None
         passed_targets = kwargs.pop("target_nodes", None)
-        if passed_targets is not None and not self._is_nodes_flag(passed_targets):
+        if passed_targets and not self._is_nodes_flag(passed_targets):
             target_nodes = self._parse_target_nodes(passed_targets)
             target_nodes_specified = True
 

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -2934,6 +2934,25 @@ class TestStaticMetadataRouting:
         await rc.aclose()
 
     @pytest.mark.fixed_client
+    @pytest.mark.parametrize("empty_targets", [[], {}, ""])
+    async def test_execute_command_empty_target_nodes_falls_back(
+        self, empty_targets: Any
+    ) -> None:
+        rc = await get_mocked_redis_client(host=default_host, port=7000)
+        default_node = rc.get_default_node()
+
+        with mock.patch.object(
+            RedisCluster,
+            "_execute_command",
+            new=mock.AsyncMock(return_value=100),
+        ) as execute:
+            result = await rc.execute_command("DBSIZE", target_nodes=empty_targets)
+
+        assert result == 100
+        execute.assert_awaited_once_with(default_node, "DBSIZE")
+        await rc.aclose()
+
+    @pytest.mark.fixed_client
     async def test_command_subcommands_route_to_default_node(self) -> None:
         rc = await get_mocked_redis_client(host=default_host, port=7000)
         default_node = rc.get_default_node()

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3083,6 +3083,18 @@ class TestStaticMetadataRouting:
         assert nodes == [default_node]
 
     @pytest.mark.fixed_client
+    @pytest.mark.parametrize("empty_targets", [[], {}, ""])
+    def test_execute_command_empty_target_nodes_falls_back(self, empty_targets):
+        rc = get_mocked_redis_client(host=default_host, port=7000)
+        default_node = rc.get_default_node()
+
+        with patch.object(RedisCluster, "_execute_command", return_value=100) as execute:
+            result = rc.execute_command("DBSIZE", target_nodes=empty_targets)
+
+        assert result == 100
+        execute.assert_called_once_with(default_node, "DBSIZE")
+
+    @pytest.mark.fixed_client
     def test_command_subcommands_route_to_default_node(self):
         rc = get_mocked_redis_client(host=default_host, port=7000)
         default_node = rc.get_default_node()


### PR DESCRIPTION
## What changed

The synchronous cluster client now treats empty `target_nodes` values the same way as the async client and pipeline implementation: they fall back to normal command-policy routing instead of being treated as an explicit empty target set.

Regression tests cover empty lists, mappings, and strings for both sync and async clients.

Fixes #4318.

## Validation

- `uv run --no-project --with pytest --with pytest-asyncio --with async-timeout python -m pytest tests/test_cluster.py tests/test_asyncio/test_cluster.py -q -k empty_target_nodes`
- `uv run --no-project --with ruff ruff check redis/cluster.py tests/test_cluster.py tests/test_asyncio/test_cluster.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing-only change for an edge-case kwarg; behavior becomes more permissive for empty containers and is covered by new tests.
> 
> **Overview**
> **Empty `target_nodes` no longer count as an explicit node list** in sync and async `execute_command`. Passing `[]`, `{}`, or `""` now skips `_parse_target_nodes` and uses normal command-policy routing (e.g. default node for `DBSIZE`) instead of executing against zero nodes or mis-handling an empty string.
> 
> The guard is shared in **`redis/cluster.py`** and **`redis/asyncio/cluster.py`**: only non-flag values that are not empty `list` / `dict` / `str` set `target_nodes_specified`. Other falsy or wrong types (e.g. `False`, `0`, `()`, `b""`) still hit `_parse_target_nodes` and raise **`TypeError`**.
> 
> Regression tests in **`tests/test_cluster.py`** and **`tests/test_asyncio/test_cluster.py`** cover the fallback and invalid inputs. Fixes #4318.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef4a2d3b12ec8534e553ca8af664d02432677593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->